### PR TITLE
feat: agent apis exec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Agent Tool Schemas for LLM Agents**: Function-calling definitions for AI agent integration
+  - `GET /api/v1/tools` — returns tool definitions for LLM function calling
+  - `?format=openai` (default) — OpenAI function-calling format
+  - `?format=anthropic` — Anthropic tool-use format
+  - Tools: `create_session`, `execute_code`, `write_file`, `read_file`, `list_files`, `destroy_session`
+  - Schemas include descriptions, parameter types, required fields
+- **Agent CLI enhancements**:
+  - `--max-memory` flag: per-session linear memory limit in MB (default: 256)
+  - Startup banner with full endpoint listing
+  - Graceful shutdown on Ctrl+C with session cleanup
+- **Agent REST API Server**: HTTP server for AI agent sandbox management
+  - `wasmrun agent` CLI command to start the agent API server
+  - `POST /api/v1/sessions` — create isolated sandbox sessions
+  - `GET /api/v1/sessions/:id` — get session status (state, uptime, timeout)
+  - `DELETE /api/v1/sessions/:id` — destroy session and clean up resources
+  - `POST /api/v1/sessions/:id/exec` — execute WASM in session with structured output capture
+    - Accepts `wasm_path`, `function`, `args`, `timeout`, `env` parameters
+    - Returns `stdout`, `stderr`, `exit_code`, `duration_ms`
+    - Thread-based timeout enforcement per execution
+  - `POST /api/v1/sessions/:id/files` — write files to session filesystem
+  - `GET /api/v1/sessions/:id/files?path=...` — read file content
+  - `GET /api/v1/sessions/:id/files?path=...&list=true` — list directory entries
+  - `DELETE /api/v1/sessions/:id/files?path=...` — delete files or directories
+  - `POST /api/v1/sessions/:id/env` — set environment variables
+  - `GET /api/v1/sessions/:id/env` — get current environment variables
+  - CORS headers (configurable via `--allow-cors`)
+  - JSON error responses with consistent format and HTTP status codes
+  - Path traversal prevention on all file operations
+  - `execute_wasm_bytes_with_env()` — exec mode API for running WASM with an existing WasiEnv
+  - `WasiEnv::set_args()` — set WASM program arguments on existing environment
+  - CLI flags: `--port`, `--timeout`, `--max-sessions`, `--allow-cors`, `--verbose`
 - **Agent Session Management**: Foundation for AI agent sandbox mode
   - `Session` struct: isolated WASM sandbox with per-session WASI environment, filesystem, and output buffers
   - `SessionManager`: thread-safe session lifecycle management (create, get, destroy, list)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -154,6 +163,12 @@ name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -276,6 +291,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+dependencies = [
+ "dispatch2",
+ "nix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,6 +330,18 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.9.4",
+ "block2",
+ "libc",
+ "objc2",
 ]
 
 [[package]]
@@ -742,6 +780,18 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags 2.9.4",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "notify"
@@ -1409,6 +1459,7 @@ dependencies = [
  "base64",
  "chrono",
  "clap",
+ "ctrlc",
  "dirs",
  "libloading",
  "notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ base64 = "0.22.1"
 sha2 = "0.10.9"
 tempfile = "3.26.0"
 ureq = "3.2.0"
+ctrlc = "3.4"
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 libloading = "0.9.0"

--- a/build.rs
+++ b/build.rs
@@ -7,13 +7,15 @@ fn main() {
     println!("cargo:rerun-if-changed=ui/package.json");
     println!("cargo:rerun-if-changed=ui/vite.config.ts");
 
+    let templates_dir = Path::new("templates");
+
     if env::var("SKIP_UI_BUILD").is_ok() {
         eprintln!("Skipping UI build (SKIP_UI_BUILD set)");
+        ensure_stub_templates(templates_dir);
         return;
     }
 
     let ui_dir = Path::new("ui");
-    let templates_dir = Path::new("templates");
     let ui_package_json = ui_dir.join("package.json");
 
     // Skip UI build if templates already exist and UI source is not available
@@ -26,7 +28,8 @@ fn main() {
             eprintln!("UI source not found but templates exist, skipping UI build");
             return;
         } else {
-            eprintln!("UI source not found, skipping UI build");
+            eprintln!("UI source not found, creating stub templates");
+            ensure_stub_templates(templates_dir);
             return;
         }
     }
@@ -224,6 +227,49 @@ fn fix_html_references(html_path: &Path) {
         }
 
         let _ = fs::write(html_path, updated);
+    }
+}
+
+/// Create minimal stub template files so `include_str!`/`include_bytes!` in
+/// source code compile even when the real UI build is skipped.
+fn ensure_stub_templates(templates_dir: &Path) {
+    use std::fs;
+
+    let stubs = [
+        ("app/index.html", "<!-- stub -->"),
+        ("app/scripts.js", "// stub"),
+        ("app/style.css", "/* stub */"),
+        ("console/index.html", "<!-- stub -->"),
+        ("console/scripts.js", "// stub"),
+        ("console/style.css", "/* stub */"),
+        ("os/index.html", "<!-- stub -->"),
+        ("os/os.js", "// stub"),
+        ("os/index.css", "/* stub */"),
+        ("os/logging.js", "// stub"),
+        ("os/logs.html", "<!-- stub -->"),
+    ];
+
+    for (path, content) in &stubs {
+        let full = templates_dir.join(path);
+        if !full.exists() {
+            if let Some(parent) = full.parent() {
+                let _ = fs::create_dir_all(parent);
+            }
+            let _ = fs::write(&full, content);
+        }
+    }
+
+    // Stub binary assets
+    let assets = ["assets/logo.png", "assets/logo-text.png"];
+    for path in &assets {
+        let full = templates_dir.join(path);
+        if !full.exists() {
+            if let Some(parent) = full.parent() {
+                let _ = fs::create_dir_all(parent);
+            }
+            // Minimal 1x1 transparent PNG
+            let _ = fs::write(&full, [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]);
+        }
     }
 }
 

--- a/docs/docs/exec/agent.md
+++ b/docs/docs/exec/agent.md
@@ -1,0 +1,107 @@
+---
+sidebar_position: 5
+title: Agent API
+---
+
+# Agent API
+
+The agent API wraps exec mode in an HTTP server, letting AI agents create isolated WASM sandboxes, upload files, execute code, and retrieve structured output — all via REST.
+
+## Starting the Server
+
+```sh
+wasmrun agent [OPTIONS]
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-P, --port` | `8430` | Server port |
+| `-t, --timeout` | `300` | Default session idle timeout (seconds) |
+| `-m, --max-sessions` | `100` | Maximum concurrent sessions |
+| `--max-memory` | `256` | Maximum linear memory per session (MB) |
+| `--allow-cors` | off | Enable wildcard CORS |
+| `-v, --verbose` | off | Log all incoming requests |
+
+All endpoints are under `http://<host>:<port>/api/v1/`.
+
+## How It Works
+
+The agent API manages **sessions** — each session is an isolated exec mode sandbox with its own:
+
+- **Filesystem** — temp directory on the host, preopened at `/` via WASI
+- **Environment variables** — independent per session
+- **Output buffers** — stdout/stderr captured per execution
+- **Timeout** — auto-cleanup after idle expiry
+
+When you call the exec endpoint, the server loads the WASM file from the session's filesystem, runs it through the same interpreter used by `wasmrun exec`, and returns the captured output as JSON.
+
+```
+┌─ wasmrun agent ─────────────────────────────────────────┐
+│                                                         │
+│  REST API (/api/v1/...)                                 │
+│       ↓                                                 │
+│  Session Manager → create/track/expire/destroy          │
+│       ↓                                                 │
+│  Per-Session Sandbox                                    │
+│    ├─ Isolated temp directory (WASI preopen at /)       │
+│    ├─ WasiEnv (stdout/stderr, args, env vars)           │
+│    └─ Idle timeout tracking                             │
+│       ↓                                                 │
+│  Exec Mode Engine (same as `wasmrun exec`)              │
+│    ├─ Module parser                                     │
+│    ├─ Bytecode interpreter                              │
+│    ├─ Linear memory                                     │
+│    └─ WASI syscalls                                     │
+│                                                         │
+└─────────────────────────────────────────────────────────┘
+```
+
+## Quick Example
+
+```sh
+# Start the server
+wasmrun agent --port 8430
+
+# Create a session
+curl -X POST http://localhost:8430/api/v1/sessions
+# → {"session_id": "a1b2c3...", "created_at": "..."}
+
+# Upload a WASM file
+curl -X POST http://localhost:8430/api/v1/sessions/a1b2c3.../files \
+  -H "Content-Type: application/json" \
+  -d '{"path": "hello.wasm", "content": "..."}'
+
+# Execute it
+curl -X POST http://localhost:8430/api/v1/sessions/a1b2c3.../exec \
+  -H "Content-Type: application/json" \
+  -d '{"wasm_path": "hello.wasm"}'
+# → {"stdout": "Hello, World!\n", "stderr": "", "exit_code": 0, "duration_ms": 12}
+
+# Clean up
+curl -X DELETE http://localhost:8430/api/v1/sessions/a1b2c3...
+```
+
+## Tool Schemas for LLM Agents
+
+The server exposes tool definitions that can be passed directly to OpenAI or Anthropic APIs for function calling:
+
+```sh
+# OpenAI format (default)
+curl http://localhost:8430/api/v1/tools
+
+# Anthropic format
+curl http://localhost:8430/api/v1/tools?format=anthropic
+```
+
+Available tools: `create_session`, `execute_code`, `write_file`, `read_file`, `list_files`, `destroy_session`.
+
+Each tool includes a description, parameter schema with types, and required fields — ready to pass to an LLM as function definitions.
+
+## API Reference
+
+See the usage sub-pages for full endpoint documentation:
+
+- [Sessions](./usage/agent-sessions.md) — create, status, destroy
+- [Execution](./usage/agent-exec.md) — run WASM with timeout and structured output
+- [File Operations](./usage/agent-files.md) — write, read, list, delete
+- [Environment Variables](./usage/agent-environment.md) — set and get per-session env

