### PR TITLE
feat(agent): add per-session resource limits

### DIFF
--- a/src/agent/api.rs
+++ b/src/agent/api.rs
@@ -1,9 +1,17 @@
 //! Agent mode: REST API request/response types.
 
+use crate::agent::limits::LimitsOverride;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 // ── Requests ──────────────────────────────────────────────────────────
+
+/// Optional body for `POST /sessions`. Lets a caller override the server's
+/// default resource limits for the new session. Absent fields use defaults.
+#[derive(Deserialize, Default)]
+pub struct CreateSessionRequest {
+    pub limits: Option<LimitsOverride>,
+}
 
 #[derive(Deserialize)]
 pub struct ExecRequest {
@@ -60,6 +68,10 @@ pub struct ExecResponse {
     pub stderr: String,
     pub exit_code: i32,
     pub duration_ms: u64,
+    /// True when captured output was dropped because the output cap was hit.
+    /// Omitted from JSON when false to keep the common response shape clean.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub output_truncated: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
 }

--- a/src/agent/executor.rs
+++ b/src/agent/executor.rs
@@ -4,7 +4,8 @@
 //! Currently supports JavaScript via QuickJS.
 
 use crate::agent::api::ApiError;
-use crate::runtime::core::native_executor::execute_wasm_bytes_with_env;
+use crate::agent::limits::{dir_size, ResourceLimits};
+use crate::runtime::core::native_executor::{execute_wasm_bytes_with_env, ExecLimits};
 use crate::runtime::runtime_cache::{wasmhub_language, RuntimeCache};
 use crate::runtime::wasi::WasiEnv;
 use std::collections::HashMap;
@@ -34,12 +35,16 @@ pub fn execute_source(
     language: &str,
     wasi_env: Arc<Mutex<WasiEnv>>,
     work_dir: &Path,
-    max_memory_pages: Option<u32>,
+    limits: &ResourceLimits,
 ) -> std::result::Result<i32, ApiError> {
     let runtime_name = resolve_runtime(language)?;
 
-    std::fs::write(work_dir.join(JS_SCRIPT_NAME), source)
-        .map_err(|e| ApiError::Internal(format!("Failed to write script: {e}")))?;
+    write_checked(
+        &work_dir.join(JS_SCRIPT_NAME),
+        source.as_bytes(),
+        limits,
+        work_dir,
+    )?;
 
     let wasm_bytes = fetch_runtime_bytes(runtime_name)?;
 
@@ -49,7 +54,7 @@ pub fn execute_source(
         "run".to_string(),
         JS_SCRIPT_NAME.to_string(),
     ];
-    execute_wasm_bytes_with_env(&wasm_bytes, wasi_env, None, args, max_memory_pages)
+    execute_wasm_bytes_with_env(&wasm_bytes, wasi_env, None, args, exec_limits(limits))
         .map_err(|e| ApiError::Internal(e.to_string()))
 }
 
@@ -65,7 +70,7 @@ pub fn execute_source_project(
     language: &str,
     wasi_env: Arc<Mutex<WasiEnv>>,
     work_dir: &Path,
-    max_memory_pages: Option<u32>,
+    limits: &ResourceLimits,
 ) -> std::result::Result<i32, ApiError> {
     let runtime_name = resolve_runtime(language)?;
 
@@ -83,13 +88,12 @@ pub fn execute_source_project(
     }
 
     for (rel_path, content) in files {
-        let resolved = work_dir.join(rel_path);
-        if let Some(parent) = resolved.parent() {
-            std::fs::create_dir_all(parent)
-                .map_err(|e| ApiError::Internal(format!("Failed to create dir: {e}")))?;
-        }
-        std::fs::write(&resolved, content)
-            .map_err(|e| ApiError::Internal(format!("Failed to write {rel_path}: {e}")))?;
+        write_checked(
+            &work_dir.join(rel_path),
+            content.as_bytes(),
+            limits,
+            work_dir,
+        )?;
     }
 
     let args = vec![
@@ -102,9 +106,39 @@ pub fn execute_source_project(
         wasi_env,
         None,
         args,
-        max_memory_pages,
+        exec_limits(limits),
     )
     .map_err(|e| ApiError::Internal(e.to_string()))
+}
+
+/// Build executor-level limits (memory + fuel) from the session's full limits.
+fn exec_limits(limits: &ResourceLimits) -> ExecLimits {
+    ExecLimits {
+        max_memory_pages: limits.max_memory_pages,
+        max_fuel: limits.max_fuel,
+    }
+}
+
+/// Write `content` to `resolved`, first enforcing the per-file size and total
+/// disk-usage caps against the session's current footprint at `work_dir`.
+fn write_checked(
+    resolved: &Path,
+    content: &[u8],
+    limits: &ResourceLimits,
+    work_dir: &Path,
+) -> std::result::Result<(), ApiError> {
+    let existing_len = std::fs::metadata(resolved).map(|m| m.len()).unwrap_or(0);
+    let current_disk = dir_size(work_dir);
+    limits
+        .check_write(content.len() as u64, existing_len, current_disk)
+        .map_err(ApiError::BadRequest)?;
+    if let Some(parent) = resolved.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| ApiError::Internal(format!("Failed to create dir: {e}")))?;
+    }
+    std::fs::write(resolved, content)
+        .map_err(|e| ApiError::Internal(format!("Failed to write file: {e}")))?;
+    Ok(())
 }
 
 fn fetch_runtime_bytes(runtime_name: &str) -> std::result::Result<Vec<u8>, ApiError> {
@@ -213,8 +247,15 @@ mod tests {
     fn test_execute_source_project_rejects_empty_files() {
         let env = Arc::new(Mutex::new(WasiEnv::new()));
         let tmp = std::env::temp_dir();
-        let err = execute_source_project(&HashMap::new(), "main.js", "javascript", env, &tmp, None)
-            .unwrap_err();
+        let err = execute_source_project(
+            &HashMap::new(),
+            "main.js",
+            "javascript",
+            env,
+            &tmp,
+            &ResourceLimits::default(),
+        )
+        .unwrap_err();
         assert_eq!(err.status_code(), 400);
         assert!(err.to_string().contains("empty"));
     }
@@ -225,8 +266,15 @@ mod tests {
         let tmp = std::env::temp_dir();
         let mut files = HashMap::new();
         files.insert("a.js".to_string(), "1".to_string());
-        let err =
-            execute_source_project(&files, "main.js", "javascript", env, &tmp, None).unwrap_err();
+        let err = execute_source_project(
+            &files,
+            "main.js",
+            "javascript",
+            env,
+            &tmp,
+            &ResourceLimits::default(),
+        )
+        .unwrap_err();
         assert_eq!(err.status_code(), 400);
         assert!(err.to_string().contains("Entry"));
     }
@@ -237,7 +285,15 @@ mod tests {
         let tmp = std::env::temp_dir();
         let mut files = HashMap::new();
         files.insert("main.py".to_string(), "print(1)".to_string());
-        let err = execute_source_project(&files, "main.py", "python", env, &tmp, None).unwrap_err();
+        let err = execute_source_project(
+            &files,
+            "main.py",
+            "python",
+            env,
+            &tmp,
+            &ResourceLimits::default(),
+        )
+        .unwrap_err();
         assert_eq!(err.status_code(), 400);
         assert!(err.to_string().contains("python"));
     }
@@ -260,8 +316,15 @@ mod tests {
         files.insert("main.js".to_string(), "console.log(1)".to_string());
         files.insert("../evil.js".to_string(), "pwned".to_string());
 
-        let err =
-            execute_source_project(&files, "main.js", "javascript", env, &tmp, None).unwrap_err();
+        let err = execute_source_project(
+            &files,
+            "main.js",
+            "javascript",
+            env,
+            &tmp,
+            &ResourceLimits::default(),
+        )
+        .unwrap_err();
         assert_eq!(err.status_code(), 400);
         assert!(err.to_string().contains("traversal"));
 

--- a/src/agent/limits.rs
+++ b/src/agent/limits.rs
@@ -1,0 +1,318 @@
+//! Agent mode: per-session resource limits.
+//!
+//! A single source of truth for the resource ceilings applied to a sandbox
+//! session: linear memory, execution fuel (instruction budget), captured
+//! output, individual file size, and total disk usage. Limits are configured
+//! globally via CLI flags and may be overridden per-session at creation.
+//!
+//! A field of `None` means "unlimited" for that dimension.
+
+/// WASM linear memory page size (64 KiB), used to convert MB → pages.
+const WASM_PAGE_SIZE_BYTES: u64 = 65536;
+const BYTES_PER_MB: u64 = 1024 * 1024;
+
+/// Resource ceilings for a single sandbox session.
+///
+/// Each field caps one dimension of resource use. `None` disables that cap.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResourceLimits {
+    /// Maximum linear memory in WASM pages (64 KiB each). Enforced by the
+    /// executor when a module calls `memory.grow`.
+    pub max_memory_pages: Option<u32>,
+    /// Maximum number of WASM instructions ("fuel") a single execution may
+    /// run before it is aborted. Guards against runaway / infinite loops.
+    pub max_fuel: Option<u64>,
+    /// Maximum combined stdout + stderr bytes captured per execution. Output
+    /// beyond this is dropped and the response is flagged as truncated.
+    pub max_output_bytes: Option<usize>,
+    /// Maximum size in bytes of any single file written into the session.
+    pub max_file_size: Option<u64>,
+    /// Maximum total disk usage (bytes) of the session's working directory.
+    pub max_disk_bytes: Option<u64>,
+}
+
+impl Default for ResourceLimits {
+    /// Production defaults: generous enough for real workloads (including the
+    /// QuickJS runtime) yet bounded for everything but raw instruction count.
+    ///
+    /// Fuel defaults to unlimited because language runtimes need a very large,
+    /// workload-dependent instruction budget; operators opt into a fuel cap
+    /// explicitly via `--max-fuel`. The wall-clock exec timeout remains the
+    /// default time guard.
+    fn default() -> Self {
+        ResourceLimits {
+            max_memory_pages: Some(mb_to_pages(256)), // 256 MB
+            max_fuel: None,
+            max_output_bytes: Some((10 * BYTES_PER_MB) as usize), // 10 MB
+            max_file_size: Some(50 * BYTES_PER_MB),               // 50 MB
+            max_disk_bytes: Some(100 * BYTES_PER_MB),             // 100 MB
+        }
+    }
+}
+
+impl ResourceLimits {
+    /// Build limits from operator-facing units (MB and a raw fuel count).
+    ///
+    /// A value of `0` for any field means "unlimited" for that dimension,
+    /// matching the CLI convention where `0` disables a cap.
+    pub fn from_cli(
+        max_memory_mb: u32,
+        max_fuel: u64,
+        max_output_mb: u32,
+        max_file_size_mb: u32,
+        max_disk_mb: u32,
+    ) -> Self {
+        ResourceLimits {
+            max_memory_pages: zero_is_none_u32(max_memory_mb).map(mb_to_pages),
+            max_fuel: zero_is_none_u64(max_fuel),
+            max_output_bytes: zero_is_none_u32(max_output_mb).map(|mb| mb_to_bytes(mb) as usize),
+            max_file_size: zero_is_none_u32(max_file_size_mb).map(mb_to_bytes),
+            max_disk_bytes: zero_is_none_u32(max_disk_mb).map(mb_to_bytes),
+        }
+    }
+
+    /// Apply a set of optional overrides (already in raw units) on top of self,
+    /// returning the merged limits. `None` overrides leave the existing value.
+    pub fn with_overrides(&self, overrides: &LimitsOverride) -> Self {
+        let mut merged = self.clone();
+        if let Some(mb) = overrides.max_memory_mb {
+            merged.max_memory_pages = zero_is_none_u32(mb).map(mb_to_pages);
+        }
+        if let Some(fuel) = overrides.max_fuel {
+            merged.max_fuel = zero_is_none_u64(fuel);
+        }
+        if let Some(mb) = overrides.max_output_mb {
+            merged.max_output_bytes = zero_is_none_u32(mb).map(|mb| mb_to_bytes(mb) as usize);
+        }
+        if let Some(mb) = overrides.max_file_size_mb {
+            merged.max_file_size = zero_is_none_u32(mb).map(mb_to_bytes);
+        }
+        if let Some(mb) = overrides.max_disk_mb {
+            merged.max_disk_bytes = zero_is_none_u32(mb).map(mb_to_bytes);
+        }
+        merged
+    }
+
+    /// Check that writing a file of `new_len` bytes is allowed. `existing_len`
+    /// is the size of the file being replaced (0 for a new file), so that
+    /// overwriting an existing file is measured by its net change on disk.
+    ///
+    /// Returns an explanatory error string if the per-file or total-disk cap
+    /// would be exceeded.
+    pub fn check_write(
+        &self,
+        new_len: u64,
+        existing_len: u64,
+        current_disk_usage: u64,
+    ) -> Result<(), String> {
+        if let Some(max) = self.max_file_size {
+            if new_len > max {
+                return Err(format!(
+                    "File size limit exceeded: {new_len} bytes > {max} byte limit"
+                ));
+            }
+        }
+        if let Some(max) = self.max_disk_bytes {
+            // Net disk after replacing `existing_len` with `new_len`.
+            let projected = current_disk_usage.saturating_sub(existing_len) + new_len;
+            if projected > max {
+                return Err(format!(
+                    "Disk usage limit exceeded: {projected} bytes > {max} byte limit"
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Optional per-session limit overrides, in operator-facing units.
+///
+/// Deserialized from the optional body of `POST /sessions`. Every field is
+/// optional; absent fields fall back to the server defaults. A value of `0`
+/// disables that cap (matching the CLI convention).
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+pub struct LimitsOverride {
+    pub max_memory_mb: Option<u32>,
+    pub max_fuel: Option<u64>,
+    pub max_output_mb: Option<u32>,
+    pub max_file_size_mb: Option<u32>,
+    pub max_disk_mb: Option<u32>,
+}
+
+/// Recursively sum the size of all regular files under `dir`.
+///
+/// Returns 0 if the directory does not exist or cannot be read; symlinks are
+/// not followed. Used to measure a session's current disk footprint.
+pub fn dir_size(dir: &std::path::Path) -> u64 {
+    let mut total = 0u64;
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return 0;
+    };
+    for entry in entries.flatten() {
+        let Ok(meta) = entry.metadata() else {
+            continue;
+        };
+        if meta.is_dir() {
+            total += dir_size(&entry.path());
+        } else if meta.is_file() {
+            total += meta.len();
+        }
+    }
+    total
+}
+
+fn mb_to_pages(mb: u32) -> u32 {
+    ((mb as u64 * BYTES_PER_MB) / WASM_PAGE_SIZE_BYTES) as u32
+}
+
+fn mb_to_bytes(mb: u32) -> u64 {
+    mb as u64 * BYTES_PER_MB
+}
+
+fn zero_is_none_u32(v: u32) -> Option<u32> {
+    if v == 0 {
+        None
+    } else {
+        Some(v)
+    }
+}
+
+fn zero_is_none_u64(v: u64) -> Option<u64> {
+    if v == 0 {
+        None
+    } else {
+        Some(v)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mb_to_pages() {
+        // 1 MB = 16 pages of 64 KiB
+        assert_eq!(mb_to_pages(1), 16);
+        assert_eq!(mb_to_pages(256), 4096);
+    }
+
+    #[test]
+    fn test_from_cli_units() {
+        let l = ResourceLimits::from_cli(256, 1_000_000, 10, 50, 100);
+        assert_eq!(l.max_memory_pages, Some(4096));
+        assert_eq!(l.max_fuel, Some(1_000_000));
+        assert_eq!(l.max_output_bytes, Some(10 * 1024 * 1024));
+        assert_eq!(l.max_file_size, Some(50 * 1024 * 1024));
+        assert_eq!(l.max_disk_bytes, Some(100 * 1024 * 1024));
+    }
+
+    #[test]
+    fn test_from_cli_zero_means_unlimited() {
+        let l = ResourceLimits::from_cli(0, 0, 0, 0, 0);
+        assert_eq!(l.max_memory_pages, None);
+        assert_eq!(l.max_fuel, None);
+        assert_eq!(l.max_output_bytes, None);
+        assert_eq!(l.max_file_size, None);
+        assert_eq!(l.max_disk_bytes, None);
+    }
+
+    #[test]
+    fn test_default_has_no_fuel_cap() {
+        // Fuel is opt-in so heavy runtimes (QuickJS) are not broken by default.
+        assert_eq!(ResourceLimits::default().max_fuel, None);
+        assert!(ResourceLimits::default().max_memory_pages.is_some());
+    }
+
+    #[test]
+    fn test_with_overrides_partial() {
+        let base = ResourceLimits::from_cli(256, 0, 10, 50, 100);
+        let ov = LimitsOverride {
+            max_fuel: Some(5000),
+            max_file_size_mb: Some(1),
+            ..Default::default()
+        };
+        let merged = base.with_overrides(&ov);
+        // Overridden fields change
+        assert_eq!(merged.max_fuel, Some(5000));
+        assert_eq!(merged.max_file_size, Some(1024 * 1024));
+        // Untouched fields stay
+        assert_eq!(merged.max_memory_pages, base.max_memory_pages);
+        assert_eq!(merged.max_output_bytes, base.max_output_bytes);
+    }
+
+    #[test]
+    fn test_with_overrides_zero_disables() {
+        let base = ResourceLimits::from_cli(256, 1000, 10, 50, 100);
+        let ov = LimitsOverride {
+            max_fuel: Some(0),
+            ..Default::default()
+        };
+        let merged = base.with_overrides(&ov);
+        assert_eq!(merged.max_fuel, None);
+    }
+
+    #[test]
+    fn test_check_write_file_size() {
+        let l = ResourceLimits {
+            max_file_size: Some(100),
+            max_disk_bytes: None,
+            ..ResourceLimits::default()
+        };
+        assert!(l.check_write(100, 0, 0).is_ok());
+        let err = l.check_write(101, 0, 0).unwrap_err();
+        assert!(err.contains("File size limit"));
+    }
+
+    #[test]
+    fn test_check_write_disk_usage() {
+        let l = ResourceLimits {
+            max_file_size: None,
+            max_disk_bytes: Some(1000),
+            ..ResourceLimits::default()
+        };
+        // 900 used + 100 new = 1000, ok
+        assert!(l.check_write(100, 0, 900).is_ok());
+        // 900 used + 101 new = 1001, over
+        let err = l.check_write(101, 0, 900).unwrap_err();
+        assert!(err.contains("Disk usage limit"));
+    }
+
+    #[test]
+    fn test_check_write_disk_counts_replacement() {
+        let l = ResourceLimits {
+            max_file_size: None,
+            max_disk_bytes: Some(1000),
+            ..ResourceLimits::default()
+        };
+        // Replacing a 500-byte file with a 600-byte one when 900 total are used:
+        // 900 - 500 + 600 = 1000, still within limit.
+        assert!(l.check_write(600, 500, 900).is_ok());
+    }
+
+    #[test]
+    fn test_check_write_unlimited() {
+        let l = ResourceLimits {
+            max_file_size: None,
+            max_disk_bytes: None,
+            ..ResourceLimits::default()
+        };
+        assert!(l.check_write(u64::MAX, 0, u64::MAX).is_ok());
+    }
+
+    #[test]
+    fn test_dir_size_missing_is_zero() {
+        let p = std::path::Path::new("/nonexistent/wasmrun/path/xyz");
+        assert_eq!(dir_size(p), 0);
+    }
+
+    #[test]
+    fn test_dir_size_sums_files() {
+        let tmp = std::env::temp_dir().join(format!("wasmrun_dirsize_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(tmp.join("sub")).unwrap();
+        std::fs::write(tmp.join("a.txt"), b"hello").unwrap(); // 5
+        std::fs::write(tmp.join("sub/b.txt"), b"world!").unwrap(); // 6
+        assert_eq!(dir_size(&tmp), 11);
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+}

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod api;
 pub mod executor;
+pub mod limits;
 pub mod server;
 pub mod session;
 pub mod shell;

--- a/src/agent/server.rs
+++ b/src/agent/server.rs
@@ -2,11 +2,12 @@
 
 use crate::agent::api::*;
 use crate::agent::executor;
+use crate::agent::limits::{dir_size, ResourceLimits};
 use crate::agent::session::{SessionConfig, SessionError, SessionManager, SessionState};
 use crate::agent::shell;
 use crate::agent::tools;
 use crate::error::{Result, WasmrunError};
-use crate::runtime::core::native_executor::execute_wasm_bytes_with_env;
+use crate::runtime::core::native_executor::{execute_wasm_bytes_with_env, ExecLimits};
 use serde::Serialize;
 use std::collections::HashMap;
 use std::io::Read;
@@ -26,7 +27,6 @@ pub struct AgentConfig {
     pub session_config: SessionConfig,
     pub allow_cors: bool,
     pub verbose: bool,
-    pub max_memory_mb: u32,
 }
 
 impl Default for AgentConfig {
@@ -36,7 +36,6 @@ impl Default for AgentConfig {
             session_config: SessionConfig::default(),
             allow_cors: false,
             verbose: false,
-            max_memory_mb: 256,
         }
     }
 }
@@ -97,7 +96,7 @@ impl AgentServer {
         let port = self.config.port;
         let max = self.config.session_config.max_sessions;
         let timeout = self.config.session_config.default_timeout.as_secs();
-        let mem = self.config.max_memory_mb;
+        let limits = &self.config.session_config.limits;
         let cors = if self.config.allow_cors {
             "open"
         } else {
@@ -107,7 +106,23 @@ impl AgentServer {
         println!("   Endpoint:        http://0.0.0.0:{port}{API_PREFIX}");
         println!("   Max sessions:    {max}");
         println!("   Session timeout: {timeout}s");
-        println!("   Memory limit:    {mem} MB / session");
+        println!(
+            "   Memory limit:    {}",
+            fmt_pages_mb(limits.max_memory_pages)
+        );
+        println!(
+            "   Fuel limit:      {}",
+            fmt_opt_u64(limits.max_fuel, "instructions")
+        );
+        println!(
+            "   Output limit:    {}",
+            fmt_bytes_mb(limits.max_output_bytes.map(|b| b as u64))
+        );
+        println!("   File size limit: {}", fmt_bytes_mb(limits.max_file_size));
+        println!(
+            "   Disk limit:      {}",
+            fmt_bytes_mb(limits.max_disk_bytes)
+        );
         println!("   CORS:            {cors}");
         println!();
         println!("   Endpoints:");
@@ -173,7 +188,8 @@ impl AgentServer {
                 self.respond_json(request, self.handle_get_tools(format))
             }
             (Method::Post, ["sessions"]) => {
-                self.respond_json(request, self.handle_create_session())
+                let body = read_body(request.as_reader())?;
+                self.respond_json(request, self.handle_create_session_with_body(&body))
             }
             (Method::Get, ["sessions", id]) => {
                 self.respond_json(request, self.handle_get_session(id))
@@ -221,10 +237,37 @@ impl AgentServer {
 
     // ── Session endpoints ─────────────────────────────────────────
 
+    #[allow(dead_code)] // Used by tests; the HTTP route uses the _with_body variant.
     pub fn handle_create_session(&self) -> std::result::Result<CreateSessionResponse, ApiError> {
+        self.create_session_with_limits(self.config.session_config.limits.clone())
+    }
+
+    /// Create a session, applying any per-session limit overrides supplied in
+    /// the (optional) request body on top of the server defaults.
+    pub fn handle_create_session_with_body(
+        &self,
+        body: &str,
+    ) -> std::result::Result<CreateSessionResponse, ApiError> {
+        let limits = if body.trim().is_empty() {
+            self.config.session_config.limits.clone()
+        } else {
+            let req: CreateSessionRequest =
+                serde_json::from_str(body).map_err(|e| ApiError::BadRequest(e.to_string()))?;
+            match req.limits {
+                Some(ov) => self.config.session_config.limits.with_overrides(&ov),
+                None => self.config.session_config.limits.clone(),
+            }
+        };
+        self.create_session_with_limits(limits)
+    }
+
+    fn create_session_with_limits(
+        &self,
+        limits: ResourceLimits,
+    ) -> std::result::Result<CreateSessionResponse, ApiError> {
         let id = self
             .session_manager
-            .create_session()
+            .create_session_with_limits(self.config.session_config.default_timeout, limits)
             .map_err(map_session_err)?;
         Ok(CreateSessionResponse {
             session_id: id,
@@ -268,9 +311,11 @@ impl AgentServer {
         let req: ExecRequest =
             serde_json::from_str(body).map_err(|e| ApiError::BadRequest(e.to_string()))?;
 
-        let (wasi_env, work_dir) = self
+        let (wasi_env, work_dir, limits) = self
             .session_manager
-            .get_session(id, |s| (s.wasi_env(), s.work_dir().to_path_buf()))
+            .get_session(id, |s| {
+                (s.wasi_env(), s.work_dir().to_path_buf(), s.limits().clone())
+            })
             .map_err(map_session_err)?;
 
         // Prepare environment
@@ -290,7 +335,10 @@ impl AgentServer {
         let timeout_secs = req.timeout.unwrap_or(DEFAULT_EXEC_TIMEOUT_SECS);
         let timeout = Duration::from_secs(timeout_secs);
         let start = Instant::now();
-        let max_pages = Some(self.config.max_memory_mb * 16);
+        let exec_limits = ExecLimits {
+            max_memory_pages: limits.max_memory_pages,
+            max_fuel: limits.max_fuel,
+        };
         let exec_env = wasi_env.clone();
 
         let (tx, rx) = std::sync::mpsc::channel::<std::result::Result<i32, ApiError>>();
@@ -321,6 +369,7 @@ impl AgentServer {
                 )));
             }
             let work_dir_clone = work_dir.clone();
+            let limits_clone = limits.clone();
             std::thread::Builder::new()
                 .stack_size(EXEC_THREAD_STACK_BYTES)
                 .spawn(move || {
@@ -330,7 +379,7 @@ impl AgentServer {
                         &lang,
                         exec_env,
                         &work_dir_clone,
-                        max_pages,
+                        &limits_clone,
                     );
                     let _ = tx.send(result);
                 })
@@ -341,6 +390,7 @@ impl AgentServer {
             // Validate language before spawning so callers get a 400 immediately
             executor::resolve_runtime(&lang)?;
             let work_dir_clone = work_dir.clone();
+            let limits_clone = limits.clone();
             std::thread::Builder::new()
                 .stack_size(EXEC_THREAD_STACK_BYTES)
                 .spawn(move || {
@@ -349,7 +399,7 @@ impl AgentServer {
                         &lang,
                         exec_env,
                         &work_dir_clone,
-                        max_pages,
+                        &limits_clone,
                     );
                     let _ = tx.send(result);
                 })
@@ -369,7 +419,7 @@ impl AgentServer {
                         exec_env,
                         function,
                         args,
-                        max_pages,
+                        exec_limits,
                     )
                     .map_err(|e| ApiError::Internal(e.to_string()));
                     let _ = tx.send(result);
@@ -394,6 +444,7 @@ impl AgentServer {
                     stderr: read_env_stderr(&wasi_env),
                     exit_code: -1,
                     duration_ms,
+                    output_truncated: read_env_truncated(&wasi_env),
                     error: Some(format!("Execution timed out after {timeout_secs}s")),
                 });
             }
@@ -404,6 +455,7 @@ impl AgentServer {
                     stderr: String::new(),
                     exit_code: -1,
                     duration_ms,
+                    output_truncated: false,
                     error: Some("Execution thread panicked".into()),
                 });
             }
@@ -415,6 +467,7 @@ impl AgentServer {
                 stderr: read_env_stderr(&wasi_env),
                 exit_code,
                 duration_ms,
+                output_truncated: read_env_truncated(&wasi_env),
                 error: None,
             }),
             Err(e) => Ok(ExecResponse {
@@ -422,6 +475,7 @@ impl AgentServer {
                 stderr: read_env_stderr(&wasi_env),
                 exit_code: -1,
                 duration_ms,
+                output_truncated: read_env_truncated(&wasi_env),
                 error: Some(e.to_string()),
             }),
         }
@@ -437,12 +491,19 @@ impl AgentServer {
         let req: WriteFileRequest =
             serde_json::from_str(body).map_err(|e| ApiError::BadRequest(e.to_string()))?;
 
-        let work_dir = self
+        let (work_dir, limits) = self
             .session_manager
-            .get_session(id, |s| s.work_dir().to_path_buf())
+            .get_session(id, |s| (s.work_dir().to_path_buf(), s.limits().clone()))
             .map_err(map_session_err)?;
 
         let resolved = resolve_session_path(&work_dir, &req.path)?;
+
+        // Enforce per-file size and total disk caps before writing.
+        let existing_len = std::fs::metadata(&resolved).map(|m| m.len()).unwrap_or(0);
+        limits
+            .check_write(req.content.len() as u64, existing_len, dir_size(&work_dir))
+            .map_err(ApiError::BadRequest)?;
+
         if let Some(parent) = resolved.parent() {
             std::fs::create_dir_all(parent)
                 .map_err(|e| ApiError::Internal(format!("mkdir: {e}")))?;
@@ -626,6 +687,30 @@ impl AgentServer {
 
 // ── Helpers ───────────────────────────────────────────────────────────
 
+/// Format a memory page count as a human-readable MB string for the banner.
+fn fmt_pages_mb(pages: Option<u32>) -> String {
+    match pages {
+        Some(p) => format!("{} MB / session", (p as u64 * 65536) / (1024 * 1024)),
+        None => "unlimited".to_string(),
+    }
+}
+
+/// Format an optional byte cap as a human-readable MB string for the banner.
+fn fmt_bytes_mb(bytes: Option<u64>) -> String {
+    match bytes {
+        Some(b) => format!("{} MB / session", b / (1024 * 1024)),
+        None => "unlimited".to_string(),
+    }
+}
+
+/// Format an optional numeric limit with a unit label for the banner.
+fn fmt_opt_u64(val: Option<u64>, unit: &str) -> String {
+    match val {
+        Some(v) => format!("{v} {unit}"),
+        None => "unlimited".to_string(),
+    }
+}
+
 fn map_session_err(e: SessionError) -> ApiError {
     match e {
         SessionError::NotFound { id } => ApiError::SessionNotFound(id),
@@ -719,6 +804,12 @@ fn read_env_stderr(
         .unwrap_or_default()
 }
 
+fn read_env_truncated(
+    env: &std::sync::Arc<std::sync::Mutex<crate::runtime::wasi::WasiEnv>>,
+) -> bool {
+    env.lock().map(|e| e.output_truncated()).unwrap_or(false)
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -732,10 +823,10 @@ mod tests {
                 default_timeout: Duration::from_secs(60),
                 max_sessions: 10,
                 cleanup_interval: Duration::from_secs(300),
+                limits: crate::agent::limits::ResourceLimits::default(),
             },
             allow_cors: true,
             verbose: false,
-            max_memory_mb: 256,
         })
     }
 
@@ -1410,5 +1501,175 @@ mod tests {
         assert!(names.contains(&"read_file"));
         assert!(names.contains(&"list_files"));
         assert!(names.contains(&"destroy_session"));
+    }
+
+    // ── Resource limits ───────────────────────────────────────────
+
+    /// Hand-built WASM whose `_start` is an infinite `loop { br 0 }`.
+    fn infinite_loop_wasm() -> Vec<u8> {
+        #[rustfmt::skip]
+        let wasm: Vec<u8> = vec![
+            0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+            // Type section: 1 type ()->()
+            0x01, 0x04, 0x01, 0x60, 0x00, 0x00,
+            // Function section: 1 func, type 0
+            0x03, 0x02, 0x01, 0x00,
+            // Export section: "_start" -> func 0
+            0x07, 0x0a, 0x01, 0x06, 0x5f, 0x73, 0x74, 0x61, 0x72, 0x74, 0x00, 0x00,
+            // Code section: loop; br 0; end; end
+            0x0a, 0x09, 0x01, 0x07, 0x00, 0x03, 0x40, 0x0c, 0x00, 0x0b, 0x0b,
+        ];
+        wasm
+    }
+
+    fn make_session_with_limits(server: &AgentServer, limits: ResourceLimits) -> String {
+        server
+            .session_manager
+            .create_session_with_limits(Duration::from_secs(60), limits)
+            .unwrap()
+    }
+
+    #[test]
+    fn test_create_session_with_limits_override() {
+        let server = test_server();
+        let body = r#"{"limits":{"max_fuel":500,"max_output_mb":0,"max_file_size_mb":1}}"#;
+        let id = server
+            .handle_create_session_with_body(body)
+            .unwrap()
+            .session_id;
+
+        let limits = server
+            .session_manager
+            .get_session(&id, |s| s.limits().clone())
+            .unwrap();
+        assert_eq!(limits.max_fuel, Some(500));
+        assert_eq!(limits.max_output_bytes, None); // 0 disables the cap
+        assert_eq!(limits.max_file_size, Some(1024 * 1024));
+        // Unspecified fields keep the server defaults.
+        assert_eq!(
+            limits.max_memory_pages,
+            server.config.session_config.limits.max_memory_pages
+        );
+
+        server.session_manager.destroy_all().unwrap();
+    }
+
+    #[test]
+    fn test_create_session_empty_body_uses_defaults() {
+        let server = test_server();
+        let id = server
+            .handle_create_session_with_body("")
+            .unwrap()
+            .session_id;
+        let limits = server
+            .session_manager
+            .get_session(&id, |s| s.limits().clone())
+            .unwrap();
+        assert_eq!(limits, server.config.session_config.limits);
+        server.session_manager.destroy_all().unwrap();
+    }
+
+    #[test]
+    fn test_create_session_invalid_limits_body_returns_400() {
+        let server = test_server();
+        let err = server
+            .handle_create_session_with_body(r#"{"limits": "not-an-object"}"#)
+            .unwrap_err();
+        assert_eq!(err.status_code(), 400);
+    }
+
+    #[test]
+    fn test_write_file_exceeds_file_size_limit() {
+        let server = test_server();
+        let limits = ResourceLimits {
+            max_file_size: Some(10),
+            max_disk_bytes: None,
+            ..ResourceLimits::default()
+        };
+        let id = make_session_with_limits(&server, limits);
+
+        let err = server
+            .handle_write_file(
+                &id,
+                r#"{"path": "big.txt", "content": "this is more than ten bytes"}"#,
+            )
+            .unwrap_err();
+        assert_eq!(err.status_code(), 400);
+        assert!(err.to_string().contains("File size limit"));
+
+        server.session_manager.destroy_all().unwrap();
+    }
+
+    #[test]
+    fn test_write_file_exceeds_disk_limit() {
+        let server = test_server();
+        let limits = ResourceLimits {
+            max_file_size: None,
+            max_disk_bytes: Some(10),
+            ..ResourceLimits::default()
+        };
+        let id = make_session_with_limits(&server, limits);
+
+        // First 5-byte file fits (5 <= 10).
+        server
+            .handle_write_file(&id, r#"{"path": "a.txt", "content": "12345"}"#)
+            .unwrap();
+        // Second 6-byte file pushes total to 11 > 10 → rejected.
+        let err = server
+            .handle_write_file(&id, r#"{"path": "b.txt", "content": "678901"}"#)
+            .unwrap_err();
+        assert_eq!(err.status_code(), 400);
+        assert!(err.to_string().contains("Disk usage limit"));
+
+        server.session_manager.destroy_all().unwrap();
+    }
+
+    #[test]
+    fn test_exec_command_output_truncated() {
+        let server = test_server();
+        let limits = ResourceLimits {
+            max_output_bytes: Some(3),
+            ..ResourceLimits::default()
+        };
+        let id = make_session_with_limits(&server, limits);
+
+        // "echo hello" emits "hello\n" (6 bytes); capped to 3.
+        let resp = server
+            .handle_exec(&id, r#"{"command": "echo hello"}"#)
+            .unwrap();
+        assert_eq!(resp.stdout, "hel");
+        assert!(resp.output_truncated);
+
+        server.session_manager.destroy_all().unwrap();
+    }
+
+    #[test]
+    fn test_exec_fuel_limit_aborts_runaway_wasm() {
+        let server = test_server();
+        let limits = ResourceLimits {
+            max_fuel: Some(50_000),
+            ..ResourceLimits::default()
+        };
+        let id = make_session_with_limits(&server, limits);
+
+        let work_dir = server
+            .session_manager
+            .get_session(&id, |s| s.work_dir().to_path_buf())
+            .unwrap();
+        std::fs::write(work_dir.join("loop.wasm"), infinite_loop_wasm()).unwrap();
+
+        // With a fuel cap the runaway loop aborts well before the exec timeout.
+        let resp = server
+            .handle_exec(&id, r#"{"wasm_path": "loop.wasm", "timeout": 30}"#)
+            .unwrap();
+        assert_eq!(resp.exit_code, -1);
+        let err = resp.error.unwrap_or_default();
+        assert!(
+            err.contains("instruction limit") || err.contains("fuel"),
+            "expected fuel-limit error, got: {err}"
+        );
+        assert!(resp.duration_ms < 30_000);
+
+        server.session_manager.destroy_all().unwrap();
     }
 }

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -5,6 +5,7 @@
 //! - WasiEnv (independent stdout/stderr buffers, args, env vars)
 //! - Timeout tracking (auto-cleanup on idle expiry)
 
+use crate::agent::limits::ResourceLimits;
 use crate::runtime::wasi::WasiEnv;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -79,6 +80,8 @@ pub struct Session {
     work_dir: PathBuf,
     /// Whether we own the work_dir and should delete it on drop.
     owns_work_dir: bool,
+    /// Resource ceilings applied to executions in this session.
+    limits: ResourceLimits,
 }
 
 impl Session {
@@ -86,7 +89,8 @@ impl Session {
     ///
     /// The temp directory is preopened at `/` in the WASI environment,
     /// giving the sandboxed code access to a clean, isolated filesystem.
-    pub fn new(timeout: Duration) -> Result<Self, SessionError> {
+    /// `limits` configure the session's WASI output/file-size caps.
+    pub fn new(timeout: Duration, limits: ResourceLimits) -> Result<Self, SessionError> {
         let id = generate_session_id();
         let work_dir = std::env::temp_dir().join(format!("wasmrun-session-{id}"));
 
@@ -94,7 +98,7 @@ impl Session {
             message: format!("Failed to create session directory: {e}"),
         })?;
 
-        let wasi_env = WasiEnv::new().with_preopen("/", &work_dir);
+        let wasi_env = Self::build_wasi_env(&work_dir, &limits);
 
         Ok(Session {
             id,
@@ -105,19 +109,39 @@ impl Session {
             wasi_env: Arc::new(Mutex::new(wasi_env)),
             work_dir,
             owns_work_dir: true,
+            limits,
         })
+    }
+
+    /// Build a WASI environment for the session, preopened at `/` and
+    /// configured with the session's output and per-file size caps.
+    fn build_wasi_env(work_dir: &Path, limits: &ResourceLimits) -> WasiEnv {
+        let mut wasi_env = WasiEnv::new().with_preopen("/", work_dir);
+        wasi_env.set_max_output_bytes(limits.max_output_bytes);
+        wasi_env.set_max_file_size(limits.max_file_size);
+        wasi_env
     }
 
     /// Create a session with a specific work directory (for testing).
     #[cfg(test)]
     fn with_work_dir(timeout: Duration, work_dir: PathBuf) -> Result<Self, SessionError> {
+        Self::with_work_dir_and_limits(timeout, work_dir, ResourceLimits::default())
+    }
+
+    /// Create a session with a specific work directory and limits (for testing).
+    #[cfg(test)]
+    fn with_work_dir_and_limits(
+        timeout: Duration,
+        work_dir: PathBuf,
+        limits: ResourceLimits,
+    ) -> Result<Self, SessionError> {
         let id = generate_session_id();
 
         std::fs::create_dir_all(&work_dir).map_err(|e| SessionError::IoError {
             message: format!("Failed to create session directory: {e}"),
         })?;
 
-        let wasi_env = WasiEnv::new().with_preopen("/", &work_dir);
+        let wasi_env = Self::build_wasi_env(&work_dir, &limits);
 
         Ok(Session {
             id,
@@ -128,6 +152,7 @@ impl Session {
             wasi_env: Arc::new(Mutex::new(wasi_env)),
             work_dir,
             owns_work_dir: false, // test manages cleanup
+            limits,
         })
     }
 
@@ -159,6 +184,11 @@ impl Session {
     /// Path to the session's isolated working directory.
     pub fn work_dir(&self) -> &Path {
         &self.work_dir
+    }
+
+    /// Resource ceilings applied to executions in this session.
+    pub fn limits(&self) -> &ResourceLimits {
+        &self.limits
     }
 
     /// Get a clone of the WASI environment Arc for use with the executor.
@@ -245,6 +275,8 @@ pub struct SessionConfig {
     pub max_sessions: usize,
     /// How often the cleanup thread checks for expired sessions.
     pub cleanup_interval: Duration,
+    /// Default resource ceilings applied to each new session.
+    pub limits: ResourceLimits,
 }
 
 impl Default for SessionConfig {
@@ -253,6 +285,7 @@ impl Default for SessionConfig {
             default_timeout: Duration::from_secs(300), // 5 minutes
             max_sessions: 100,
             cleanup_interval: Duration::from_secs(30),
+            limits: ResourceLimits::default(),
         }
     }
 }
@@ -283,17 +316,30 @@ impl SessionManager {
         }
     }
 
-    /// Create a new session with the default timeout.
+    /// Create a new session with the default timeout and default limits.
     ///
     /// Returns the session ID on success.
+    #[allow(dead_code)] // Used by tests; HTTP path uses create_session_with_limits.
     pub fn create_session(&self) -> Result<String, SessionError> {
-        self.create_session_with_timeout(self.config.default_timeout)
+        self.create_session_with_limits(self.config.default_timeout, self.config.limits.clone())
     }
 
-    /// Create a new session with a custom timeout.
+    /// Create a new session with a custom timeout and the default limits.
     ///
     /// Returns the session ID on success.
+    #[allow(dead_code)] // Used by tests; HTTP path uses create_session_with_limits.
     pub fn create_session_with_timeout(&self, timeout: Duration) -> Result<String, SessionError> {
+        self.create_session_with_limits(timeout, self.config.limits.clone())
+    }
+
+    /// Create a new session with a custom timeout and resource limits.
+    ///
+    /// Returns the session ID on success.
+    pub fn create_session_with_limits(
+        &self,
+        timeout: Duration,
+        limits: ResourceLimits,
+    ) -> Result<String, SessionError> {
         let mut sessions = self.sessions.write().map_err(|_| SessionError::LockError)?;
 
         // Enforce max sessions limit (after removing expired ones)
@@ -304,7 +350,7 @@ impl SessionManager {
             });
         }
 
-        let session = Session::new(timeout)?;
+        let session = Session::new(timeout, limits)?;
         let id = session.id().to_string();
         sessions.insert(id.clone(), session);
         Ok(id)
@@ -498,6 +544,7 @@ mod tests {
             default_timeout: Duration::from_secs(60),
             max_sessions: 10,
             cleanup_interval: Duration::from_millis(100),
+            limits: ResourceLimits::default(),
         }
     }
 
@@ -540,10 +587,7 @@ mod tests {
         // Write to s1's stdout, s2 should be unaffected
         {
             let env1 = s1.wasi_env();
-            env1.lock()
-                .unwrap()
-                .stdout_mut()
-                .extend_from_slice(b"hello from s1");
+            env1.lock().unwrap().write_stdout(b"hello from s1");
         }
 
         assert_eq!(s1.get_stdout(), b"hello from s1");
@@ -587,8 +631,8 @@ mod tests {
         {
             let env = session.wasi_env();
             let mut locked = env.lock().unwrap();
-            locked.stdout_mut().extend_from_slice(b"output");
-            locked.stderr_mut().extend_from_slice(b"error");
+            locked.write_stdout(b"output");
+            locked.write_stderr(b"error");
         }
 
         assert!(!session.get_stdout().is_empty());
@@ -983,6 +1027,7 @@ mod tests {
             default_timeout: Duration::from_millis(50),
             cleanup_interval: Duration::from_millis(50),
             max_sessions: 10,
+            limits: ResourceLimits::default(),
         };
         let manager = Arc::new(SessionManager::with_config(config));
 

--- a/src/agent/shell.rs
+++ b/src/agent/shell.rs
@@ -466,13 +466,13 @@ impl Shell {
 
     fn append_stdout_bytes(&self, bytes: &[u8]) {
         if let Ok(mut env) = self.wasi_env.lock() {
-            env.stdout_mut().extend_from_slice(bytes);
+            env.write_stdout(bytes);
         }
     }
 
     fn append_stderr_bytes(&self, bytes: &[u8]) {
         if let Ok(mut env) = self.wasi_env.lock() {
-            env.stderr_mut().extend_from_slice(bytes);
+            env.write_stderr(bytes);
         }
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -300,13 +300,45 @@ pub enum Commands {
         )]
         max_sessions: usize,
 
-        /// Memory limit per session in MB (default: 256)
+        /// Memory limit per session in MB (default: 256, 0 = unlimited)
         #[arg(
             long,
             default_value_t = 256,
-            help = "Maximum linear memory per session (MB)"
+            help = "Maximum linear memory per session in MB (0 = unlimited)"
         )]
         max_memory: u32,
+
+        /// Instruction budget ("fuel") per execution (default: 0 = unlimited)
+        #[arg(
+            long,
+            default_value_t = 0,
+            help = "Maximum WASM instructions per execution (0 = unlimited)"
+        )]
+        max_fuel: u64,
+
+        /// Captured output cap per execution in MB (default: 10, 0 = unlimited)
+        #[arg(
+            long,
+            default_value_t = 10,
+            help = "Maximum captured stdout+stderr per execution in MB (0 = unlimited)"
+        )]
+        max_output: u32,
+
+        /// Per-file write size cap in MB (default: 50, 0 = unlimited)
+        #[arg(
+            long,
+            default_value_t = 50,
+            help = "Maximum size of any single file in MB (0 = unlimited)"
+        )]
+        max_file_size: u32,
+
+        /// Total disk usage cap per session in MB (default: 100, 0 = unlimited)
+        #[arg(
+            long,
+            default_value_t = 100,
+            help = "Maximum total disk usage per session in MB (0 = unlimited)"
+        )]
+        max_disk: u32,
 
         /// Allow wildcard CORS (Access-Control-Allow-Origin: *)
         #[arg(long, help = "Allow cross-origin requests from any domain")]

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -1,28 +1,37 @@
 //! Agent mode: CLI command handler for `wasmrun agent`.
 
+use crate::agent::limits::ResourceLimits;
 use crate::agent::server::{AgentConfig, AgentServer};
 use crate::agent::session::SessionConfig;
 use crate::error::Result;
 use std::time::Duration;
 
+#[allow(clippy::too_many_arguments)]
 pub fn handle_agent_command(
     port: u16,
     timeout: u64,
     max_sessions: usize,
     max_memory: u32,
+    max_fuel: u64,
+    max_output: u32,
+    max_file_size: u32,
+    max_disk: u32,
     allow_cors: bool,
     verbose: bool,
 ) -> Result<()> {
+    let limits =
+        ResourceLimits::from_cli(max_memory, max_fuel, max_output, max_file_size, max_disk);
+
     let config = AgentConfig {
         port,
         session_config: SessionConfig {
             default_timeout: Duration::from_secs(timeout),
             max_sessions,
             cleanup_interval: Duration::from_secs(30),
+            limits,
         },
         allow_cors,
         verbose,
-        max_memory_mb: max_memory,
     };
 
     let server = AgentServer::new(config);

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,21 +180,33 @@ fn main() {
             timeout,
             max_sessions,
             max_memory,
+            max_fuel,
+            max_output,
+            max_file_size,
+            max_disk,
             allow_cors,
             verbose,
         }) => {
             debug_println!(
-                "Processing agent command: port={}, timeout={}, max_sessions={}, max_memory={}MB",
+                "Processing agent command: port={}, timeout={}, max_sessions={}, max_memory={}MB, max_fuel={}, max_output={}MB, max_file_size={}MB, max_disk={}MB",
                 port,
                 timeout,
                 max_sessions,
-                max_memory
+                max_memory,
+                max_fuel,
+                max_output,
+                max_file_size,
+                max_disk
             );
             commands::handle_agent_command(
                 *port,
                 *timeout,
                 *max_sessions,
                 *max_memory,
+                *max_fuel,
+                *max_output,
+                *max_file_size,
+                *max_disk,
                 *allow_cors,
                 *verbose,
             )

--- a/src/runtime/core/executor.rs
+++ b/src/runtime/core/executor.rs
@@ -9,6 +9,10 @@ use std::io::Cursor;
 /// Sentinel prefix for proc_exit errors so callers can extract the exit code.
 pub const WASI_PROC_EXIT_PREFIX: &str = "__wasi_proc_exit:";
 
+/// Sentinel error returned when an execution exhausts its instruction budget
+/// ("fuel"). Callers can detect this to surface a clear resource-limit error.
+pub const FUEL_EXHAUSTED_ERROR: &str = "__wasmrun_fuel_exhausted__";
+
 /// Result of instruction dispatch for control flow signaling
 #[derive(Debug, Clone, PartialEq)]
 enum ControlFlow {
@@ -969,6 +973,10 @@ pub struct Executor {
     /// Flat function table initialized from element segments.
     /// Index = table slot, value = absolute function index (or None if unset).
     table: Vec<Option<u32>>,
+    /// Remaining instruction budget ("fuel"). `None` = unlimited. When `Some`,
+    /// each dispatched instruction decrements it; reaching zero aborts
+    /// execution with `FUEL_EXHAUSTED_ERROR`.
+    fuel: Option<u64>,
 }
 
 impl Executor {
@@ -1059,7 +1067,21 @@ impl Executor {
             linker,
             import_func_count,
             table,
+            fuel: None,
         })
+    }
+
+    /// Set the instruction budget ("fuel") for subsequent executions.
+    ///
+    /// `Some(n)` aborts execution after `n` instructions with
+    /// `FUEL_EXHAUSTED_ERROR`; `None` (the default) runs without a fuel cap.
+    pub fn set_fuel(&mut self, fuel: Option<u64>) {
+        self.fuel = fuel;
+    }
+
+    /// Check whether an error string indicates fuel exhaustion.
+    pub fn is_fuel_exhausted(err: &str) -> bool {
+        err.contains(FUEL_EXHAUSTED_ERROR)
     }
 
     /// Execute a function by index and return its results
@@ -1161,6 +1183,17 @@ impl Executor {
         loop {
             if cursor.position() >= cursor.get_ref().len() as u64 {
                 break;
+            }
+
+            // Charge one unit of fuel per instruction. `fuel` is shared across
+            // nested calls (each runs its own execute_bytecode against the same
+            // executor), so this bounds total instructions across the whole call
+            // tree, not just the current function body.
+            if let Some(remaining) = self.fuel.as_mut() {
+                if *remaining == 0 {
+                    return Err(FUEL_EXHAUSTED_ERROR.to_string());
+                }
+                *remaining -= 1;
             }
 
             let instr = decode_instruction(cursor)?;
@@ -3285,7 +3318,75 @@ impl Executor {
 
 #[cfg(test)]
 mod tests {
+    use super::super::module::{Function, FunctionType};
     use super::*;
+    use std::collections::HashMap;
+
+    /// Build a module whose only function is an infinite `loop { br 0 }`.
+    fn infinite_loop_module() -> Module {
+        Module {
+            version: 1,
+            types: vec![FunctionType {
+                params: vec![],
+                results: vec![],
+            }],
+            imports: vec![],
+            functions: vec![Function {
+                type_index: 0,
+                locals: vec![],
+                // loop (empty type); br 0; end (loop); end (func)
+                code: vec![0x03, 0x40, 0x0c, 0x00, 0x0b, 0x0b],
+            }],
+            tables: vec![],
+            memory: None,
+            globals: vec![],
+            exports: HashMap::new(),
+            start: None,
+            elements: vec![],
+            data: vec![],
+        }
+    }
+
+    #[test]
+    fn test_fuel_aborts_infinite_loop() {
+        let mut executor = Executor::new(infinite_loop_module()).unwrap();
+        executor.set_fuel(Some(1000));
+        let err = executor
+            .execute_with_args(0, vec![])
+            .expect_err("infinite loop should exhaust fuel");
+        assert!(
+            Executor::is_fuel_exhausted(&err),
+            "expected fuel-exhausted error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_no_fuel_cap_does_not_abort_finite_program() {
+        // A function that simply returns; with no fuel cap it completes.
+        let module = Module {
+            version: 1,
+            types: vec![FunctionType {
+                params: vec![],
+                results: vec![],
+            }],
+            imports: vec![],
+            functions: vec![Function {
+                type_index: 0,
+                locals: vec![],
+                code: vec![0x0b], // end
+            }],
+            tables: vec![],
+            memory: None,
+            globals: vec![],
+            exports: HashMap::new(),
+            start: None,
+            elements: vec![],
+            data: vec![],
+        };
+        let mut executor = Executor::new(module).unwrap();
+        executor.set_fuel(None);
+        assert!(executor.execute_with_args(0, vec![]).is_ok());
+    }
 
     #[test]
     fn test_frame_local_access() {

--- a/src/runtime/core/native_executor.rs
+++ b/src/runtime/core/native_executor.rs
@@ -8,6 +8,18 @@ use std::fs;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
+/// Resource ceilings applied to a single WASM execution.
+///
+/// Kept primitive (no dependency on the `agent` layer) so the core runtime
+/// stays self-contained. `None` fields mean "no cap" for that dimension.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ExecLimits {
+    /// Cap on linear memory growth, in WASM pages (64 KiB each).
+    pub max_memory_pages: Option<u32>,
+    /// Instruction budget; execution aborts once exhausted.
+    pub max_fuel: Option<u64>,
+}
+
 pub fn execute_wasm_file(wasm_path: &str) -> Result<i32> {
     if !Path::new(wasm_path).exists() {
         return Err(WasmrunError::from(format!(
@@ -127,12 +139,12 @@ pub fn execute_wasm_bytes_with_env(
     wasi_env: Arc<Mutex<WasiEnv>>,
     function: Option<String>,
     args: Vec<String>,
-    max_memory_pages: Option<u32>,
+    limits: ExecLimits,
 ) -> Result<i32> {
     let mut module = Module::parse(wasm_bytes)
         .map_err(|e| WasmrunError::from(format!("Failed to parse WASM module: {e}")))?;
 
-    if let Some(cap) = max_memory_pages {
+    if let Some(cap) = limits.max_memory_pages {
         if let Some(ref mut mem) = module.memory {
             match mem.max {
                 Some(m) if m > cap => mem.max = Some(cap),
@@ -150,6 +162,7 @@ pub fn execute_wasm_bytes_with_env(
 
     let mut executor = Executor::new_with_linker(module, wasi_linker)
         .map_err(|e| WasmrunError::from(format!("Failed to initialize executor: {e}")))?;
+    executor.set_fuel(limits.max_fuel);
 
     let func_idx = if let Some(func_name) = function {
         find_export_function(executor.module(), &func_name)
@@ -181,6 +194,11 @@ pub fn execute_wasm_bytes_with_env(
         Err(e) => {
             if let Some(code) = extract_proc_exit(&e) {
                 Ok(code)
+            } else if Executor::is_fuel_exhausted(&e.to_string()) {
+                Err(WasmrunError::from(format!(
+                    "Execution exceeded the instruction limit (fuel) of {} instructions",
+                    limits.max_fuel.unwrap_or(0)
+                )))
             } else {
                 Err(e)
             }
@@ -476,7 +494,7 @@ mod tests {
         ];
 
         let env = Arc::new(Mutex::new(WasiEnv::new()));
-        let result = execute_wasm_bytes_with_env(&wasm, env, None, vec![], None);
+        let result = execute_wasm_bytes_with_env(&wasm, env, None, vec![], ExecLimits::default());
         assert_eq!(
             result.unwrap(),
             42,
@@ -514,7 +532,7 @@ mod tests {
         ];
 
         let env = Arc::new(Mutex::new(WasiEnv::new()));
-        let result = execute_wasm_bytes_with_env(&wasm, env, None, vec![], None);
+        let result = execute_wasm_bytes_with_env(&wasm, env, None, vec![], ExecLimits::default());
         assert_eq!(
             result.unwrap(),
             0,

--- a/src/runtime/wasi/mod.rs
+++ b/src/runtime/wasi/mod.rs
@@ -46,6 +46,13 @@ pub struct WasiEnv {
     next_fd: u32,
     #[allow(dead_code)]
     preopens: Vec<(String, PathBuf)>,
+    /// Cap on combined stdout + stderr bytes captured. `None` = unlimited.
+    max_output_bytes: Option<usize>,
+    /// Set once captured output is dropped because the cap was reached.
+    output_truncated: bool,
+    /// Cap on the size of any single file written via WASI `fd_write`.
+    /// `None` = unlimited. Enforced in the syscall layer.
+    max_file_size: Option<u64>,
 }
 
 impl WasiEnv {
@@ -90,6 +97,9 @@ impl WasiEnv {
             fd_table,
             next_fd: WASI_FIRST_PREOPEN_FD,
             preopens: Vec::new(),
+            max_output_bytes: None,
+            output_truncated: false,
+            max_file_size: None,
         }
     }
 
@@ -142,12 +152,61 @@ impl WasiEnv {
         self.stderr.clone()
     }
 
-    pub fn stdout_mut(&mut self) -> &mut Vec<u8> {
-        &mut self.stdout
+    /// Configure the combined stdout + stderr capture cap (`None` = unlimited).
+    pub fn set_max_output_bytes(&mut self, max: Option<usize>) {
+        self.max_output_bytes = max;
     }
 
-    pub fn stderr_mut(&mut self) -> &mut Vec<u8> {
-        &mut self.stderr
+    /// Configure the per-file write size cap (`None` = unlimited).
+    pub fn set_max_file_size(&mut self, max: Option<u64>) {
+        self.max_file_size = max;
+    }
+
+    /// The per-file write size cap, if any.
+    pub fn max_file_size(&self) -> Option<u64> {
+        self.max_file_size
+    }
+
+    /// Whether captured output was dropped because the output cap was reached.
+    pub fn output_truncated(&self) -> bool {
+        self.output_truncated
+    }
+
+    /// Append `bytes` to the stdout buffer, honoring the output cap.
+    pub fn write_stdout(&mut self, bytes: &[u8]) {
+        self.append_capped(true, bytes);
+    }
+
+    /// Append `bytes` to the stderr buffer, honoring the output cap.
+    pub fn write_stderr(&mut self, bytes: &[u8]) {
+        self.append_capped(false, bytes);
+    }
+
+    /// Append to stdout or stderr, never letting the combined buffers exceed
+    /// `max_output_bytes`. Excess is dropped and `output_truncated` is set.
+    fn append_capped(&mut self, to_stdout: bool, bytes: &[u8]) {
+        let slice = match self.max_output_bytes {
+            Some(max) => {
+                let used = self.stdout.len() + self.stderr.len();
+                if used >= max {
+                    self.output_truncated = true;
+                    return;
+                }
+                let room = max - used;
+                if bytes.len() > room {
+                    self.output_truncated = true;
+                    &bytes[..room]
+                } else {
+                    bytes
+                }
+            }
+            None => bytes,
+        };
+        if to_stdout {
+            self.stdout.extend_from_slice(slice);
+        } else {
+            self.stderr.extend_from_slice(slice);
+        }
     }
 
     /// Add an environment variable (appends to existing list).
@@ -163,11 +222,13 @@ impl WasiEnv {
     /// Clear captured stdout buffer.
     pub fn clear_stdout(&mut self) {
         self.stdout.clear();
+        self.output_truncated = false;
     }
 
     /// Clear captured stderr buffer.
     pub fn clear_stderr(&mut self) {
         self.stderr.clear();
+        self.output_truncated = false;
     }
 
     pub fn get_fd(&self, fd: u32) -> Option<&FdEntry> {
@@ -946,6 +1007,46 @@ mod tests {
         let fd_entry = env.get_fd(WASI_FIRST_PREOPEN_FD).unwrap();
         assert_eq!(fd_entry.kind, FdKind::PreopenDir);
         assert_eq!(fd_entry.guest_path, "/sandbox");
+    }
+
+    #[test]
+    fn test_output_cap_truncates_stdout() {
+        let mut env = WasiEnv::new();
+        env.set_max_output_bytes(Some(5));
+        env.write_stdout(b"abc");
+        assert!(!env.output_truncated());
+        env.write_stdout(b"defgh"); // only "de" fits (5 total)
+        assert_eq!(env.get_stdout(), b"abcde");
+        assert!(env.output_truncated());
+    }
+
+    #[test]
+    fn test_output_cap_is_combined_across_streams() {
+        let mut env = WasiEnv::new();
+        env.set_max_output_bytes(Some(4));
+        env.write_stdout(b"ab");
+        env.write_stderr(b"cdef"); // only "cd" fits
+        assert_eq!(env.get_stdout(), b"ab");
+        assert_eq!(env.get_stderr(), b"cd");
+        assert!(env.output_truncated());
+    }
+
+    #[test]
+    fn test_output_cap_unlimited_by_default() {
+        let mut env = WasiEnv::new();
+        env.write_stdout(&vec![b'x'; 100_000]);
+        assert_eq!(env.get_stdout().len(), 100_000);
+        assert!(!env.output_truncated());
+    }
+
+    #[test]
+    fn test_clear_resets_truncation_flag() {
+        let mut env = WasiEnv::new();
+        env.set_max_output_bytes(Some(2));
+        env.write_stdout(b"toolong");
+        assert!(env.output_truncated());
+        env.clear_stdout();
+        assert!(!env.output_truncated());
     }
 
     #[test]

--- a/src/runtime/wasi/syscalls.rs
+++ b/src/runtime/wasi/syscalls.rs
@@ -9,6 +9,7 @@ use super::{FdKind, WasiEnv, WASI_STDERR_FD, WASI_STDIN_FD, WASI_STDOUT_FD};
 pub const WASI_ESUCCESS: i32 = 0;
 pub const WASI_EBADF: i32 = 8;
 pub const WASI_EEXIST: i32 = 20;
+pub const WASI_EFBIG: i32 = 27;
 pub const WASI_EINVAL: i32 = 28;
 pub const WASI_EIO: i32 = 29;
 pub const WASI_EISDIR: i32 = 31;
@@ -98,14 +99,14 @@ pub fn fd_write(
         match fd {
             WASI_STDOUT_FD => {
                 if let Ok(mut e) = env.lock() {
-                    e.stdout_mut().extend_from_slice(&bytes);
+                    e.write_stdout(&bytes);
                 }
             }
             WASI_STDERR_FD => {
                 // Pass stderr through immediately so error messages are visible
                 eprint!("{}", String::from_utf8_lossy(&bytes));
                 if let Ok(mut e) = env.lock() {
-                    e.stderr_mut().extend_from_slice(&bytes);
+                    e.write_stderr(&bytes);
                 }
             }
             _ => {
@@ -113,6 +114,7 @@ pub fn fd_write(
                     Ok(e) => e,
                     Err(_) => return WASI_EIO,
                 };
+                let max_file_size = e.max_file_size();
                 let (host_path, offset) = match e.get_fd(fd) {
                     Some(entry) if entry.kind == FdKind::File => {
                         (entry.host_path.clone(), entry.offset)
@@ -120,6 +122,15 @@ pub fn fd_write(
                     Some(_) => return WASI_EISDIR,
                     None => return WASI_EBADF,
                 };
+                // Enforce the per-file size cap: the file's resulting size is the
+                // larger of its current size and the end of this write.
+                if let Some(max) = max_file_size {
+                    let existing = std::fs::metadata(&host_path).map(|m| m.len()).unwrap_or(0);
+                    let projected = existing.max(offset + bytes.len() as u64);
+                    if projected > max {
+                        return WASI_EFBIG;
+                    }
+                }
                 match write_file_at(&host_path, offset, &bytes) {
                     Ok(n) => {
                         if let Some(fe) = e.get_fd_mut(fd) {
@@ -1300,5 +1311,33 @@ mod tests {
         assert_eq!(errno, WASI_ESUCCESS);
         assert_eq!(mem.read_i32(500).unwrap(), 5); // "56789"
         assert_eq!(&mem.read_bytes(400, 5).unwrap(), b"56789");
+    }
+
+    #[test]
+    fn test_fd_write_file_size_limit() {
+        let tmp = tempfile::tempdir().unwrap();
+        let env = Arc::new(Mutex::new(WasiEnv::new().with_preopen("/", tmp.path())));
+        env.lock().unwrap().set_max_file_size(Some(4));
+        let mut mem = LinearMemory::new(1, None).unwrap();
+
+        // Open a file for writing
+        mem.write_bytes(100, b"big.txt").unwrap();
+        let errno = path_open(3, 100, 7, WASI_O_CREAT, 0, 200, &mut mem, &env);
+        assert_eq!(errno, WASI_ESUCCESS);
+        let fd = mem.read_i32(200).unwrap() as u32;
+
+        // A 5-byte write exceeds the 4-byte cap → EFBIG
+        mem.write_bytes(400, b"hello").unwrap();
+        mem.write_i32(0, 400).unwrap(); // iovec buf_ptr
+        mem.write_i32(4, 5).unwrap(); // iovec buf_len
+        let errno = fd_write(fd, 0, 1, 300, &mut mem, &env);
+        assert_eq!(errno, WASI_EFBIG);
+
+        // A 4-byte write is allowed
+        mem.write_bytes(400, b"okay").unwrap();
+        mem.write_i32(4, 4).unwrap();
+        let errno = fd_write(fd, 0, 1, 300, &mut mem, &env);
+        assert_eq!(errno, WASI_ESUCCESS);
+        assert_eq!(std::fs::read(tmp.path().join("big.txt")).unwrap(), b"okay");
     }
 }


### PR DESCRIPTION
Sandbox sessions were unbounded: a runaway program could loop forever, flood stdout, or fill the disk, and only a wall-clock thread timeout loosely guarded execution (the thread kept burning CPU after the HTTP response returned). Add configurable ceilings for every resource dimension, enforced at the layer that owns each one.

A new `ResourceLimits` struct (`src/agent/limits.rs`) is the single source of truth: memory pages, fuel, output bytes, file size, and disk bytes. `None` (or `0` from the CLI/override) means unlimited.

- Memory: module `memory.max` is capped before execution; growth past it is rejected.
- Fuel: the executor now decrements an instruction budget per dispatched op (shared across the whole nested-call tree) and aborts when exhausted. This is the hard execution guard the timeout could not provide.
- Output: `WasiEnv` caps combined stdout+stderr and reports truncation; `fd_write` and the shell write through the capped path.
- File size: `fd_write` returns EFBIG and the agent write paths reject oversized files.
- Disk: the session directory footprint is checked before each agent-side write.

Operators configure limits via new `wasmrun agent` flags, each taking 0 to disable:

    wasmrun agent --max-memory 256 --max-fuel 5000000 \
                  --max-output 10 --max-file-size 50 --max-disk 100

A client may override any subset per session in the POST /sessions body (absent fields inherit the server defaults):

    POST /api/v1/sessions
    {"limits": {"max_fuel": 5000000, "max_file_size_mb": 1}}

Fuel defaults to unlimited (opt-in): language runtimes such as QuickJS need a very large, workload-dependent instruction budget, so a default cap would break real JS execution. The wall-clock timeout remains the default time guard. Other defaults: memory 256 MB, output 10 MB, file 50 MB, disk 100 MB.