### PR TITLE
fix(agent): halt runaway execution on exec timeout

### DIFF
--- a/src/agent/executor.rs
+++ b/src/agent/executor.rs
@@ -10,6 +10,7 @@ use crate::runtime::runtime_cache::{wasmhub_language, RuntimeCache};
 use crate::runtime::wasi::WasiEnv;
 use std::collections::HashMap;
 use std::path::{Component, Path};
+use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
 
 const JS_SCRIPT_NAME: &str = "_run_.js";
@@ -36,6 +37,7 @@ pub fn execute_source(
     wasi_env: Arc<Mutex<WasiEnv>>,
     work_dir: &Path,
     limits: &ResourceLimits,
+    cancel: Option<Arc<AtomicBool>>,
 ) -> std::result::Result<i32, ApiError> {
     let runtime_name = resolve_runtime(language)?;
 
@@ -54,8 +56,15 @@ pub fn execute_source(
         "run".to_string(),
         JS_SCRIPT_NAME.to_string(),
     ];
-    execute_wasm_bytes_with_env(&wasm_bytes, wasi_env, None, args, exec_limits(limits))
-        .map_err(|e| ApiError::Internal(e.to_string()))
+    execute_wasm_bytes_with_env(
+        &wasm_bytes,
+        wasi_env,
+        None,
+        args,
+        exec_limits(limits),
+        cancel,
+    )
+    .map_err(|e| ApiError::Internal(e.to_string()))
 }
 
 /// Execute a multi-file source project in a session sandbox.
@@ -71,6 +80,7 @@ pub fn execute_source_project(
     wasi_env: Arc<Mutex<WasiEnv>>,
     work_dir: &Path,
     limits: &ResourceLimits,
+    cancel: Option<Arc<AtomicBool>>,
 ) -> std::result::Result<i32, ApiError> {
     let runtime_name = resolve_runtime(language)?;
 
@@ -107,6 +117,7 @@ pub fn execute_source_project(
         None,
         args,
         exec_limits(limits),
+        cancel,
     )
     .map_err(|e| ApiError::Internal(e.to_string()))
 }
@@ -254,6 +265,7 @@ mod tests {
             env,
             &tmp,
             &ResourceLimits::default(),
+            None,
         )
         .unwrap_err();
         assert_eq!(err.status_code(), 400);
@@ -273,6 +285,7 @@ mod tests {
             env,
             &tmp,
             &ResourceLimits::default(),
+            None,
         )
         .unwrap_err();
         assert_eq!(err.status_code(), 400);
@@ -292,6 +305,7 @@ mod tests {
             env,
             &tmp,
             &ResourceLimits::default(),
+            None,
         )
         .unwrap_err();
         assert_eq!(err.status_code(), 400);
@@ -323,6 +337,7 @@ mod tests {
             env,
             &tmp,
             &ResourceLimits::default(),
+            None,
         )
         .unwrap_err();
         assert_eq!(err.status_code(), 400);