--- a/docs/docs/exec/usage/agent-environment.md
+++ b/docs/docs/exec/usage/agent-environment.md
@@ -1,0 +1,61 @@
+---
+sidebar_position: 8
+title: Agent Environment
+---
+
+# Environment Variables
+
+Each session maintains its own set of environment variables, accessible to WASM programs via WASI `environ_get` / `environ_sizes_get`.
+
+## Set Environment Variables
+
+```
+POST /api/v1/sessions/:id/env
+```
+
+**Request body:**
+```json
+{
+  "DATABASE_URL": "postgres://localhost/mydb",
+  "DEBUG": "true"
+}
+```
+
+Variables are merged — existing keys are updated, new keys are added.
+
+**Response** (200):
+```json
+{
+  "message": "Set 2 environment variable(s)"
+}
+```
+
+## Get Environment Variables
+
+```
+GET /api/v1/sessions/:id/env
+```
+
+**Response** (200):
+```json
+{
+  "env": {
+    "DATABASE_URL": "postgres://localhost/mydb",
+    "DEBUG": "true"
+  }
+}
+```
+
+## Per-Execution Environment
+
+You can also set environment variables in the exec request. These are applied before execution and persist for subsequent calls:
+
+```json
+POST /api/v1/sessions/:id/exec
+{
+  "wasm_path": "app.wasm",
+  "env": {
+    "MODE": "production"
+  }
+}
+```

--- a/docs/docs/exec/usage/agent-exec.md
+++ b/docs/docs/exec/usage/agent-exec.md
@@ -1,0 +1,96 @@
+---
+sidebar_position: 6
+title: Agent Execution
+---
+
+# Agent WASM Execution
+
+Execute a `.wasm` file within a session's sandbox.
+
+## Execute WASM
+
+```
+POST /api/v1/sessions/:id/exec
+```
+
+**Request body:**
+```json
+{
+  "wasm_path": "hello.wasm",
+  "function": "_start",
+  "args": ["arg1", "arg2"],
+  "timeout": 30,
+  "env": {
+    "MY_VAR": "value"
+  }
+}
+```
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `wasm_path` | yes | — | Path to `.wasm` file relative to session root |
+| `function` | no | auto-detect | Exported function to call (defaults to `_start`, `main`, or start section) |
+| `args` | no | `[]` | Arguments passed to the WASM program |
+| `timeout` | no | `30` | Execution timeout in seconds |
+| `env` | no | `{}` | Environment variables to set before execution |
+
+**Response** (200):
+```json
+{
+  "stdout": "Hello, World!\n",
+  "stderr": "",
+  "exit_code": 0,
+  "duration_ms": 12
+}
+```
+
+If execution fails (parse error, trap, etc.), the response still returns 200 with an `error` field:
+
+```json
+{
+  "stdout": "",
+  "stderr": "",
+  "exit_code": -1,
+  "duration_ms": 3,
+  "error": "Failed to parse WASM module: invalid magic bytes"
+}
+```
+
+## Timeout
+
+If execution exceeds the timeout, the response includes:
+
+```json
+{
+  "stdout": "partial output...",
+  "stderr": "",
+  "exit_code": -1,
+  "duration_ms": 30000,
+  "error": "Execution timed out after 30s"
+}
+```
+
+## Multiple Executions
+
+A session supports multiple sequential executions. Output buffers are cleared between each call — you always get only the output from the current execution.
+
+```sh
+# First exec
+curl -X POST .../exec -d '{"wasm_path": "a.wasm"}'
+# → {"stdout": "output from a", ...}
+
+# Second exec (does NOT include output from a)
+curl -X POST .../exec -d '{"wasm_path": "b.wasm"}'
+# → {"stdout": "output from b", ...}
+```
+
+## Workflow
+
+A typical agent workflow:
+
+1. Create session
+2. Write `.wasm` file via file upload endpoint
+3. Execute it via `/exec`
+4. Read the structured response
+5. Optionally run more executions
+6. Destroy session when done

--- a/docs/docs/exec/usage/agent-files.md
+++ b/docs/docs/exec/usage/agent-files.md
@@ -1,0 +1,84 @@
+---
+sidebar_position: 7
+title: Agent File Operations
+---
+
+# File Operations
+
+Each session has an isolated filesystem. Files are stored in a temp directory on the host, accessible to the WASM program via WASI preopens.
+
+## Write a File
+
+```
+POST /api/v1/sessions/:id/files
+```
+
+**Request body:**
+```json
+{
+  "path": "src/main.py",
+  "content": "print('hello')"
+}
+```
+
+Parent directories are created automatically. Paths are relative to the session root.
+
+**Response** (200):
+```json
+{
+  "message": "Written: src/main.py"
+}
+```
+
+## Read a File
+
+```
+GET /api/v1/sessions/:id/files?path=src/main.py
+```
+
+**Response** (200):
+```json
+{
+  "path": "src/main.py",
+  "content": "print('hello')"
+}
+```
+
+## List a Directory
+
+```
+GET /api/v1/sessions/:id/files?path=/&list=true
+```
+
+**Response** (200):
+```json
+{
+  "path": "/",
+  "entries": [
+    { "name": "src", "is_dir": true, "size": 0 },
+    { "name": "hello.wasm", "is_dir": false, "size": 1024 }
+  ]
+}
+```
+
+## Delete a File or Directory
+
+```
+DELETE /api/v1/sessions/:id/files?path=src/main.py
+```
+
+Deletes files or directories (recursive for directories).
+
+**Response** (200):
+```json
+{
+  "message": "Deleted: src/main.py"
+}
+```
+
+## Path Safety
+
+- All paths are relative to the session root
+- Leading `/` is stripped (treated as session root)
+- Path traversal (`../`) is rejected with 400 Bad Request
+- Files are only accessible within the session's isolated directory

--- a/docs/docs/exec/usage/agent-sessions.md
+++ b/docs/docs/exec/usage/agent-sessions.md
@@ -1,0 +1,69 @@
+---
+sidebar_position: 5
+title: Agent Sessions
+---
+
+# Session Management
+
+Sessions are isolated WASM sandboxes. Each session has its own filesystem, environment, and output buffers.
+
+## Create a Session
+
+```
+POST /api/v1/sessions
+```
+
+**Response** (200):
+```json
+{
+  "session_id": "a1b2c3d4e5f6...",
+  "created_at": "2025-01-15T10:30:00Z"
+}
+```
+
+## Get Session Status
+
+```
+GET /api/v1/sessions/:id
+```
+
+**Response** (200):
+```json
+{
+  "session_id": "a1b2c3d4e5f6...",
+  "state": "active",
+  "created_at_elapsed_ms": 5000,
+  "last_accessed_elapsed_ms": 1200,
+  "timeout_secs": 300
+}
+```
+
+## Destroy a Session
+
+```
+DELETE /api/v1/sessions/:id
+```
+
+Destroys the session and cleans up its filesystem.
+
+**Response** (200):
+```json
+{
+  "message": "Session a1b2c3d4e5f6... destroyed"
+}
+```
+
+## Session Lifecycle
+
+1. **Created** — `POST /sessions` allocates an isolated temp directory and WASI environment
+2. **Active** — every API call to the session resets the idle timer
+3. **Expired** — after `timeout` seconds of inactivity, the session is marked expired
+4. **Cleaned up** — a background thread periodically removes expired sessions and their files
+
+## Error Responses
+
+| Status | When |
+|--------|------|
+| 404 | Session not found |
+| 410 | Session expired |
+| 429 | Maximum concurrent sessions reached |

--- a/docs/docs/exec/usage/index.md
+++ b/docs/docs/exec/usage/index.md
@@ -33,3 +33,5 @@ wasmrun exec ./module.wasm --call add 5 3
 | [Running WASM Files](./running.md) | Basic execution, entry points, output |
 | [Function Calling](./functions.md) | Call specific exported functions with `--call` |
 | [Argument Passing](./arguments.md) | Pass arguments to WASM programs |
+
+For HTTP-based access (AI agents, automation), see [Agent API](../agent.md).

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -15,7 +15,12 @@ const config: Config = {
   projectName: 'wasmrun',
 
   onBrokenLinks: 'throw',
-  onBrokenMarkdownLinks: 'warn',
+
+  markdown: {
+    hooks: {
+      onBrokenMarkdownLinks: 'warn',
+    },
+  },
 
   i18n: {
     defaultLocale: 'en',

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -54,6 +54,18 @@ const sidebars: SidebarsConfig = {
           ],
         },
         'exec/wasi',
+        {
+          type: 'category',
+          label: 'Agent API',
+          collapsed: true,
+          link: { type: 'doc', id: 'exec/agent' },
+          items: [
+            'exec/usage/agent-sessions',
+            'exec/usage/agent-exec',
+            'exec/usage/agent-files',
+            'exec/usage/agent-environment',
+          ],
+        },
       ],
     },
   ],

--- a/src/agent/api.rs
+++ b/src/agent/api.rs
@@ -1,0 +1,132 @@
+//! Agent mode: REST API request/response types.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+// ── Requests ──────────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct ExecRequest {
+    pub wasm_path: Option<String>,
+    pub function: Option<String>,
+    #[serde(default)]
+    pub args: Vec<String>,
+    pub timeout: Option<u64>,
+    pub env: Option<HashMap<String, String>>,
+}
+
+#[derive(Deserialize)]
+pub struct WriteFileRequest {
+    pub path: String,
+    pub content: String,
+}
+
+// ── Responses ─────────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize)]
+pub struct CreateSessionResponse {
+    pub session_id: String,
+    pub created_at: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SessionStatusResponse {
+    pub session_id: String,
+    pub state: String,
+    pub created_at_elapsed_ms: u64,
+    pub last_accessed_elapsed_ms: u64,
+    pub timeout_secs: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ExecResponse {
+    pub stdout: String,
+    pub stderr: String,
+    pub exit_code: i32,
+    pub duration_ms: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ReadFileResponse {
+    pub path: String,
+    pub content: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ListFilesResponse {
+    pub path: String,
+    pub entries: Vec<FileEntry>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct FileEntry {
+    pub name: String,
+    pub is_dir: bool,
+    pub size: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct EnvVarsResponse {
+    pub env: HashMap<String, String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct MessageResponse {
+    pub message: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ErrorResponse {
+    pub error: String,
+    pub code: u16,
+}
+
+// ── API Error ─────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+pub enum ApiError {
+    SessionNotFound(String),
+    SessionExpired(String),
+    MaxSessions(usize),
+    BadRequest(String),
+    NotFound(String),
+    #[allow(dead_code)] // TODO: Used when exec timeout triggers API-level error
+    Timeout,
+    Internal(String),
+}
+
+impl ApiError {
+    pub fn status_code(&self) -> u16 {
+        match self {
+            ApiError::SessionNotFound(_) | ApiError::NotFound(_) => 404,
+            ApiError::SessionExpired(_) => 410,
+            ApiError::MaxSessions(_) => 429,
+            ApiError::BadRequest(_) => 400,
+            ApiError::Timeout => 408,
+            ApiError::Internal(_) => 500,
+        }
+    }
+
+    pub fn to_error_response(&self) -> ErrorResponse {
+        ErrorResponse {
+            error: self.to_string(),
+            code: self.status_code(),
+        }
+    }
+}
+
+impl std::fmt::Display for ApiError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ApiError::SessionNotFound(id) => write!(f, "Session not found: {id}"),
+            ApiError::SessionExpired(id) => write!(f, "Session expired: {id}"),
+            ApiError::MaxSessions(max) => write!(f, "Maximum sessions reached: {max}"),
+            ApiError::BadRequest(msg) => write!(f, "Bad request: {msg}"),
+            ApiError::NotFound(msg) => write!(f, "Not found: {msg}"),
+            ApiError::Timeout => write!(f, "Execution timed out"),
+            ApiError::Internal(msg) => write!(f, "Internal error: {msg}"),
+        }
+    }
+}

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -4,4 +4,7 @@
 //! for LLM agent integration. Each session gets isolated WASI
 //! filesystem, environment, and output buffers.
 
+pub mod api;
+pub mod server;
 pub mod session;
+pub mod tools;

--- a/src/agent/server.rs
+++ b/src/agent/server.rs
@@ -1,0 +1,1119 @@
+//! Agent mode: REST API server for AI agent sandbox management.
+
+use crate::agent::api::*;
+use crate::agent::session::{SessionConfig, SessionError, SessionManager, SessionState};
+use crate::agent::tools;
+use crate::error::{Result, WasmrunError};
+use crate::runtime::core::native_executor::execute_wasm_bytes_with_env;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::io::Read;
+use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tiny_http::{Header, Method, Request, Response, Server, StatusCode};
+
+const API_PREFIX: &str = "/api/v1";
+const DEFAULT_EXEC_TIMEOUT_SECS: u64 = 30;
+
+pub struct AgentConfig {
+    pub port: u16,
+    pub session_config: SessionConfig,
+    pub allow_cors: bool,
+    pub verbose: bool,
+    pub max_memory_mb: u32,
+}
+
+impl Default for AgentConfig {
+    fn default() -> Self {
+        Self {
+            port: 8430,
+            session_config: SessionConfig::default(),
+            allow_cors: false,
+            verbose: false,
+            max_memory_mb: 256,
+        }
+    }
+}
+
+pub struct AgentServer {
+    session_manager: Arc<SessionManager>,
+    config: AgentConfig,
+}
+
+impl AgentServer {
+    pub fn new(config: AgentConfig) -> Self {
+        let session_manager = Arc::new(SessionManager::with_config(config.session_config.clone()));
+        Self {
+            session_manager,
+            config,
+        }
+    }
+
+    pub fn start(self) -> Result<()> {
+        let addr = format!("0.0.0.0:{}", self.config.port);
+        let server = Server::http(&addr)
+            .map_err(|e| WasmrunError::from(format!("Failed to start agent server: {e}")))?;
+
+        self.print_banner();
+
+        let cleanup_handle = SessionManager::start_cleanup_thread(self.session_manager.clone());
+
+        // Graceful shutdown on Ctrl+C
+        let shutdown = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let shutdown_flag = shutdown.clone();
+        let _ = ctrlc::set_handler(move || {
+            shutdown_flag.store(true, std::sync::atomic::Ordering::Relaxed);
+        });
+
+        for request in server.incoming_requests() {
+            if shutdown.load(std::sync::atomic::Ordering::Relaxed) {
+                let _ =
+                    request.respond(Response::from_string("").with_status_code(StatusCode(503)));
+                break;
+            }
+            if let Err(e) = self.handle_request(request) {
+                eprintln!("Request error: {e}");
+            }
+        }
+
+        eprintln!("\n🛑 Shutting down...");
+        let destroyed = self.session_manager.destroy_all().unwrap_or(0);
+        self.session_manager.stop_cleanup();
+        let _ = cleanup_handle.join();
+        if destroyed > 0 {
+            eprintln!("   Cleaned up {destroyed} session(s)");
+        }
+        eprintln!("   Goodbye.");
+        Ok(())
+    }
+
+    fn print_banner(&self) {
+        let port = self.config.port;
+        let max = self.config.session_config.max_sessions;
+        let timeout = self.config.session_config.default_timeout.as_secs();
+        let mem = self.config.max_memory_mb;
+        let cors = if self.config.allow_cors {
+            "open"
+        } else {
+            "restricted"
+        };
+        println!("\n🤖 Wasmrun Agent Server");
+        println!("   Endpoint:        http://0.0.0.0:{port}{API_PREFIX}");
+        println!("   Max sessions:    {max}");
+        println!("   Session timeout: {timeout}s");
+        println!("   Memory limit:    {mem} MB / session");
+        println!("   CORS:            {cors}");
+        println!();
+        println!("   Endpoints:");
+        println!("     POST   /sessions              create session");
+        println!("     GET    /sessions/:id           session status");
+        println!("     DELETE /sessions/:id           destroy session");
+        println!("     POST   /sessions/:id/exec      execute WASM");
+        println!("     POST   /sessions/:id/files     write file");
+        println!("     GET    /sessions/:id/files     read / list files");
+        println!("     DELETE /sessions/:id/files     delete file");
+        println!("     POST   /sessions/:id/env       set env vars");
+        println!("     GET    /sessions/:id/env       get env vars");
+        println!("     GET    /tools                  LLM tool schemas");
+        println!();
+    }
+
+    fn cors_headers(&self) -> Vec<Header> {
+        let origin = if self.config.allow_cors {
+            "*"
+        } else {
+            "http://127.0.0.1"
+        };
+        vec![
+            Header::from_bytes(&b"Access-Control-Allow-Origin"[..], origin.as_bytes()).unwrap(),
+            Header::from_bytes(
+                &b"Access-Control-Allow-Methods"[..],
+                &b"GET, POST, DELETE, OPTIONS"[..],
+            )
+            .unwrap(),
+            Header::from_bytes(
+                &b"Access-Control-Allow-Headers"[..],
+                &b"Content-Type, Authorization"[..],
+            )
+            .unwrap(),
+            Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..]).unwrap(),
+        ]
+    }
+
+    fn handle_request(&self, mut request: Request) -> Result<()> {
+        let method = request.method().clone();
+        let url = request.url().to_string();
+
+        if self.config.verbose {
+            eprintln!("{method} {url}");
+        }
+
+        if method == Method::Options {
+            return self.respond_empty(request, 204);
+        }
+
+        let (path, query) = split_url(&url);
+        let segments: Vec<&str> = path
+            .trim_start_matches(API_PREFIX)
+            .trim_matches('/')
+            .split('/')
+            .filter(|s| !s.is_empty())
+            .collect();
+
+        let result = match (method, segments.as_slice()) {
+            (Method::Get, ["tools"]) => {
+                let params = parse_query(&query);
+                let format = params.get("format").map(|s| s.as_str()).unwrap_or("openai");
+                self.respond_json(request, self.handle_get_tools(format))
+            }
+            (Method::Post, ["sessions"]) => {
+                self.respond_json(request, self.handle_create_session())
+            }
+            (Method::Get, ["sessions", id]) => {
+                self.respond_json(request, self.handle_get_session(id))
+            }
+            (Method::Delete, ["sessions", id]) => {
+                self.respond_json(request, self.handle_delete_session(id))
+            }
+            (Method::Post, ["sessions", id, "exec"]) => {
+                let body = read_body(request.as_reader())?;
+                self.respond_json(request, self.handle_exec(id, &body))
+            }
+            (Method::Post, ["sessions", id, "files"]) => {
+                let body = read_body(request.as_reader())?;
+                self.respond_json(request, self.handle_write_file(id, &body))
+            }
+            (Method::Get, ["sessions", id, "files"]) => {
+                let params = parse_query(&query);
+                let path = params.get("path").map(|s| s.as_str()).unwrap_or("/");
+                if params.get("list").map(|v| v == "true").unwrap_or(false) {
+                    self.respond_json(request, self.handle_list_files(id, path))
+                } else {
+                    self.respond_json(request, self.handle_read_file(id, path))
+                }
+            }
+            (Method::Delete, ["sessions", id, "files"]) => {
+                let params = parse_query(&query);
+                let path = params.get("path").map(|s| s.as_str()).unwrap_or("");
+                self.respond_json(request, self.handle_delete_file(id, path))
+            }
+            (Method::Post, ["sessions", id, "env"]) => {
+                let body = read_body(request.as_reader())?;
+                self.respond_json(request, self.handle_set_env(id, &body))
+            }
+            (Method::Get, ["sessions", id, "env"]) => {
+                self.respond_json(request, self.handle_get_env(id))
+            }
+            _ => {
+                let err = ApiError::NotFound(format!("Unknown endpoint: {path}"));
+                self.respond_json(request, Err::<serde_json::Value, _>(err))
+            }
+        };
+
+        result
+    }
+
+    // ── Session endpoints ─────────────────────────────────────────
+
+    pub fn handle_create_session(&self) -> std::result::Result<CreateSessionResponse, ApiError> {
+        let id = self
+            .session_manager
+            .create_session()
+            .map_err(map_session_err)?;
+        Ok(CreateSessionResponse {
+            session_id: id,
+            created_at: chrono::Utc::now().to_rfc3339(),
+        })
+    }
+
+    pub fn handle_get_session(
+        &self,
+        id: &str,
+    ) -> std::result::Result<SessionStatusResponse, ApiError> {
+        self.session_manager
+            .get_session(id, |s| SessionStatusResponse {
+                session_id: s.id().to_string(),
+                state: match s.state() {
+                    SessionState::Active => "active".into(),
+                    SessionState::Expired => "expired".into(),
+                },
+                created_at_elapsed_ms: s.created_at().elapsed().as_millis() as u64,
+                last_accessed_elapsed_ms: s.last_accessed().elapsed().as_millis() as u64,
+                timeout_secs: s.timeout().as_secs(),
+            })
+            .map_err(map_session_err)
+    }
+
+    pub fn handle_delete_session(
+        &self,
+        id: &str,
+    ) -> std::result::Result<MessageResponse, ApiError> {
+        self.session_manager
+            .destroy_session(id)
+            .map_err(map_session_err)?;
+        Ok(MessageResponse {
+            message: format!("Session {id} destroyed"),
+        })
+    }
+
+    // ── Exec endpoint ─────────────────────────────────────────────
+
+    pub fn handle_exec(&self, id: &str, body: &str) -> std::result::Result<ExecResponse, ApiError> {
+        let req: ExecRequest =
+            serde_json::from_str(body).map_err(|e| ApiError::BadRequest(e.to_string()))?;
+
+        let wasm_path = req
+            .wasm_path
+            .as_deref()
+            .ok_or_else(|| ApiError::BadRequest("Missing wasm_path".into()))?;
+
+        let (wasi_env, work_dir) = self
+            .session_manager
+            .get_session(id, |s| (s.wasi_env(), s.work_dir().to_path_buf()))
+            .map_err(map_session_err)?;
+
+        let resolved = resolve_session_path(&work_dir, wasm_path)?;
+        let wasm_bytes = std::fs::read(&resolved)
+            .map_err(|e| ApiError::NotFound(format!("{}: {e}", resolved.display())))?;
+
+        // Prepare environment
+        {
+            let mut env = wasi_env
+                .lock()
+                .map_err(|_| ApiError::Internal("Lock".into()))?;
+            env.clear_stdout();
+            env.clear_stderr();
+            if let Some(ref vars) = req.env {
+                for (k, v) in vars {
+                    env.add_env(k.clone(), v.clone());
+                }
+            }
+        }
+
+        let timeout_secs = req.timeout.unwrap_or(DEFAULT_EXEC_TIMEOUT_SECS);
+        let timeout = Duration::from_secs(timeout_secs);
+        let start = Instant::now();
+
+        let exec_env = wasi_env.clone();
+        let function = req.function.clone();
+        let args = req.args.clone();
+        let max_pages = Some(self.config.max_memory_mb * 16); // 1 page = 64KB
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let result =
+                execute_wasm_bytes_with_env(&wasm_bytes, exec_env, function, args, max_pages);
+            let _ = tx.send(result);
+        });
+
+        let duration_ms;
+        let exec_result = match rx.recv_timeout(timeout) {
+            Ok(result) => {
+                duration_ms = start.elapsed().as_millis() as u64;
+                result
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                duration_ms = start.elapsed().as_millis() as u64;
+                return Ok(ExecResponse {
+                    stdout: read_env_stdout(&wasi_env),
+                    stderr: read_env_stderr(&wasi_env),
+                    exit_code: -1,
+                    duration_ms,
+                    error: Some(format!("Execution timed out after {timeout_secs}s")),
+                });
+            }
+            Err(_) => {
+                duration_ms = start.elapsed().as_millis() as u64;
+                return Ok(ExecResponse {
+                    stdout: String::new(),
+                    stderr: String::new(),
+                    exit_code: -1,
+                    duration_ms,
+                    error: Some("Execution thread panicked".into()),
+                });
+            }
+        };
+
+        match exec_result {
+            Ok(exit_code) => Ok(ExecResponse {
+                stdout: read_env_stdout(&wasi_env),
+                stderr: read_env_stderr(&wasi_env),
+                exit_code,
+                duration_ms,
+                error: None,
+            }),
+            Err(e) => Ok(ExecResponse {
+                stdout: read_env_stdout(&wasi_env),
+                stderr: read_env_stderr(&wasi_env),
+                exit_code: -1,
+                duration_ms,
+                error: Some(e.to_string()),
+            }),
+        }
+    }
+
+    // ── File endpoints ────────────────────────────────────────────
+
+    pub fn handle_write_file(
+        &self,
+        id: &str,
+        body: &str,
+    ) -> std::result::Result<MessageResponse, ApiError> {
+        let req: WriteFileRequest =
+            serde_json::from_str(body).map_err(|e| ApiError::BadRequest(e.to_string()))?;
+
+        let work_dir = self
+            .session_manager
+            .get_session(id, |s| s.work_dir().to_path_buf())
+            .map_err(map_session_err)?;
+
+        let resolved = resolve_session_path(&work_dir, &req.path)?;
+        if let Some(parent) = resolved.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| ApiError::Internal(format!("mkdir: {e}")))?;
+        }
+
+        std::fs::write(&resolved, &req.content)
+            .map_err(|e| ApiError::Internal(format!("write: {e}")))?;
+
+        Ok(MessageResponse {
+            message: format!("Written: {}", req.path),
+        })
+    }
+
+    pub fn handle_read_file(
+        &self,
+        id: &str,
+        path: &str,
+    ) -> std::result::Result<ReadFileResponse, ApiError> {
+        let work_dir = self
+            .session_manager
+            .get_session(id, |s| s.work_dir().to_path_buf())
+            .map_err(map_session_err)?;
+
+        let resolved = resolve_session_path(&work_dir, path)?;
+        let content = std::fs::read_to_string(&resolved)
+            .map_err(|e| ApiError::NotFound(format!("{path}: {e}")))?;
+
+        Ok(ReadFileResponse {
+            path: path.to_string(),
+            content,
+        })
+    }
+
+    pub fn handle_list_files(
+        &self,
+        id: &str,
+        path: &str,
+    ) -> std::result::Result<ListFilesResponse, ApiError> {
+        let work_dir = self
+            .session_manager
+            .get_session(id, |s| s.work_dir().to_path_buf())
+            .map_err(map_session_err)?;
+
+        let resolved = resolve_session_path(&work_dir, path)?;
+        let entries = std::fs::read_dir(&resolved)
+            .map_err(|e| ApiError::NotFound(format!("{path}: {e}")))?
+            .filter_map(|entry| {
+                let entry = entry.ok()?;
+                let meta = entry.metadata().ok()?;
+                Some(FileEntry {
+                    name: entry.file_name().to_string_lossy().into(),
+                    is_dir: meta.is_dir(),
+                    size: meta.len(),
+                })
+            })
+            .collect();
+
+        Ok(ListFilesResponse {
+            path: path.to_string(),
+            entries,
+        })
+    }
+
+    pub fn handle_delete_file(
+        &self,
+        id: &str,
+        path: &str,
+    ) -> std::result::Result<MessageResponse, ApiError> {
+        if path.is_empty() {
+            return Err(ApiError::BadRequest("Missing path parameter".into()));
+        }
+
+        let work_dir = self
+            .session_manager
+            .get_session(id, |s| s.work_dir().to_path_buf())
+            .map_err(map_session_err)?;
+
+        let resolved = resolve_session_path(&work_dir, path)?;
+
+        if resolved.is_dir() {
+            std::fs::remove_dir_all(&resolved)
+                .map_err(|e| ApiError::NotFound(format!("{path}: {e}")))?;
+        } else {
+            std::fs::remove_file(&resolved)
+                .map_err(|e| ApiError::NotFound(format!("{path}: {e}")))?;
+        }
+
+        Ok(MessageResponse {
+            message: format!("Deleted: {path}"),
+        })
+    }
+
+    // ── Env endpoints ─────────────────────────────────────────────
+
+    pub fn handle_set_env(
+        &self,
+        id: &str,
+        body: &str,
+    ) -> std::result::Result<MessageResponse, ApiError> {
+        let vars: HashMap<String, String> =
+            serde_json::from_str(body).map_err(|e| ApiError::BadRequest(e.to_string()))?;
+
+        self.session_manager
+            .get_session(id, |s| {
+                for (k, v) in &vars {
+                    s.set_env(k, v);
+                }
+            })
+            .map_err(map_session_err)?;
+
+        Ok(MessageResponse {
+            message: format!("Set {} environment variable(s)", vars.len()),
+        })
+    }
+
+    pub fn handle_get_env(&self, id: &str) -> std::result::Result<EnvVarsResponse, ApiError> {
+        let env = self
+            .session_manager
+            .get_session(id, |s| {
+                let wasi = s.wasi_env();
+                let locked = wasi.lock().unwrap();
+                locked
+                    .env_vars()
+                    .iter()
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect::<HashMap<_, _>>()
+            })
+            .map_err(map_session_err)?;
+
+        Ok(EnvVarsResponse { env })
+    }
+
+    // ── Tools endpoint ──────────────────────────────────────────
+
+    pub fn handle_get_tools(
+        &self,
+        format: &str,
+    ) -> std::result::Result<serde_json::Value, ApiError> {
+        match format {
+            "anthropic" => serde_json::to_value(tools::anthropic_tools())
+                .map_err(|e| ApiError::Internal(e.to_string())),
+            _ => serde_json::to_value(tools::openai_tools())
+                .map_err(|e| ApiError::Internal(e.to_string())),
+        }
+    }
+
+    // ── Response helpers ──────────────────────────────────────────
+
+    fn respond_json<T: Serialize>(
+        &self,
+        request: Request,
+        result: std::result::Result<T, ApiError>,
+    ) -> Result<()> {
+        let (status, body) = match result {
+            Ok(data) => (200, serde_json::to_string(&data).unwrap_or_default()),
+            Err(e) => {
+                let code = e.status_code();
+                let body = serde_json::to_string(&e.to_error_response()).unwrap_or_default();
+                (code, body)
+            }
+        };
+        let mut response = Response::from_string(body).with_status_code(StatusCode(status));
+        for h in self.cors_headers() {
+            response = response.with_header(h);
+        }
+        request
+            .respond(response)
+            .map_err(|e| WasmrunError::from(format!("Response error: {e}")))
+    }
+
+    fn respond_empty(&self, request: Request, status: u16) -> Result<()> {
+        let mut response = Response::from_string("").with_status_code(StatusCode(status));
+        for h in self.cors_headers() {
+            response = response.with_header(h);
+        }
+        request
+            .respond(response)
+            .map_err(|e| WasmrunError::from(format!("Response error: {e}")))
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────
+
+fn map_session_err(e: SessionError) -> ApiError {
+    match e {
+        SessionError::NotFound { id } => ApiError::SessionNotFound(id),
+        SessionError::Expired { id } => ApiError::SessionExpired(id),
+        SessionError::MaxSessionsReached { max } => ApiError::MaxSessions(max),
+        SessionError::IoError { message } => ApiError::Internal(message),
+        SessionError::LockError => ApiError::Internal("Lock error".into()),
+    }
+}
+
+fn resolve_session_path(
+    work_dir: &Path,
+    guest_path: &str,
+) -> std::result::Result<PathBuf, ApiError> {
+    let cleaned = guest_path.trim_start_matches('/');
+    for component in Path::new(cleaned).components() {
+        if let Component::ParentDir = component {
+            return Err(ApiError::BadRequest("Path traversal not allowed".into()));
+        }
+    }
+    Ok(work_dir.join(cleaned))
+}
+
+fn read_body(reader: &mut dyn Read) -> Result<String> {
+    let mut body = String::new();
+    reader
+        .read_to_string(&mut body)
+        .map_err(|e| WasmrunError::from(format!("Failed to read request body: {e}")))?;
+    Ok(body)
+}
+
+fn split_url(url: &str) -> (String, String) {
+    match url.split_once('?') {
+        Some((path, query)) => (path.to_string(), query.to_string()),
+        None => (url.to_string(), String::new()),
+    }
+}
+
+fn parse_query(query: &str) -> HashMap<String, String> {
+    query
+        .split('&')
+        .filter(|s| !s.is_empty())
+        .filter_map(|pair| {
+            let (k, v) = pair.split_once('=')?;
+            Some((k.to_string(), url_decode(v)))
+        })
+        .collect()
+}
+
+fn url_decode(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    let mut chars = s.bytes();
+    while let Some(b) = chars.next() {
+        if b == b'%' {
+            let hi = chars.next().and_then(hex_val);
+            let lo = chars.next().and_then(hex_val);
+            if let (Some(h), Some(l)) = (hi, lo) {
+                result.push((h << 4 | l) as char);
+            }
+        } else if b == b'+' {
+            result.push(' ');
+        } else {
+            result.push(b as char);
+        }
+    }
+    result
+}
+
+fn hex_val(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn read_env_stdout(
+    env: &std::sync::Arc<std::sync::Mutex<crate::runtime::wasi::WasiEnv>>,
+) -> String {
+    env.lock()
+        .map(|e| String::from_utf8_lossy(&e.get_stdout()).into_owned())
+        .unwrap_or_default()
+}
+
+fn read_env_stderr(
+    env: &std::sync::Arc<std::sync::Mutex<crate::runtime::wasi::WasiEnv>>,
+) -> String {
+    env.lock()
+        .map(|e| String::from_utf8_lossy(&e.get_stderr()).into_owned())
+        .unwrap_or_default()
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_server() -> AgentServer {
+        AgentServer::new(AgentConfig {
+            port: 0,
+            session_config: SessionConfig {
+                default_timeout: Duration::from_secs(60),
+                max_sessions: 10,
+                cleanup_interval: Duration::from_secs(300),
+            },
+            allow_cors: true,
+            verbose: false,
+            max_memory_mb: 256,
+        })
+    }
+
+    // Hand-built WASM that calls fd_write to print "Hello, World!\n"
+    fn hello_wasm() -> Vec<u8> {
+        #[rustfmt::skip]
+        let wasm: Vec<u8> = vec![
+            0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+            0x01, 0x0c, 0x02,
+            0x60, 0x04, 0x7f, 0x7f, 0x7f, 0x7f, 0x01, 0x7f,
+            0x60, 0x00, 0x00,
+            0x02, 0x23, 0x01,
+            0x16,
+            0x77, 0x61, 0x73, 0x69, 0x5f, 0x73, 0x6e, 0x61,
+            0x70, 0x73, 0x68, 0x6f, 0x74, 0x5f, 0x70, 0x72,
+            0x65, 0x76, 0x69, 0x65, 0x77, 0x31,
+            0x08,
+            0x66, 0x64, 0x5f, 0x77, 0x72, 0x69, 0x74, 0x65,
+            0x00, 0x00,
+            0x03, 0x02, 0x01, 0x01,
+            0x05, 0x03, 0x01, 0x00, 0x01,
+            0x07, 0x13, 0x02,
+            0x06, 0x6d, 0x65, 0x6d, 0x6f, 0x72, 0x79, 0x02, 0x00,
+            0x06, 0x5f, 0x73, 0x74, 0x61, 0x72, 0x74, 0x00, 0x01,
+            0x0a, 0x1d, 0x01, 0x1b, 0x00,
+            0x41, 0x00, 0x41, 0x10, 0x36, 0x02, 0x00,
+            0x41, 0x04, 0x41, 0x0e, 0x36, 0x02, 0x00,
+            0x41, 0x01, 0x41, 0x00, 0x41, 0x01, 0x41, 0x08,
+            0x10, 0x00, 0x1a, 0x0b,
+            0x0b, 0x14, 0x01, 0x00,
+            0x41, 0x10, 0x0b, 0x0e,
+            0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x2c, 0x20,
+            0x57, 0x6f, 0x72, 0x6c, 0x64, 0x21, 0x0a,
+        ];
+        wasm
+    }
+
+    // ── Session lifecycle ─────────────────────────────────────────
+
+    #[test]
+    fn test_create_session() {
+        let server = test_server();
+        let resp = server.handle_create_session().unwrap();
+        assert_eq!(resp.session_id.len(), 32);
+        assert!(!resp.created_at.is_empty());
+        server.session_manager.destroy_all().unwrap();
+    }
+
+    #[test]
+    fn test_get_session() {
+        let server = test_server();
+        let id = server.handle_create_session().unwrap().session_id;
+        let resp = server.handle_get_session(&id).unwrap();
+        assert_eq!(resp.session_id, id);
+        assert_eq!(resp.state, "active");
+        server.session_manager.destroy_all().unwrap();
+    }
+
+    #[test]
+    fn test_delete_session() {
+        let server = test_server();
+        let id = server.handle_create_session().unwrap().session_id;
+        server.handle_delete_session(&id).unwrap();
+        assert!(server.handle_get_session(&id).is_err());
+    }
+
+    #[test]
+    fn test_session_not_found() {
+        let server = test_server();
+        let err = server.handle_get_session("nonexistent").unwrap_err();
+        assert_eq!(err.status_code(), 404);
+    }
+
+    // ── File CRUD ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_write_and_read_file() {
+        let server = test_server();
+        let id = server.handle_create_session().unwrap().session_id;
+
+        server
+            .handle_write_file(&id, r#"{"path": "test.txt", "content": "hello agent"}"#)
+            .unwrap();
+
+        let resp = server.handle_read_file(&id, "test.txt").unwrap();
+        assert_eq!(resp.content, "hello agent");
+
+        server.session_manager.destroy_all().unwrap();
+    }
+
+    #[test]
+    fn test_write_nested_file() {
+        let server = test_server();
+        let id = server.handle_create_session().unwrap().session_id;
+
+        server
+            .handle_write_file(&id, r#"{"path": "sub/dir/file.txt", "content": "nested"}"#)
+            .unwrap();
+
+        let resp = server.handle_read_file(&id, "sub/dir/file.txt").unwrap();
+        assert_eq!(resp.content, "nested");
+
+        server.session_manager.destroy_all().unwrap();
+    }
+
+    #[test]
+    fn test_list_files() {
+        let server = test_server();
+        let id = server.handle_create_session().unwrap().session_id;
+
+        server
+            .handle_write_file(&id, r#"{"path": "a.txt", "content": "a"}"#)
+            .unwrap();
+        server
+            .handle_write_file(&id, r#"{"path": "b.txt", "content": "bb"}"#)
+            .unwrap();
+
+        let resp = server.handle_list_files(&id, "/").unwrap();
+        assert_eq!(resp.entries.len(), 2);
+
+        let names: Vec<&str> = resp.entries.iter().map(|e| e.name.as_str()).collect();
+        assert!(names.contains(&"a.txt"));
+        assert!(names.contains(&"b.txt"));
+
+        server.session_manager.destroy_all().unwrap();
+    }
+
+    #[test]
+    fn test_delete_file() {
+        let server = test_server();
+        let id = server.handle_create_session().unwrap().session_id;
+
+        server
+            .handle_write_file(&id, r#"{"path": "del.txt", "content": "x"}"#)
+            .unwrap();
+
+        server.handle_delete_file(&id, "del.txt").unwrap();
+        assert!(server.handle_read_file(&id, "del.txt").is_err());
+
+        server.session_manager.destroy_all().unwrap();
+    }
+
+    #[test]
+    fn test_read_nonexistent_file() {
+        let server = test_server();
+        let id = server.handle_create_session().unwrap().session_id;
+        let err = server.handle_read_file(&id, "nope.txt").unwrap_err();
+        assert_eq!(err.status_code(), 404);
+        server.session_manager.destroy_all().unwrap();
+    }
+
+    #[test]
+    fn test_path_traversal_rejected() {
+        let server = test_server();
+        let id = server.handle_create_session().unwrap().session_id;
+        let err = server
+            .handle_read_file(&id, "../../../etc/passwd")
+            .unwrap_err();
+        assert_eq!(err.status_code(), 400);
+        server.session_manager.destroy_all().unwrap();
+    }
+
+    // ── Env ───────────────────────────────────────────────────────
+
+    #[test]
+    fn test_set_and_get_env() {
+        let server = test_server();
+        let id = server.handle_create_session().unwrap().session_id;
+
+        server
+            .handle_set_env(&id, r#"{"FOO": "bar", "BAZ": "qux"}"#)
+            .unwrap();
+
+        let resp = server.handle_get_env(&id).unwrap();
+        assert_eq!(resp.env.get("FOO").unwrap(), "bar");
+        assert_eq!(resp.env.get("BAZ").unwrap(), "qux");
+
+        server.session_manager.destroy_all().unwrap();
+    }
+
+    // ── Exec ──────────────────────────────────────────────────────
+
+    #[test]
+    fn test_exec_wasm() {
+        let server = test_server();
+        let id = server.handle_create_session().unwrap().session_id;
+
+        // Write the hello WASM to the session
+        let wasm = hello_wasm();
+        let work_dir = server
+            .session_manager
+            .get_session(&id, |s| s.work_dir().to_path_buf())
+            .unwrap();
+        std::fs::write(work_dir.join("hello.wasm"), &wasm).unwrap();
+
+        let resp = server
+            .handle_exec(&id, r#"{"wasm_path": "hello.wasm"}"#)
+            .unwrap();
+
+        assert_eq!(resp.stdout, "Hello, World!\n");
+        assert_eq!(resp.exit_code, 0);
+        assert!(resp.error.is_none());
+        assert!(resp.duration_ms < 5000);
+
+        server.session_manager.destroy_all().unwrap();
+    }
+
+    #[test]
+    fn test_exec_nonexistent_wasm() {
+        let server = test_server();
+        let id = server.handle_create_session().unwrap().session_id;
+
+        let err = server
+            .handle_exec(&id, r#"{"wasm_path": "nope.wasm"}"#)
+            .unwrap_err();
+        assert_eq!(err.status_code(), 404);
+
+        server.session_manager.destroy_all().unwrap();
+    }
+
+    #[test]
+    fn test_exec_missing_wasm_path() {
+        let server = test_server();
+        let id = server.handle_create_session().unwrap().session_id;
+
+        let err = server.handle_exec(&id, r#"{}"#).unwrap_err();
+        assert_eq!(err.status_code(), 400);
+
+        server.session_manager.destroy_all().unwrap();
+    }
+
+    #[test]
+    fn test_exec_clears_output_between_calls() {
+        let server = test_server();
+        let id = server.handle_create_session().unwrap().session_id;
+
+        let wasm = hello_wasm();
+        let work_dir = server
+            .session_manager
+            .get_session(&id, |s| s.work_dir().to_path_buf())
+            .unwrap();
+        std::fs::write(work_dir.join("hello.wasm"), &wasm).unwrap();
+
+        // First exec
+        let resp1 = server
+            .handle_exec(&id, r#"{"wasm_path": "hello.wasm"}"#)
+            .unwrap();
+        assert_eq!(resp1.stdout, "Hello, World!\n");
+
+        // Second exec should not accumulate
+        let resp2 = server
+            .handle_exec(&id, r#"{"wasm_path": "hello.wasm"}"#)
+            .unwrap();
+        assert_eq!(resp2.stdout, "Hello, World!\n");
+
+        server.session_manager.destroy_all().unwrap();
+    }
+
+    // ── Full lifecycle ────────────────────────────────────────────
+
+    #[test]
+    fn test_full_session_lifecycle() {
+        let server = test_server();
+
+        // 1. Create
+        let id = server.handle_create_session().unwrap().session_id;
+
+        // 2. Set env
+        server.handle_set_env(&id, r#"{"APP": "test"}"#).unwrap();
+
+        // 3. Write WASM file
+        let wasm = hello_wasm();
+        let work_dir = server
+            .session_manager
+            .get_session(&id, |s| s.work_dir().to_path_buf())
+            .unwrap();
+        std::fs::write(work_dir.join("hello.wasm"), &wasm).unwrap();
+
+        // 4. Write a data file
+        server
+            .handle_write_file(&id, r#"{"path": "data.txt", "content": "test data"}"#)
+            .unwrap();
+
+        // 5. List files
+        let files = server.handle_list_files(&id, "/").unwrap();
+        assert!(files.entries.len() >= 2);
+
+        // 6. Execute WASM
+        let exec = server
+            .handle_exec(&id, r#"{"wasm_path": "hello.wasm"}"#)
+            .unwrap();
+        assert_eq!(exec.stdout, "Hello, World!\n");
+        assert_eq!(exec.exit_code, 0);
+
+        // 7. Read file back
+        let content = server.handle_read_file(&id, "data.txt").unwrap();
+        assert_eq!(content.content, "test data");
+
+        // 8. Check env
+        let env = server.handle_get_env(&id).unwrap();
+        assert_eq!(env.env.get("APP").unwrap(), "test");
+
+        // 9. Destroy
+        server.handle_delete_session(&id).unwrap();
+        assert!(server.handle_get_session(&id).is_err());
+    }
+
+    // ── Concurrent sessions ───────────────────────────────────────
+
+    #[test]
+    fn test_concurrent_sessions_isolation() {
+        let server = Arc::new(test_server());
+        let wasm = hello_wasm();
+
+        let handles: Vec<_> = (0..5)
+            .map(|i| {
+                let srv = server.clone();
+                let wasm = wasm.clone();
+                std::thread::spawn(move || {
+                    let id = srv.handle_create_session().unwrap().session_id;
+
+                    // Each session writes its own file
+                    let body = format!(r#"{{"path": "id.txt", "content": "session-{i}"}}"#);
+                    srv.handle_write_file(&id, &body).unwrap();
+
+                    // Write and exec WASM
+                    let work_dir = srv
+                        .session_manager
+                        .get_session(&id, |s| s.work_dir().to_path_buf())
+                        .unwrap();
+                    std::fs::write(work_dir.join("hello.wasm"), &wasm).unwrap();
+
+                    let exec = srv
+                        .handle_exec(&id, r#"{"wasm_path": "hello.wasm"}"#)
+                        .unwrap();
+                    assert_eq!(exec.stdout, "Hello, World!\n");
+
+                    // Verify isolation
+                    let content = srv.handle_read_file(&id, "id.txt").unwrap();
+                    assert_eq!(content.content, format!("session-{i}"));
+
+                    id
+                })
+            })
+            .collect();
+
+        let ids: Vec<String> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+        assert_eq!(ids.len(), 5);
+
+        // Unique session IDs
+        let unique: std::collections::HashSet<&String> = ids.iter().collect();
+        assert_eq!(unique.len(), 5);
+
+        server.session_manager.destroy_all().unwrap();
+    }
+
+    // ── URL parsing helpers ───────────────────────────────────────
+
+    #[test]
+    fn test_split_url() {
+        assert_eq!(
+            split_url("/api/v1/sessions?foo=bar"),
+            ("/api/v1/sessions".into(), "foo=bar".into())
+        );
+        assert_eq!(
+            split_url("/api/v1/sessions"),
+            ("/api/v1/sessions".into(), String::new())
+        );
+    }
+
+    #[test]
+    fn test_parse_query() {
+        let q = parse_query("path=test.txt&list=true");
+        assert_eq!(q.get("path").unwrap(), "test.txt");
+        assert_eq!(q.get("list").unwrap(), "true");
+    }
+
+    #[test]
+    fn test_url_decode() {
+        assert_eq!(url_decode("hello%20world"), "hello world");
+        assert_eq!(url_decode("a+b"), "a b");
+        assert_eq!(url_decode("test%2Fpath"), "test/path");
+    }
+
+    #[test]
+    fn test_resolve_session_path_normal() {
+        let work = PathBuf::from("/tmp/session");
+        let p = resolve_session_path(&work, "test.txt").unwrap();
+        assert_eq!(p, PathBuf::from("/tmp/session/test.txt"));
+    }
+
+    #[test]
+    fn test_resolve_session_path_strips_leading_slash() {
+        let work = PathBuf::from("/tmp/session");
+        let p = resolve_session_path(&work, "/test.txt").unwrap();
+        assert_eq!(p, PathBuf::from("/tmp/session/test.txt"));
+    }
+
+    #[test]
+    fn test_resolve_session_path_rejects_traversal() {
+        let work = PathBuf::from("/tmp/session");
+        assert!(resolve_session_path(&work, "../etc/passwd").is_err());
+        assert!(resolve_session_path(&work, "sub/../../etc/passwd").is_err());
+    }
+
+    // ── Tools endpoint ────────────────────────────────────────────
+
+    #[test]
+    fn test_get_tools_openai_format() {
+        let server = test_server();
+        let result = server.handle_get_tools("openai").unwrap();
+        let tools = result.as_array().unwrap();
+        assert_eq!(tools.len(), 6);
+        assert_eq!(tools[0]["type"], "function");
+        assert!(tools[0]["function"]["name"].is_string());
+        assert!(tools[0]["function"]["parameters"].is_object());
+    }
+
+    #[test]
+    fn test_get_tools_anthropic_format() {
+        let server = test_server();
+        let result = server.handle_get_tools("anthropic").unwrap();
+        let tools = result.as_array().unwrap();
+        assert_eq!(tools.len(), 6);
+        assert!(tools[0]["input_schema"].is_object());
+        // Anthropic format has no "function" wrapper
+        assert!(tools[0].get("function").is_none());
+    }
+
+    #[test]
+    fn test_get_tools_default_is_openai() {
+        let server = test_server();
+        let result = server.handle_get_tools("unknown").unwrap();
+        let tools = result.as_array().unwrap();
+        assert_eq!(tools[0]["type"], "function");
+    }
+
+    #[test]
+    fn test_get_tools_has_all_operations() {
+        let server = test_server();
+        let result = server.handle_get_tools("openai").unwrap();
+        let names: Vec<&str> = result
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|t| t["function"]["name"].as_str().unwrap())
+            .collect();
+        assert!(names.contains(&"create_session"));
+        assert!(names.contains(&"execute_code"));
+        assert!(names.contains(&"write_file"));
+        assert!(names.contains(&"read_file"));
+        assert!(names.contains(&"list_files"));
+        assert!(names.contains(&"destroy_session"));
+    }
+}

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -17,7 +17,6 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 ///
 /// Uses system time nanos + counter for entropy, mixed via xorshift64.
 /// Not cryptographically secure — sufficient for session identifiers.
-#[allow(dead_code)] // TODO: Used by Session::new, consumed by agent API (0.18.2)
 fn generate_session_id() -> String {
     use std::sync::atomic::{AtomicU64, Ordering};
     static COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -42,7 +41,6 @@ fn generate_session_id() -> String {
     hex_encode(&bytes)
 }
 
-#[allow(dead_code)] // TODO: Used by generate_session_id
 fn hex_encode(bytes: &[u8]) -> String {
     bytes.iter().map(|b| format!("{b:02x}")).collect()
 }
@@ -51,7 +49,6 @@ fn hex_encode(bytes: &[u8]) -> String {
 
 /// Current lifecycle state of a session.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(dead_code)] // TODO: Consumed by agent API (0.18.2)
 pub enum SessionState {
     /// Session is active and accepting commands.
     Active,
@@ -65,7 +62,6 @@ pub enum SessionState {
 ///
 /// Each session owns a temporary directory on the host filesystem,
 /// a WASI environment with independent I/O buffers, and timeout tracking.
-#[allow(dead_code)] // TODO: Consumed by agent API (0.18.2)
 pub struct Session {
     /// Unique session identifier (32-char hex string).
     id: String,
@@ -85,7 +81,6 @@ pub struct Session {
     owns_work_dir: bool,
 }
 
-#[allow(dead_code)] // TODO: Consumed by agent API (0.18.2)
 impl Session {
     /// Create a new session with an isolated temp directory.
     ///
@@ -199,6 +194,7 @@ impl Session {
     }
 
     /// Get captured stdout from the session's WASI environment.
+    #[allow(dead_code)] // TODO: Used by agent tools/shell
     pub fn get_stdout(&self) -> Vec<u8> {
         self.wasi_env
             .lock()
@@ -207,6 +203,7 @@ impl Session {
     }
 
     /// Get captured stderr from the session's WASI environment.
+    #[allow(dead_code)] // TODO: Used by agent tools/shell
     pub fn get_stderr(&self) -> Vec<u8> {
         self.wasi_env
             .lock()
@@ -215,6 +212,7 @@ impl Session {
     }
 
     /// Clear captured stdout/stderr buffers (e.g., between exec calls).
+    #[allow(dead_code)] // TODO: Used by agent tools/shell
     pub fn clear_output(&self) {
         if let Ok(mut env) = self.wasi_env.lock() {
             env.clear_stdout();
@@ -240,7 +238,6 @@ impl Drop for Session {
 
 /// Configuration for the SessionManager.
 #[derive(Debug, Clone)]
-#[allow(dead_code)] // TODO: Consumed by agent API (0.18.2)
 pub struct SessionConfig {
     /// Default idle timeout for new sessions.
     pub default_timeout: Duration,
@@ -264,7 +261,6 @@ impl Default for SessionConfig {
 ///
 /// Thread-safe: all operations are behind a RwLock.
 /// Optionally runs a background cleanup thread for expired sessions.
-#[allow(dead_code)] // TODO: Consumed by agent API (0.18.2)
 pub struct SessionManager {
     sessions: RwLock<HashMap<String, Session>>,
     config: SessionConfig,
@@ -272,7 +268,6 @@ pub struct SessionManager {
     cleanup_stop: Arc<Mutex<bool>>,
 }
 
-#[allow(dead_code)] // TODO: Consumed by agent API (0.18.2)
 impl SessionManager {
     /// Create a new SessionManager with default configuration.
     pub fn new() -> Self {
@@ -347,6 +342,7 @@ impl SessionManager {
     }
 
     /// List all active (non-expired) session IDs.
+    #[allow(dead_code)] // TODO: Used by agent list sessions endpoint
     pub fn list_sessions(&self) -> Result<Vec<SessionInfo>, SessionError> {
         let sessions = self.sessions.read().map_err(|_| SessionError::LockError)?;
         Ok(sessions
@@ -382,6 +378,7 @@ impl SessionManager {
     }
 
     /// Get the number of active (non-expired) sessions.
+    #[allow(dead_code)] // TODO: Used by agent metrics
     pub fn active_count(&self) -> usize {
         self.sessions
             .read()
@@ -390,6 +387,7 @@ impl SessionManager {
     }
 
     /// Get the total number of sessions (including expired ones not yet cleaned up).
+    #[allow(dead_code)] // TODO: Used by agent metrics
     pub fn total_count(&self) -> usize {
         self.sessions.read().map(|s| s.len()).unwrap_or(0)
     }
@@ -431,6 +429,7 @@ impl SessionManager {
     }
 
     /// Get session configuration.
+    #[allow(dead_code)] // TODO: Used by agent status endpoint
     pub fn config(&self) -> &SessionConfig {
         &self.config
     }
@@ -446,7 +445,7 @@ impl Default for SessionManager {
 
 /// Summary information about a session (safe to serialize/return via API).
 #[derive(Debug, Clone)]
-#[allow(dead_code)] // TODO: Consumed by agent API (0.18.2)
+#[allow(dead_code)] // TODO: Used by agent list sessions endpoint
 pub struct SessionInfo {
     pub id: String,
     pub state: SessionState,
@@ -459,7 +458,6 @@ pub struct SessionInfo {
 
 /// Errors specific to session management.
 #[derive(Debug)]
-#[allow(dead_code)] // TODO: Consumed by agent API (0.18.2)
 pub enum SessionError {
     /// Session not found.
     NotFound { id: String },

--- a/src/agent/tools.rs
+++ b/src/agent/tools.rs
@@ -1,0 +1,277 @@
+//! Agent mode: LLM tool schema definitions.
+//!
+//! Provides tool definitions in OpenAI and Anthropic function-calling formats
+//! so LLM agents can discover and invoke sandbox operations.
+
+use serde::Serialize;
+use serde_json::{json, Value};
+
+#[derive(Debug, Serialize)]
+pub struct OpenAiTool {
+    pub r#type: &'static str,
+    pub function: OpenAiFunction,
+}
+
+#[derive(Debug, Serialize)]
+pub struct OpenAiFunction {
+    pub name: &'static str,
+    pub description: &'static str,
+    pub parameters: Value,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AnthropicTool {
+    pub name: &'static str,
+    pub description: &'static str,
+    pub input_schema: Value,
+}
+
+pub fn openai_tools() -> Vec<OpenAiTool> {
+    vec![
+        OpenAiTool {
+            r#type: "function",
+            function: OpenAiFunction {
+                name: "create_session",
+                description: "Create a new isolated WASM sandbox session with its own filesystem and environment.",
+                parameters: json!({
+                    "type": "object",
+                    "properties": {},
+                    "required": [],
+                    "additionalProperties": false
+                }),
+            },
+        },
+        OpenAiTool {
+            r#type: "function",
+            function: OpenAiFunction {
+                name: "execute_code",
+                description: "Execute a WASM file inside a sandbox session. Returns stdout, stderr, exit code, and duration.",
+                parameters: json!({
+                    "type": "object",
+                    "properties": {
+                        "session_id": {
+                            "type": "string",
+                            "description": "The session ID returned by create_session"
+                        },
+                        "wasm_path": {
+                            "type": "string",
+                            "description": "Path to the .wasm file relative to the session root"
+                        },
+                        "function": {
+                            "type": "string",
+                            "description": "Exported function to call (defaults to _start or main)"
+                        },
+                        "args": {
+                            "type": "array",
+                            "items": { "type": "string" },
+                            "description": "Arguments passed to the WASM program"
+                        },
+                        "timeout": {
+                            "type": "integer",
+                            "description": "Execution timeout in seconds (default: 30)"
+                        },
+                        "env": {
+                            "type": "object",
+                            "additionalProperties": { "type": "string" },
+                            "description": "Environment variables to set before execution"
+                        }
+                    },
+                    "required": ["session_id", "wasm_path"],
+                    "additionalProperties": false
+                }),
+            },
+        },
+        OpenAiTool {
+            r#type: "function",
+            function: OpenAiFunction {
+                name: "write_file",
+                description: "Write a file to the session's isolated filesystem. Parent directories are created automatically.",
+                parameters: json!({
+                    "type": "object",
+                    "properties": {
+                        "session_id": {
+                            "type": "string",
+                            "description": "The session ID"
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "File path relative to session root"
+                        },
+                        "content": {
+                            "type": "string",
+                            "description": "File content to write"
+                        }
+                    },
+                    "required": ["session_id", "path", "content"],
+                    "additionalProperties": false
+                }),
+            },
+        },
+        OpenAiTool {
+            r#type: "function",
+            function: OpenAiFunction {
+                name: "read_file",
+                description: "Read a file from the session's filesystem.",
+                parameters: json!({
+                    "type": "object",
+                    "properties": {
+                        "session_id": {
+                            "type": "string",
+                            "description": "The session ID"
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "File path relative to session root"
+                        }
+                    },
+                    "required": ["session_id", "path"],
+                    "additionalProperties": false
+                }),
+            },
+        },
+        OpenAiTool {
+            r#type: "function",
+            function: OpenAiFunction {
+                name: "list_files",
+                description: "List files and directories at a path in the session's filesystem.",
+                parameters: json!({
+                    "type": "object",
+                    "properties": {
+                        "session_id": {
+                            "type": "string",
+                            "description": "The session ID"
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": "Directory path relative to session root (default: /)"
+                        }
+                    },
+                    "required": ["session_id"],
+                    "additionalProperties": false
+                }),
+            },
+        },
+        OpenAiTool {
+            r#type: "function",
+            function: OpenAiFunction {
+                name: "destroy_session",
+                description: "Destroy a sandbox session and clean up all its files and resources.",
+                parameters: json!({
+                    "type": "object",
+                    "properties": {
+                        "session_id": {
+                            "type": "string",
+                            "description": "The session ID to destroy"
+                        }
+                    },
+                    "required": ["session_id"],
+                    "additionalProperties": false
+                }),
+            },
+        },
+    ]
+}
+
+pub fn anthropic_tools() -> Vec<AnthropicTool> {
+    openai_tools()
+        .into_iter()
+        .map(|t| AnthropicTool {
+            name: t.function.name,
+            description: t.function.description,
+            input_schema: t.function.parameters,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_openai_tools_valid_structure() {
+        let tools = openai_tools();
+        assert_eq!(tools.len(), 6);
+        for tool in &tools {
+            assert_eq!(tool.r#type, "function");
+            assert!(!tool.function.name.is_empty());
+            assert!(!tool.function.description.is_empty());
+            assert!(tool.function.parameters.is_object());
+            assert_eq!(tool.function.parameters["type"], "object");
+            assert!(tool.function.parameters["properties"].is_object());
+            assert!(tool.function.parameters["required"].is_array());
+        }
+    }
+
+    #[test]
+    fn test_openai_tool_names() {
+        let tools = openai_tools();
+        let names: Vec<&str> = tools.iter().map(|t| t.function.name).collect();
+        assert!(names.contains(&"create_session"));
+        assert!(names.contains(&"execute_code"));
+        assert!(names.contains(&"write_file"));
+        assert!(names.contains(&"read_file"));
+        assert!(names.contains(&"list_files"));
+        assert!(names.contains(&"destroy_session"));
+    }
+
+    #[test]
+    fn test_execute_code_has_required_params() {
+        let tools = openai_tools();
+        let exec = tools
+            .iter()
+            .find(|t| t.function.name == "execute_code")
+            .unwrap();
+        let required = exec.function.parameters["required"].as_array().unwrap();
+        let req_strs: Vec<&str> = required.iter().map(|v| v.as_str().unwrap()).collect();
+        assert!(req_strs.contains(&"session_id"));
+        assert!(req_strs.contains(&"wasm_path"));
+    }
+
+    #[test]
+    fn test_anthropic_tools_same_count() {
+        assert_eq!(openai_tools().len(), anthropic_tools().len());
+    }
+
+    #[test]
+    fn test_anthropic_tools_valid_structure() {
+        let tools = anthropic_tools();
+        for tool in &tools {
+            assert!(!tool.name.is_empty());
+            assert!(!tool.description.is_empty());
+            assert!(tool.input_schema.is_object());
+            assert_eq!(tool.input_schema["type"], "object");
+        }
+    }
+
+    #[test]
+    fn test_anthropic_tool_names_match_openai() {
+        let openai_names: Vec<&str> = openai_tools().iter().map(|t| t.function.name).collect();
+        let anthropic_names: Vec<&str> = anthropic_tools().iter().map(|t| t.name).collect();
+        assert_eq!(openai_names, anthropic_names);
+    }
+
+    #[test]
+    fn test_openai_tools_serializable() {
+        let tools = openai_tools();
+        let json = serde_json::to_string(&tools).unwrap();
+        assert!(json.contains("create_session"));
+        assert!(json.contains("\"type\":\"function\""));
+    }
+
+    #[test]
+    fn test_anthropic_tools_serializable() {
+        let tools = anthropic_tools();
+        let json = serde_json::to_string(&tools).unwrap();
+        assert!(json.contains("input_schema"));
+        assert!(json.contains("destroy_session"));
+    }
+
+    #[test]
+    fn test_tools_roundtrip_parse() {
+        let tools = openai_tools();
+        let json = serde_json::to_string(&tools).unwrap();
+        let parsed: Vec<Value> = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.len(), 6);
+        assert_eq!(parsed[0]["type"], "function");
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -270,6 +270,53 @@ pub enum Commands {
         allow_cors: bool,
     },
 
+    /// Start the agent sandbox API server for AI agents
+    Agent {
+        /// Server port (default: 8430)
+        #[arg(
+            short = 'P',
+            long,
+            default_value_t = 8430,
+            value_parser = clap::value_parser!(u16).range(1..=65535),
+            help = "Agent API server port"
+        )]
+        port: u16,
+
+        /// Default session timeout in seconds (default: 300)
+        #[arg(
+            short = 't',
+            long,
+            default_value_t = 300,
+            help = "Default idle timeout per session (seconds)"
+        )]
+        timeout: u64,
+
+        /// Maximum concurrent sessions (default: 100)
+        #[arg(
+            short = 'm',
+            long,
+            default_value_t = 100,
+            help = "Maximum number of concurrent sandbox sessions"
+        )]
+        max_sessions: usize,
+
+        /// Memory limit per session in MB (default: 256)
+        #[arg(
+            long,
+            default_value_t = 256,
+            help = "Maximum linear memory per session (MB)"
+        )]
+        max_memory: u32,
+
+        /// Allow wildcard CORS (Access-Control-Allow-Origin: *)
+        #[arg(long, help = "Allow cross-origin requests from any domain")]
+        allow_cors: bool,
+
+        /// Enable verbose request logging
+        #[arg(short = 'v', long, help = "Log all incoming requests")]
+        verbose: bool,
+    },
+
     /// Plugin management commands
     #[command(subcommand)]
     Plugin(PluginSubcommands),
@@ -505,6 +552,7 @@ impl CommandArgs for Commands {
             //     name.clone()
             //         .unwrap_or_else(|| "my-wasmrun-project".to_string())
             // }),
+            Commands::Agent { .. } => "./".to_string(),
             Commands::Plugin(_) => "./".to_string(),
             Commands::Stop => "./".to_string(),
         }

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -1,0 +1,30 @@
+//! Agent mode: CLI command handler for `wasmrun agent`.
+
+use crate::agent::server::{AgentConfig, AgentServer};
+use crate::agent::session::SessionConfig;
+use crate::error::Result;
+use std::time::Duration;
+
+pub fn handle_agent_command(
+    port: u16,
+    timeout: u64,
+    max_sessions: usize,
+    max_memory: u32,
+    allow_cors: bool,
+    verbose: bool,
+) -> Result<()> {
+    let config = AgentConfig {
+        port,
+        session_config: SessionConfig {
+            default_timeout: Duration::from_secs(timeout),
+            max_sessions,
+            cleanup_interval: Duration::from_secs(30),
+        },
+        allow_cors,
+        verbose,
+        max_memory_mb: max_memory,
+    };
+
+    let server = AgentServer::new(config);
+    server.start()
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,4 @@
+mod agent;
 mod clean;
 mod compile;
 mod exec;
@@ -10,6 +11,7 @@ mod run;
 mod stop;
 mod verify;
 
+pub use agent::handle_agent_command;
 pub use clean::handle_clean_command;
 pub use compile::handle_compile_command;
 pub use exec::handle_exec_command;

--- a/src/main.rs
+++ b/src/main.rs
@@ -175,6 +175,31 @@ fn main() {
             })
         }
 
+        Some(Commands::Agent {
+            port,
+            timeout,
+            max_sessions,
+            max_memory,
+            allow_cors,
+            verbose,
+        }) => {
+            debug_println!(
+                "Processing agent command: port={}, timeout={}, max_sessions={}, max_memory={}MB",
+                port,
+                timeout,
+                max_sessions,
+                max_memory
+            );
+            commands::handle_agent_command(
+                *port,
+                *timeout,
+                *max_sessions,
+                *max_memory,
+                *allow_cors,
+                *verbose,
+            )
+        }
+
         Some(Commands::Plugin(plugin_cmd)) => {
             commands::run_plugin_command(plugin_cmd).map_err(|e| match e {
                 WasmrunError::Command(_) | WasmrunError::Path { .. } => e,

--- a/src/runtime/core/native_executor.rs
+++ b/src/runtime/core/native_executor.rs
@@ -114,6 +114,77 @@ pub fn execute_wasm_bytes_with_args(
     }
 }
 
+/// Execute WASM bytes using an existing WasiEnv (for agent session reuse).
+///
+/// Unlike `execute_wasm_bytes_with_args`, this does not print captured output —
+/// the caller reads stdout/stderr from the WasiEnv after execution.
+pub fn execute_wasm_bytes_with_env(
+    wasm_bytes: &[u8],
+    wasi_env: Arc<Mutex<WasiEnv>>,
+    function: Option<String>,
+    args: Vec<String>,
+    max_memory_pages: Option<u32>,
+) -> Result<i32> {
+    let mut module = Module::parse(wasm_bytes)
+        .map_err(|e| WasmrunError::from(format!("Failed to parse WASM module: {e}")))?;
+
+    if let Some(cap) = max_memory_pages {
+        if let Some(ref mut mem) = module.memory {
+            match mem.max {
+                Some(m) if m > cap => mem.max = Some(cap),
+                None => mem.max = Some(cap),
+                _ => {}
+            }
+        }
+    }
+
+    if let Ok(mut env) = wasi_env.lock() {
+        env.set_args(args.clone());
+    }
+
+    let wasi_linker = create_wasi_linker(wasi_env);
+
+    let mut executor = Executor::new_with_linker(module, wasi_linker)
+        .map_err(|e| WasmrunError::from(format!("Failed to initialize executor: {e}")))?;
+
+    let func_idx = if let Some(func_name) = function {
+        find_export_function(executor.module(), &func_name)
+            .map(|(_, idx)| idx)
+            .ok_or_else(|| {
+                WasmrunError::from(format!(
+                    "Exported function '{func_name}' not found in WASM module"
+                ))
+            })?
+    } else {
+        let start_func = executor.module().start;
+        if let Some(func_idx) = start_func {
+            func_idx
+        } else if let Some((_, func_idx)) = find_export_function(executor.module(), "main") {
+            func_idx
+        } else if let Some((_, func_idx)) = find_export_function(executor.module(), "_start") {
+            func_idx
+        } else {
+            return Err(WasmrunError::from(
+                "No entry point found (checked: start section, main, _start)".to_string(),
+            ));
+        }
+    };
+
+    let wasm_args = convert_string_args_to_values(&args);
+
+    match execute_function(&mut executor, func_idx, wasm_args) {
+        Ok(()) => Ok(0),
+        Err(e) => {
+            let err_str = e.to_string();
+            if let Some(code) = Executor::is_proc_exit(&err_str) {
+                Ok(code)
+            } else {
+                Err(e)
+            }
+        }
+    }
+}
+
 fn convert_string_args_to_values(args: &[String]) -> Vec<Value> {
     args.iter()
         .map(|arg| {

--- a/src/runtime/wasi/mod.rs
+++ b/src/runtime/wasi/mod.rs
@@ -98,13 +98,12 @@ impl WasiEnv {
         self
     }
 
-    #[allow(dead_code)]
+    #[allow(dead_code)] // TODO: Used by agent session builder
     pub fn with_env(mut self, key: String, value: String) -> Self {
         self.env_vars.push((key, value));
         self
     }
 
-    #[allow(dead_code)]
     pub fn with_preopen(mut self, guest_path: &str, host_path: impl AsRef<Path>) -> Self {
         let host = host_path.as_ref().to_path_buf();
         let fd = self.next_fd;
@@ -121,6 +120,10 @@ impl WasiEnv {
         );
         self.preopens.push((guest_path.to_string(), host));
         self
+    }
+
+    pub fn set_args(&mut self, args: Vec<String>) {
+        self.args = args;
     }
 
     pub fn args(&self) -> &[String] {
@@ -148,7 +151,6 @@ impl WasiEnv {
     }
 
     /// Add an environment variable (appends to existing list).
-    #[allow(dead_code)] // TODO: Used by agent session management (0.18.1)
     pub fn add_env(&mut self, key: String, value: String) {
         // Update existing or append
         if let Some(entry) = self.env_vars.iter_mut().find(|(k, _)| k == &key) {
@@ -159,13 +161,11 @@ impl WasiEnv {
     }
 
     /// Clear captured stdout buffer.
-    #[allow(dead_code)] // TODO: Used by agent session management (0.18.1)
     pub fn clear_stdout(&mut self) {
         self.stdout.clear();
     }
 
     /// Clear captured stderr buffer.
-    #[allow(dead_code)] // TODO: Used by agent session management (0.18.1)
     pub fn clear_stderr(&mut self) {
         self.stderr.clear();
     }


### PR DESCRIPTION
HTTP server wrapping exec mode for AI agent integration. Agents create isolated sessions, upload files, execute WASM, and retrieve structured output, all via REST.

CLI:
```sh
wasmrun agent [--port 8430] [--timeout 300] [--max-sessions 100] [--max-memory 256] [--allow-cors] [--verbose]
```