--- a/src/agent/server.rs
+++ b/src/agent/server.rs
@@ -12,6 +12,7 @@ use serde::Serialize;
 use std::collections::HashMap;
 use std::io::Read;
 use std::path::{Component, Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tiny_http::{Header, Method, Request, Response, Server, StatusCode};
@@ -342,6 +343,10 @@ impl AgentServer {
         let exec_env = wasi_env.clone();
 
         let (tx, rx) = std::sync::mpsc::channel::<std::result::Result<i32, ApiError>>();
+        // Cooperative cancellation: the worker runs detached, so if the
+        // wall-clock timeout fires we trip this flag to make the (possibly
+        // unlimited-fuel) interpreter self-terminate instead of running on.
+        let cancel = Arc::new(AtomicBool::new(false));
 
         if let Some(command) = req.command {
             // Built-in shell emulation: parse and run the command line
@@ -370,6 +375,7 @@ impl AgentServer {
             }
             let work_dir_clone = work_dir.clone();
             let limits_clone = limits.clone();
+            let cancel_worker = cancel.clone();
             std::thread::Builder::new()
                 .stack_size(EXEC_THREAD_STACK_BYTES)
                 .spawn(move || {
@@ -380,6 +386,7 @@ impl AgentServer {
                         exec_env,
                         &work_dir_clone,
                         &limits_clone,
+                        Some(cancel_worker),
                     );
                     let _ = tx.send(result);
                 })
@@ -391,6 +398,7 @@ impl AgentServer {
             executor::resolve_runtime(&lang)?;
             let work_dir_clone = work_dir.clone();
             let limits_clone = limits.clone();
+            let cancel_worker = cancel.clone();
             std::thread::Builder::new()
                 .stack_size(EXEC_THREAD_STACK_BYTES)
                 .spawn(move || {
@@ -400,6 +408,7 @@ impl AgentServer {
                         exec_env,
                         &work_dir_clone,
                         &limits_clone,
+                        Some(cancel_worker),
                     );
                     let _ = tx.send(result);
                 })
@@ -411,6 +420,7 @@ impl AgentServer {
                 .map_err(|e| ApiError::NotFound(format!("{}: {e}", resolved.display())))?;
             let function = req.function.clone();
             let args = req.args.clone();
+            let cancel_worker = cancel.clone();
             std::thread::Builder::new()
                 .stack_size(EXEC_THREAD_STACK_BYTES)
                 .spawn(move || {
@@ -420,6 +430,7 @@ impl AgentServer {
                         function,
                         args,
                         exec_limits,
+                        Some(cancel_worker),
                     )
                     .map_err(|e| ApiError::Internal(e.to_string()));
                     let _ = tx.send(result);
@@ -438,6 +449,10 @@ impl AgentServer {
                 result
             }
             Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                // Trip the cancel flag so the detached worker stops executing
+                // instructions instead of running on past the timeout. (No-op
+                // for the shell path, which isn't a long-running interpreter.)
+                cancel.store(true, Ordering::Relaxed);
                 duration_ms = start.elapsed().as_millis() as u64;
                 return Ok(ExecResponse {
                     stdout: read_env_stdout(&wasi_env),
@@ -1669,6 +1684,47 @@ mod tests {
             "expected fuel-limit error, got: {err}"
         );
         assert!(resp.duration_ms < 30_000);
+
+        server.session_manager.destroy_all().unwrap();
+    }
+
+    #[test]
+    fn test_exec_timeout_cancels_runaway_wasm_without_fuel() {
+        // No fuel cap → only the wall-clock timeout can stop the loop. The
+        // worker must self-terminate via the cancel flag, freeing the session
+        // so a follow-up exec still completes promptly.
+        let server = test_server();
+        let limits = ResourceLimits {
+            max_fuel: None,
+            ..ResourceLimits::default()
+        };
+        let id = make_session_with_limits(&server, limits);
+
+        let work_dir = server
+            .session_manager
+            .get_session(&id, |s| s.work_dir().to_path_buf())
+            .unwrap();
+        std::fs::write(work_dir.join("loop.wasm"), infinite_loop_wasm()).unwrap();
+        std::fs::write(work_dir.join("hello.wasm"), hello_wasm()).unwrap();
+
+        let resp = server
+            .handle_exec(&id, r#"{"wasm_path": "loop.wasm", "timeout": 1}"#)
+            .unwrap();
+        assert_eq!(resp.exit_code, -1);
+        assert!(
+            resp.error.unwrap_or_default().contains("timed out"),
+            "expected a timeout error"
+        );
+        // ~1s timeout, well under any runaway ceiling.
+        assert!(resp.duration_ms < 5_000);
+
+        // The session is still usable: a normal exec runs and returns promptly,
+        // which it could not if the runaway worker were still pinning the core.
+        let ok = server
+            .handle_exec(&id, r#"{"wasm_path": "hello.wasm", "timeout": 10}"#)
+            .unwrap();
+        assert_eq!(ok.stdout, "Hello, World!\n");
+        assert_eq!(ok.exit_code, 0);
 
         server.session_manager.destroy_all().unwrap();
     }

--- a/src/runtime/core/executor.rs
+++ b/src/runtime/core/executor.rs
@@ -5,6 +5,8 @@ use super::memory::LinearMemory;
 use super::module::{ImportKind, Module, ValueType};
 use super::values::Value;
 use std::io::Cursor;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
 /// Sentinel prefix for proc_exit errors so callers can extract the exit code.
 pub const WASI_PROC_EXIT_PREFIX: &str = "__wasi_proc_exit:";
@@ -12,6 +14,11 @@ pub const WASI_PROC_EXIT_PREFIX: &str = "__wasi_proc_exit:";
 /// Sentinel error returned when an execution exhausts its instruction budget
 /// ("fuel"). Callers can detect this to surface a clear resource-limit error.
 pub const FUEL_EXHAUSTED_ERROR: &str = "__wasmrun_fuel_exhausted__";
+
+/// Sentinel error returned when an execution is cancelled via its cancel token
+/// (e.g. the agent server tripping it on wall-clock timeout). Callers detect
+/// this to distinguish a deliberate halt from a program error.
+pub const EXECUTION_CANCELLED_ERROR: &str = "__wasmrun_execution_cancelled__";
 
 /// Result of instruction dispatch for control flow signaling
 #[derive(Debug, Clone, PartialEq)]
@@ -977,6 +984,11 @@ pub struct Executor {
     /// each dispatched instruction decrements it; reaching zero aborts
     /// execution with `FUEL_EXHAUSTED_ERROR`.
     fuel: Option<u64>,
+    /// Cooperative cancellation flag. When set and flipped to `true`, the
+    /// instruction loop aborts with `EXECUTION_CANCELLED_ERROR` at the next
+    /// check. `None` = not cancellable. Shared (`Arc`) so an outside thread —
+    /// e.g. the agent server on wall-clock timeout — can trip it while we run.
+    cancel: Option<Arc<AtomicBool>>,
 }
 
 impl Executor {
@@ -1068,6 +1080,7 @@ impl Executor {
             import_func_count,
             table,
             fuel: None,
+            cancel: None,
         })
     }
 
@@ -1082,6 +1095,20 @@ impl Executor {
     /// Check whether an error string indicates fuel exhaustion.
     pub fn is_fuel_exhausted(err: &str) -> bool {
         err.contains(FUEL_EXHAUSTED_ERROR)
+    }
+
+    /// Install a cancellation token checked during execution.
+    ///
+    /// When the shared flag is flipped to `true`, the instruction loop aborts
+    /// with `EXECUTION_CANCELLED_ERROR` at the next check. `None` disables
+    /// cancellation (the default).
+    pub fn set_cancel_token(&mut self, token: Option<Arc<AtomicBool>>) {
+        self.cancel = token;
+    }
+
+    /// Check whether an error string indicates a cancelled execution.
+    pub fn is_cancelled(err: &str) -> bool {
+        err.contains(EXECUTION_CANCELLED_ERROR)
     }
 
     /// Execute a function by index and return its results
@@ -1194,6 +1221,16 @@ impl Executor {
                     return Err(FUEL_EXHAUSTED_ERROR.to_string());
                 }
                 *remaining -= 1;
+            }
+
+            // Cooperative cancellation: an outside thread (e.g. the agent
+            // server on wall-clock timeout) can trip this flag to halt a
+            // runaway execution that fuel alone wouldn't stop. The Relaxed
+            // atomic load is negligible next to instruction decode/dispatch.
+            if let Some(flag) = self.cancel.as_ref() {
+                if flag.load(Ordering::Relaxed) {
+                    return Err(EXECUTION_CANCELLED_ERROR.to_string());
+                }
             }
 
             let instr = decode_instruction(cursor)?;
@@ -3321,6 +3358,8 @@ mod tests {
     use super::super::module::{Function, FunctionType};
     use super::*;
     use std::collections::HashMap;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
 
     /// Build a module whose only function is an infinite `loop { br 0 }`.
     fn infinite_loop_module() -> Module {
@@ -3385,6 +3424,70 @@ mod tests {
         };
         let mut executor = Executor::new(module).unwrap();
         executor.set_fuel(None);
+        assert!(executor.execute_with_args(0, vec![]).is_ok());
+    }
+
+    #[test]
+    fn test_cancel_token_preset_aborts_infinite_loop() {
+        // A token already tripped before execution aborts at the first check —
+        // deterministic, no timing involved. Note: no fuel cap is set, proving
+        // cancellation halts a runaway loop that fuel alone would let run.
+        let mut executor = Executor::new(infinite_loop_module()).unwrap();
+        executor.set_cancel_token(Some(Arc::new(AtomicBool::new(true))));
+        let err = executor
+            .execute_with_args(0, vec![])
+            .expect_err("pre-cancelled run should error");
+        assert!(
+            Executor::is_cancelled(&err),
+            "expected cancellation error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_cancel_token_aborts_running_infinite_loop() {
+        // Trip the flag from a watcher thread while the loop runs on this
+        // thread (so the test never depends on Executor being Send).
+        let mut executor = Executor::new(infinite_loop_module()).unwrap();
+        let flag = Arc::new(AtomicBool::new(false));
+        executor.set_cancel_token(Some(flag.clone()));
+        std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(50));
+            flag.store(true, Ordering::Relaxed);
+        });
+        let err = executor
+            .execute_with_args(0, vec![])
+            .expect_err("cancelled run should error");
+        assert!(
+            Executor::is_cancelled(&err),
+            "expected cancellation error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_untripped_cancel_token_allows_completion() {
+        // An installed-but-untripped token must not affect a finite program.
+        let module = Module {
+            version: 1,
+            types: vec![FunctionType {
+                params: vec![],
+                results: vec![],
+            }],
+            imports: vec![],
+            functions: vec![Function {
+                type_index: 0,
+                locals: vec![],
+                code: vec![0x0b], // end
+            }],
+            tables: vec![],
+            memory: None,
+            globals: vec![],
+            exports: HashMap::new(),
+            start: None,
+            elements: vec![],
+            data: vec![],
+        };
+        let mut executor = Executor::new(module).unwrap();
+        executor.set_cancel_token(Some(Arc::new(AtomicBool::new(false))));
         assert!(executor.execute_with_args(0, vec![]).is_ok());
     }
 

--- a/src/runtime/core/native_executor.rs
+++ b/src/runtime/core/native_executor.rs
@@ -6,6 +6,7 @@ use crate::error::{CommandError, Result, WasmrunError};
 use crate::runtime::wasi::{create_wasi_linker, WasiEnv};
 use std::fs;
 use std::path::Path;
+use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex};
 
 /// Resource ceilings applied to a single WASM execution.
@@ -140,6 +141,7 @@ pub fn execute_wasm_bytes_with_env(
     function: Option<String>,
     args: Vec<String>,
     limits: ExecLimits,
+    cancel: Option<Arc<AtomicBool>>,
 ) -> Result<i32> {
     let mut module = Module::parse(wasm_bytes)
         .map_err(|e| WasmrunError::from(format!("Failed to parse WASM module: {e}")))?;
@@ -163,6 +165,7 @@ pub fn execute_wasm_bytes_with_env(
     let mut executor = Executor::new_with_linker(module, wasi_linker)
         .map_err(|e| WasmrunError::from(format!("Failed to initialize executor: {e}")))?;
     executor.set_fuel(limits.max_fuel);
+    executor.set_cancel_token(cancel);
 
     let func_idx = if let Some(func_name) = function {
         find_export_function(executor.module(), &func_name)
@@ -194,6 +197,10 @@ pub fn execute_wasm_bytes_with_env(
         Err(e) => {
             if let Some(code) = extract_proc_exit(&e) {
                 Ok(code)
+            } else if Executor::is_cancelled(&e.to_string()) {
+                Err(WasmrunError::from(
+                    "Execution cancelled (timed out)".to_string(),
+                ))
             } else if Executor::is_fuel_exhausted(&e.to_string()) {
                 Err(WasmrunError::from(format!(
                     "Execution exceeded the instruction limit (fuel) of {} instructions",
@@ -494,7 +501,8 @@ mod tests {
         ];
 
         let env = Arc::new(Mutex::new(WasiEnv::new()));
-        let result = execute_wasm_bytes_with_env(&wasm, env, None, vec![], ExecLimits::default());
+        let result =
+            execute_wasm_bytes_with_env(&wasm, env, None, vec![], ExecLimits::default(), None);
         assert_eq!(
             result.unwrap(),
             42,
@@ -532,7 +540,8 @@ mod tests {
         ];
 
         let env = Arc::new(Mutex::new(WasiEnv::new()));
-        let result = execute_wasm_bytes_with_env(&wasm, env, None, vec![], ExecLimits::default());
+        let result =
+            execute_wasm_bytes_with_env(&wasm, env, None, vec![], ExecLimits::default(), None);
         assert_eq!(
             result.unwrap(),
             0,


### PR DESCRIPTION
The exec API ran each request on a detached worker thread and relied on the wall-clock timeout in `handle_exec` to bound it. But on timeout the HTTP handler returned while the worker kept running — Rust has no safe way to kill a thread, and the interpreter loop had no preemption point. The only halt mechanism was fuel, which defaults to unlimited because language runtimes (QuickJS) need a large, workload-dependent budget. So under default config a runaway or infinite-loop module pinned a CPU core and held its 256 MB memory + 64 MB thread stack indefinitely after the client already received its timeout response — a latent DoS even in a trusted single-tenant deployment.

Add cooperative cancellation. The `Executor` gains an optional `Arc<AtomicBool>` cancel token checked once per instruction in `execute_bytecode`, right beside the fuel decrement; tripping it aborts with the `EXECUTION_CANCELLED_ERROR` sentinel. `execute_wasm_bytes_with_env` threads the token through, and `handle_exec` hands a clone to each interpreter worker (wasm, source, project) and trips it on `RecvTimeoutError::Timeout` before returning. The worker observes the flag at its next instruction and self-terminates, freeing the core and stack. Fuel remains the deterministic instruction budget; the cancel flag is the wall-clock backstop that works even with unlimited fuel.

The token is a separate parameter rather than a field on `ExecLimits` because it's a control handle, not a resource ceiling, and folding it in would force that struct to drop `Copy`. Shell execs are synchronous Rust builtins with nothing to cancel, so they are left unwired.