### PR TITLE
feat(agent): bound request body size and exec concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Request Body & Execution Concurrency Limits**: bound the server's memory and thread footprint regardless of client behavior
+  - `--max-body` flag (default 32 MB, `0` = unlimited): oversized request bodies are rejected with **413 Payload Too Large** before being fully buffered — the body is read via `Read::take(limit + 1)` and the `Content-Length` header is never trusted
+  - `--max-concurrent-exec` flag (default 100, `0` = unlimited): a global cap on in-flight exec workers across all sessions; saturation returns **429 Too Many Requests** before a fresh 64 MB-stack thread is spawned
+  - The concurrency permit is held for the duration of execution and released on worker completion (not when the HTTP response returns), so a timed-out-but-still-running worker keeps its slot until cancellation halts it
+  - Request body is now read once, up front, in the router so the body cap applies uniformly to every POST route
+  - New `ApiError` variants `PayloadTooLarge` (413) and `TooManyRequests` (429); both new limits are shown in the startup banner
+- **Per-Session Resource Limits**: configurable ceilings enforced at the layer that owns each resource
+  - `--max-fuel` (instruction budget per execution; default `0` = unlimited), `--max-output` (captured stdout+stderr, MB), `--max-file-size` (per-file write, MB), `--max-disk` (total session disk, MB) CLI flags — `0` disables any individual cap
+  - Per-session overrides via an optional `{"limits": {...}}` body on `POST /api/v1/sessions`, merged over the server defaults
+  - Fuel exhaustion aborts runaway / infinite-loop modules; captured output beyond the cap is truncated and flagged via `output_truncated` in the exec response; oversized or over-quota file writes are rejected (per-file via `EFBIG` at the WASI layer, disk total at the agent ingress)
+  - New `ResourceLimits` (`src/agent/limits.rs`) is the single source of truth, fed by both the CLI and per-session overrides
 - **Shell Emulation in Agent Exec API**: built-in shell commands for familiar terminal patterns inside sandbox sessions
   - `POST /api/v1/sessions/:id/exec` accepts a new `command` field with a shell-style command line
   - Built-ins: `echo`, `cat`, `ls`, `pwd`, `cd`, `mkdir` (`-p`), `rm` (`-r`/`-rf`), `cp`, `mv`, `env`, `export`
@@ -38,6 +49,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Exec threads (both source and WASM execution paths) now run with a 64 MB stack via `std::thread::Builder::stack_size` — language runtimes like QuickJS generate deep call chains that overflow the default 8 MB stack
 - wasmhub runtime renamed `quickjs` → `nodejs`; manifest URL pinned to v0.2.0
 - Removed six WASI debug `eprintln!` calls that leaked to host stderr
+
+### Fixed
+- **Runaway execution halted on timeout**: exec workers now observe a cooperative cancel flag (checked per-instruction, alongside the fuel decrement, in the interpreter's hot loop). When the wall-clock timeout fires, the handler trips the flag and the detached worker self-terminates at its next instruction — freeing its CPU, memory, and 64 MB stack. Previously a runaway / infinite-loop module under the default (unlimited-fuel) config kept pinning a core indefinitely after the client had already received its timeout response.
 
 ## [0.19.0](https://github.com/anistark/wasmrun/releases/tag/v0.19.0) - 2026-05-20
 

--- a/docs/docs/exec/agent.md
+++ b/docs/docs/exec/agent.md
@@ -19,8 +19,16 @@ wasmrun agent [OPTIONS]
 | `-t, --timeout` | `300` | Default session idle timeout (seconds) |
 | `-m, --max-sessions` | `100` | Maximum concurrent sessions |
 | `--max-memory` | `256` | Maximum linear memory per session (MB) |
+| `--max-fuel` | `0` | Instruction budget per execution (`0` = unlimited) |
+| `--max-output` | `10` | Captured stdout+stderr per execution (MB) |
+| `--max-file-size` | `50` | Maximum size of any single file write (MB) |
+| `--max-disk` | `100` | Maximum total disk usage per session (MB) |
+| `--max-body` | `32` | Maximum accepted request body size (MB) |
+| `--max-concurrent-exec` | `100` | Maximum executions in flight across all sessions |
 | `--allow-cors` | off | Enable wildcard CORS |
 | `-v, --verbose` | off | Log all incoming requests |
+
+For every size/count limit, `0` means **unlimited**. Memory, fuel, output, file-size, and disk caps are **per session** and can be overridden per session at creation (see [Sessions](./usage/agent-sessions.md)); body size and exec concurrency are **server-wide** ingress guards.
 
 All endpoints are under `http://<host>:<port>/api/v1/`.
 

--- a/docs/docs/exec/usage/agent-exec.md
+++ b/docs/docs/exec/usage/agent-exec.md
@@ -177,6 +177,32 @@ If execution exceeds the timeout, the response includes:
 }
 ```
 
+Partial output captured before the timeout is still returned. The worker is then cooperatively cancelled so it stops executing and frees its resources, even under the default (unlimited) fuel budget.
+
+## Limits & Errors
+
+Execution is bounded by the per-session resource limits and server-wide ingress guards configured on [`wasmrun agent`](../agent.md#starting-the-server) (and overridable per session). These surface in two ways.
+
+**Within a 200 response** (the execution ran but hit a soft cap):
+
+| Field / value | Meaning |
+|---------------|---------|
+| `error` contains `"instruction limit"` | The execution exceeded `--max-fuel` and was aborted (`exit_code: -1`) |
+| `output_truncated: true` | Captured stdout+stderr hit `--max-output`; output in the response is truncated (the field is omitted when `false`) |
+| `error` contains `"File size limit"` / `"Disk usage limit"` | A file write from the sandbox exceeded `--max-file-size` or the session's `--max-disk` quota |
+
+**As an HTTP error status** (the request was rejected before or instead of running):
+
+| Status | When |
+|--------|------|
+| 400 | Bad request — no input mode given, unknown language, invalid `files`/`entry`, or path traversal |
+| 404 | Session not found |
+| 410 | Session expired |
+| 413 | Request body exceeded `--max-body` |
+| 429 | `--max-concurrent-exec` reached — too many executions already in flight; retry after backoff |
+
+A 429 is returned immediately (no thread is spawned). The exec slot it was waiting on is freed only when an in-flight execution actually completes, so a long-running or timed-out execution continues to hold its slot until it is cancelled.
+
 ## Workflow
 
 A typical agent loop:

--- a/docs/docs/exec/usage/agent-files.md
+++ b/docs/docs/exec/usage/agent-files.md
@@ -30,6 +30,8 @@ Parent directories are created automatically. Paths are relative to the session 
 }
 ```
 
+A write is rejected with **400 Bad Request** if it would exceed the session's `--max-file-size` (per file) or `--max-disk` (total) quota, and the whole request is rejected with **413 Payload Too Large** if the request body exceeds the server's `--max-body` limit. See [resource limits](../agent.md#starting-the-server).
+
 ## Read a File
 
 ```

--- a/docs/docs/exec/usage/agent-sessions.md
+++ b/docs/docs/exec/usage/agent-sessions.md
@@ -21,6 +21,24 @@ POST /api/v1/sessions
 }
 ```
 
+### Per-Session Limit Overrides
+
+The body is optional. To override the server's default [resource limits](../agent.md#starting-the-server) for this session only, pass a `limits` object — any omitted field keeps the server default, and `0` disables that cap:
+
+```json
+{
+  "limits": {
+    "max_memory_mb": 128,
+    "max_fuel": 5000000,
+    "max_output_mb": 5,
+    "max_file_size_mb": 10,
+    "max_disk_mb": 50
+  }
+}
+```
+
+Body size and exec concurrency are server-wide and cannot be overridden per session.
+
 ## Get Session Status
 
 ```
@@ -66,4 +84,5 @@ Destroys the session and cleans up its filesystem.
 |--------|------|
 | 404 | Session not found |
 | 410 | Session expired |
+| 413 | Request body exceeded the server's `--max-body` limit |
 | 429 | Maximum concurrent sessions reached |

--- a/src/agent/api.rs
+++ b/src/agent/api.rs
@@ -120,6 +120,10 @@ pub enum ApiError {
     MaxSessions(usize),
     BadRequest(String),
     NotFound(String),
+    /// Request body exceeded the configured size cap. Carries the limit (bytes).
+    PayloadTooLarge(usize),
+    /// Too many concurrent executions in flight. Carries the configured cap.
+    TooManyRequests(usize),
     #[allow(dead_code)] // TODO: Used when exec timeout triggers API-level error
     Timeout,
     Internal(String),
@@ -130,8 +134,9 @@ impl ApiError {
         match self {
             ApiError::SessionNotFound(_) | ApiError::NotFound(_) => 404,
             ApiError::SessionExpired(_) => 410,
-            ApiError::MaxSessions(_) => 429,
+            ApiError::MaxSessions(_) | ApiError::TooManyRequests(_) => 429,
             ApiError::BadRequest(_) => 400,
+            ApiError::PayloadTooLarge(_) => 413,
             ApiError::Timeout => 408,
             ApiError::Internal(_) => 500,
         }
@@ -153,6 +158,12 @@ impl std::fmt::Display for ApiError {
             ApiError::MaxSessions(max) => write!(f, "Maximum sessions reached: {max}"),
             ApiError::BadRequest(msg) => write!(f, "Bad request: {msg}"),
             ApiError::NotFound(msg) => write!(f, "Not found: {msg}"),
+            ApiError::PayloadTooLarge(max) => {
+                write!(f, "Request body too large: exceeds {max} byte limit")
+            }
+            ApiError::TooManyRequests(max) => {
+                write!(f, "Too many concurrent executions: limit is {max}")
+            }
             ApiError::Timeout => write!(f, "Execution timed out"),
             ApiError::Internal(msg) => write!(f, "Internal error: {msg}"),
         }

--- a/src/agent/server.rs
+++ b/src/agent/server.rs
@@ -12,7 +12,7 @@ use serde::Serialize;
 use std::collections::HashMap;
 use std::io::Read;
 use std::path::{Component, Path, PathBuf};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tiny_http::{Header, Method, Request, Response, Server, StatusCode};
@@ -22,12 +22,22 @@ const DEFAULT_EXEC_TIMEOUT_SECS: u64 = 30;
 // Language runtimes (e.g. QuickJS compiled to WASM) generate deep call chains that
 // overflow the default 8 MB thread stack when run through the WASM interpreter.
 const EXEC_THREAD_STACK_BYTES: usize = 64 * 1024 * 1024;
+/// Default request body cap (32 MB) when none is configured.
+const DEFAULT_MAX_BODY_BYTES: usize = 32 * 1024 * 1024;
+/// Default ceiling on concurrent exec workers when none is configured.
+const DEFAULT_MAX_CONCURRENT_EXEC: usize = 100;
 
 pub struct AgentConfig {
     pub port: u16,
     pub session_config: SessionConfig,
     pub allow_cors: bool,
     pub verbose: bool,
+    /// Maximum accepted request body size in bytes. `None` = unlimited.
+    pub max_body_bytes: Option<usize>,
+    /// Maximum number of exec workers allowed to run concurrently across all
+    /// sessions. `0` = unlimited. Bounds thread / stack / memory footprint
+    /// independently of `max_sessions` (which only bounds session count).
+    pub max_concurrent_exec: usize,
 }
 
 impl Default for AgentConfig {
@@ -37,6 +47,69 @@ impl Default for AgentConfig {
             session_config: SessionConfig::default(),
             allow_cors: false,
             verbose: false,
+            max_body_bytes: Some(DEFAULT_MAX_BODY_BYTES),
+            max_concurrent_exec: DEFAULT_MAX_CONCURRENT_EXEC,
+        }
+    }
+}
+
+/// Non-blocking counting semaphore bounding concurrent exec workers.
+///
+/// `max == 0` means unlimited. [`try_acquire`](ExecSlots::try_acquire) never
+/// blocks: it either returns a permit or `None` (caller responds 429). A permit
+/// is released when its guard is dropped — and because the guard is moved into
+/// the exec worker thread, release happens on *worker completion*, not when the
+/// HTTP response returns. This keeps a slot held by a timed-out-but-still-running
+/// worker until cooperative cancellation actually stops it.
+struct ExecSlots {
+    in_flight: AtomicUsize,
+    max: usize,
+}
+
+impl ExecSlots {
+    fn new(max: usize) -> Arc<Self> {
+        Arc::new(Self {
+            in_flight: AtomicUsize::new(0),
+            max,
+        })
+    }
+
+    /// Try to take a slot. Returns `None` when saturated (caller → 429).
+    fn try_acquire(self: &Arc<Self>) -> Option<ExecPermit> {
+        if self.max == 0 {
+            return Some(ExecPermit { slots: None });
+        }
+        let mut cur = self.in_flight.load(Ordering::Acquire);
+        loop {
+            if cur >= self.max {
+                return None;
+            }
+            match self.in_flight.compare_exchange_weak(
+                cur,
+                cur + 1,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => {
+                    return Some(ExecPermit {
+                        slots: Some(self.clone()),
+                    })
+                }
+                Err(actual) => cur = actual,
+            }
+        }
+    }
+}
+
+/// RAII permit for a slot in [`ExecSlots`]. Releases the slot on drop.
+struct ExecPermit {
+    slots: Option<Arc<ExecSlots>>,
+}
+
+impl Drop for ExecPermit {
+    fn drop(&mut self) {
+        if let Some(slots) = &self.slots {
+            slots.in_flight.fetch_sub(1, Ordering::AcqRel);
         }
     }
 }
@@ -44,14 +117,17 @@ impl Default for AgentConfig {
 pub struct AgentServer {
     session_manager: Arc<SessionManager>,
     config: AgentConfig,
+    exec_slots: Arc<ExecSlots>,
 }
 
 impl AgentServer {
     pub fn new(config: AgentConfig) -> Self {
         let session_manager = Arc::new(SessionManager::with_config(config.session_config.clone()));
+        let exec_slots = ExecSlots::new(config.max_concurrent_exec);
         Self {
             session_manager,
             config,
+            exec_slots,
         }
     }
 
@@ -124,6 +200,14 @@ impl AgentServer {
             "   Disk limit:      {}",
             fmt_bytes_mb(limits.max_disk_bytes)
         );
+        println!(
+            "   Max body size:   {}",
+            fmt_bytes_mb(self.config.max_body_bytes.map(|b| b as u64))
+        );
+        println!(
+            "   Max concurrent:  {}",
+            fmt_count(self.config.max_concurrent_exec, "exec(s)")
+        );
         println!("   CORS:            {cors}");
         println!();
         println!("   Endpoints:");
@@ -182,6 +266,18 @@ impl AgentServer {
             .filter(|s| !s.is_empty())
             .collect();
 
+        // Read the request body once, up front, for methods that carry one.
+        // Oversize bodies are rejected (413) before they are fully buffered, so
+        // a large POST cannot OOM the process before a handler-level limit runs.
+        let body = if method == Method::Post {
+            match read_body(request.as_reader(), self.config.max_body_bytes) {
+                Ok(b) => b,
+                Err(e) => return self.respond_json(request, Err::<serde_json::Value, _>(e)),
+            }
+        } else {
+            String::new()
+        };
+
         let result = match (method, segments.as_slice()) {
             (Method::Get, ["tools"]) => {
                 let params = parse_query(&query);
@@ -189,7 +285,6 @@ impl AgentServer {
                 self.respond_json(request, self.handle_get_tools(format))
             }
             (Method::Post, ["sessions"]) => {
-                let body = read_body(request.as_reader())?;
                 self.respond_json(request, self.handle_create_session_with_body(&body))
             }
             (Method::Get, ["sessions", id]) => {
@@ -199,11 +294,9 @@ impl AgentServer {
                 self.respond_json(request, self.handle_delete_session(id))
             }
             (Method::Post, ["sessions", id, "exec"]) => {
-                let body = read_body(request.as_reader())?;
                 self.respond_json(request, self.handle_exec(id, &body))
             }
             (Method::Post, ["sessions", id, "files"]) => {
-                let body = read_body(request.as_reader())?;
                 self.respond_json(request, self.handle_write_file(id, &body))
             }
             (Method::Get, ["sessions", id, "files"]) => {
@@ -221,7 +314,6 @@ impl AgentServer {
                 self.respond_json(request, self.handle_delete_file(id, path))
             }
             (Method::Post, ["sessions", id, "env"]) => {
-                let body = read_body(request.as_reader())?;
                 self.respond_json(request, self.handle_set_env(id, &body))
             }
             (Method::Get, ["sessions", id, "env"]) => {
@@ -342,6 +434,16 @@ impl AgentServer {
         };
         let exec_env = wasi_env.clone();
 
+        // Bound concurrent exec workers globally. The permit is moved into the
+        // spawned worker so its slot is released on *worker completion* (not when
+        // this HTTP response returns) — a timed-out-but-still-running worker keeps
+        // its slot until cooperative cancellation actually stops it. On saturation
+        // reject with 429 before spawning a fresh 64 MB-stack thread.
+        let permit = self
+            .exec_slots
+            .try_acquire()
+            .ok_or(ApiError::TooManyRequests(self.config.max_concurrent_exec))?;
+
         let (tx, rx) = std::sync::mpsc::channel::<std::result::Result<i32, ApiError>>();
         // Cooperative cancellation: the worker runs detached, so if the
         // wall-clock timeout fires we trip this flag to make the (possibly
@@ -355,8 +457,10 @@ impl AgentServer {
             std::thread::Builder::new()
                 .stack_size(EXEC_THREAD_STACK_BYTES)
                 .spawn(move || {
+                    let permit = permit; // held for the duration of execution
                     let result = shell::run_command(&command, &work_dir_clone, exec_env)
                         .map_err(|e| ApiError::BadRequest(e.to_string()));
+                    drop(permit); // free the slot once execution is done
                     let _ = tx.send(result);
                 })
                 .map_err(|e| ApiError::Internal(format!("Failed to spawn exec thread: {e}")))?;
@@ -379,6 +483,7 @@ impl AgentServer {
             std::thread::Builder::new()
                 .stack_size(EXEC_THREAD_STACK_BYTES)
                 .spawn(move || {
+                    let permit = permit; // held for the duration of execution
                     let result = executor::execute_source_project(
                         &files,
                         &entry,
@@ -388,6 +493,7 @@ impl AgentServer {
                         &limits_clone,
                         Some(cancel_worker),
                     );
+                    drop(permit); // free the slot once execution is done
                     let _ = tx.send(result);
                 })
                 .map_err(|e| ApiError::Internal(format!("Failed to spawn exec thread: {e}")))?;
@@ -402,6 +508,7 @@ impl AgentServer {
             std::thread::Builder::new()
                 .stack_size(EXEC_THREAD_STACK_BYTES)
                 .spawn(move || {
+                    let permit = permit; // held for the duration of execution
                     let result = executor::execute_source(
                         &source,
                         &lang,
@@ -410,6 +517,7 @@ impl AgentServer {
                         &limits_clone,
                         Some(cancel_worker),
                     );
+                    drop(permit); // free the slot once execution is done
                     let _ = tx.send(result);
                 })
                 .map_err(|e| ApiError::Internal(format!("Failed to spawn exec thread: {e}")))?;
@@ -424,6 +532,7 @@ impl AgentServer {
             std::thread::Builder::new()
                 .stack_size(EXEC_THREAD_STACK_BYTES)
                 .spawn(move || {
+                    let permit = permit; // held for the duration of execution
                     let result = execute_wasm_bytes_with_env(
                         &wasm_bytes,
                         exec_env,
@@ -433,6 +542,7 @@ impl AgentServer {
                         Some(cancel_worker),
                     )
                     .map_err(|e| ApiError::Internal(e.to_string()));
+                    drop(permit); // free the slot once execution is done
                     let _ = tx.send(result);
                 })
                 .map_err(|e| ApiError::Internal(format!("Failed to spawn exec thread: {e}")))?;
@@ -718,6 +828,15 @@ fn fmt_bytes_mb(bytes: Option<u64>) -> String {
     }
 }
 
+/// Format a count cap for the banner, where `0` means unlimited.
+fn fmt_count(n: usize, unit: &str) -> String {
+    if n == 0 {
+        "unlimited".to_string()
+    } else {
+        format!("{n} {unit}")
+    }
+}
+
 /// Format an optional numeric limit with a unit label for the banner.
 fn fmt_opt_u64(val: Option<u64>, unit: &str) -> String {
     match val {
@@ -749,12 +868,33 @@ fn resolve_session_path(
     Ok(work_dir.join(cleaned))
 }
 
-fn read_body(reader: &mut dyn Read) -> Result<String> {
-    let mut body = String::new();
+/// Read the full request body as a UTF-8 string.
+///
+/// When `max_bytes` is set, reads at most `max_bytes + 1` bytes so an oversize
+/// body is detected (and rejected with 413) without buffering beyond the cap —
+/// the `Content-Length` header is never trusted. `None` reads the body in full.
+fn read_body(
+    reader: &mut dyn Read,
+    max_bytes: Option<usize>,
+) -> std::result::Result<String, ApiError> {
+    let Some(limit) = max_bytes else {
+        let mut body = String::new();
+        reader
+            .read_to_string(&mut body)
+            .map_err(|e| ApiError::BadRequest(format!("Failed to read request body: {e}")))?;
+        return Ok(body);
+    };
+
+    let mut buf = Vec::new();
     reader
-        .read_to_string(&mut body)
-        .map_err(|e| WasmrunError::from(format!("Failed to read request body: {e}")))?;
-    Ok(body)
+        .take(limit as u64 + 1)
+        .read_to_end(&mut buf)
+        .map_err(|e| ApiError::BadRequest(format!("Failed to read request body: {e}")))?;
+    if buf.len() > limit {
+        return Err(ApiError::PayloadTooLarge(limit));
+    }
+    String::from_utf8(buf)
+        .map_err(|e| ApiError::BadRequest(format!("Request body is not valid UTF-8: {e}")))
 }
 
 fn split_url(url: &str) -> (String, String) {
@@ -832,6 +972,10 @@ mod tests {
     use super::*;
 
     fn test_server() -> AgentServer {
+        test_server_with_concurrency(100)
+    }
+
+    fn test_server_with_concurrency(max_concurrent_exec: usize) -> AgentServer {
         AgentServer::new(AgentConfig {
             port: 0,
             session_config: SessionConfig {
@@ -842,6 +986,8 @@ mod tests {
             },
             allow_cors: true,
             verbose: false,
+            max_body_bytes: Some(32 * 1024 * 1024),
+            max_concurrent_exec,
         })
     }
 
@@ -1725,6 +1871,114 @@ mod tests {
             .unwrap();
         assert_eq!(ok.stdout, "Hello, World!\n");
         assert_eq!(ok.exit_code, 0);
+
+        server.session_manager.destroy_all().unwrap();
+    }
+
+    // ── Request body size limit (0.20.3) ──────────────────────────
+
+    #[test]
+    fn test_read_body_within_limit() {
+        let mut cur = std::io::Cursor::new(&b"hello"[..]);
+        assert_eq!(read_body(&mut cur, Some(5)).unwrap(), "hello");
+    }
+
+    #[test]
+    fn test_read_body_unlimited() {
+        let data = vec![b'x'; 1024];
+        let mut cur = std::io::Cursor::new(&data[..]);
+        assert_eq!(read_body(&mut cur, None).unwrap().len(), 1024);
+    }
+
+    #[test]
+    fn test_read_body_rejects_oversize_with_413() {
+        let mut cur = std::io::Cursor::new(&b"hello world"[..]);
+        let err = read_body(&mut cur, Some(5)).unwrap_err();
+        assert_eq!(err.status_code(), 413);
+        assert!(matches!(err, ApiError::PayloadTooLarge(5)));
+    }
+
+    #[test]
+    fn test_read_body_at_exact_limit_is_ok() {
+        // Exactly `limit` bytes must be accepted; only `> limit` is rejected.
+        let mut cur = std::io::Cursor::new(&b"12345"[..]);
+        assert_eq!(read_body(&mut cur, Some(5)).unwrap(), "12345");
+    }
+
+    // ── Exec concurrency cap (0.20.3) ─────────────────────────────
+
+    #[test]
+    fn test_exec_slots_saturation_and_release() {
+        let slots = ExecSlots::new(2);
+        let p1 = slots.try_acquire().unwrap();
+        let p2 = slots.try_acquire().unwrap();
+        // Saturated: third acquire fails.
+        assert!(slots.try_acquire().is_none());
+        // Releasing one frees a slot.
+        drop(p1);
+        let p3 = slots.try_acquire().unwrap();
+        drop(p2);
+        drop(p3);
+        // After all release, capacity is restored.
+        assert!(slots.try_acquire().is_some());
+    }
+
+    #[test]
+    fn test_exec_slots_unlimited() {
+        let slots = ExecSlots::new(0);
+        let permits: Vec<_> = (0..1000).map(|_| slots.try_acquire().unwrap()).collect();
+        assert_eq!(permits.len(), 1000);
+    }
+
+    #[test]
+    fn test_exec_returns_429_when_saturated() {
+        let server = test_server_with_concurrency(1);
+        let id = server.handle_create_session().unwrap().session_id;
+        let work_dir = server
+            .session_manager
+            .get_session(&id, |s| s.work_dir().to_path_buf())
+            .unwrap();
+        std::fs::write(work_dir.join("hello.wasm"), hello_wasm()).unwrap();
+
+        // Hold the only slot to simulate a worker already in flight.
+        let held = server.exec_slots.try_acquire().unwrap();
+        let err = server
+            .handle_exec(&id, r#"{"wasm_path": "hello.wasm"}"#)
+            .unwrap_err();
+        assert_eq!(err.status_code(), 429);
+        assert!(matches!(err, ApiError::TooManyRequests(1)));
+
+        // Releasing the slot lets the next exec through.
+        drop(held);
+        let ok = server
+            .handle_exec(&id, r#"{"wasm_path": "hello.wasm"}"#)
+            .unwrap();
+        assert_eq!(ok.exit_code, 0);
+
+        server.session_manager.destroy_all().unwrap();
+    }
+
+    #[test]
+    fn test_exec_permit_released_after_worker_completion() {
+        // With a single slot, several *sequential* execs must all succeed —
+        // proving each worker's permit is released when it completes (not
+        // leaked), or the second call would 429.
+        let server = test_server_with_concurrency(1);
+        let id = server.handle_create_session().unwrap().session_id;
+        let work_dir = server
+            .session_manager
+            .get_session(&id, |s| s.work_dir().to_path_buf())
+            .unwrap();
+        std::fs::write(work_dir.join("hello.wasm"), hello_wasm()).unwrap();
+
+        for _ in 0..3 {
+            let ok = server
+                .handle_exec(&id, r#"{"wasm_path": "hello.wasm"}"#)
+                .unwrap();
+            assert_eq!(ok.exit_code, 0);
+        }
+        // The slot is free again after the loop.
+        assert!(server.exec_slots.try_acquire().is_some());
 
         server.session_manager.destroy_all().unwrap();
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -340,6 +340,22 @@ pub enum Commands {
         )]
         max_disk: u32,
 
+        /// Maximum accepted request body size in MB (default: 32, 0 = unlimited)
+        #[arg(
+            long,
+            default_value_t = 32,
+            help = "Maximum accepted request body size in MB (0 = unlimited)"
+        )]
+        max_body: u32,
+
+        /// Maximum concurrent executions across all sessions (default: 100, 0 = unlimited)
+        #[arg(
+            long,
+            default_value_t = 100,
+            help = "Maximum concurrent executions across all sessions (0 = unlimited)"
+        )]
+        max_concurrent_exec: usize,
+
         /// Allow wildcard CORS (Access-Control-Allow-Origin: *)
         #[arg(long, help = "Allow cross-origin requests from any domain")]
         allow_cors: bool,

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -16,11 +16,16 @@ pub fn handle_agent_command(
     max_output: u32,
     max_file_size: u32,
     max_disk: u32,
+    max_body: u32,
+    max_concurrent_exec: usize,
     allow_cors: bool,
     verbose: bool,
 ) -> Result<()> {
     let limits =
         ResourceLimits::from_cli(max_memory, max_fuel, max_output, max_file_size, max_disk);
+
+    // 0 = unlimited, matching the resource-limit flag convention.
+    let max_body_bytes = (max_body != 0).then(|| max_body as usize * 1024 * 1024);
 
     let config = AgentConfig {
         port,
@@ -32,6 +37,8 @@ pub fn handle_agent_command(
         },
         allow_cors,
         verbose,
+        max_body_bytes,
+        max_concurrent_exec,
     };
 
     let server = AgentServer::new(config);

--- a/src/main.rs
+++ b/src/main.rs
@@ -184,11 +184,13 @@ fn main() {
             max_output,
             max_file_size,
             max_disk,
+            max_body,
+            max_concurrent_exec,
             allow_cors,
             verbose,
         }) => {
             debug_println!(
-                "Processing agent command: port={}, timeout={}, max_sessions={}, max_memory={}MB, max_fuel={}, max_output={}MB, max_file_size={}MB, max_disk={}MB",
+                "Processing agent command: port={}, timeout={}, max_sessions={}, max_memory={}MB, max_fuel={}, max_output={}MB, max_file_size={}MB, max_disk={}MB, max_body={}MB, max_concurrent_exec={}",
                 port,
                 timeout,
                 max_sessions,
@@ -196,7 +198,9 @@ fn main() {
                 max_fuel,
                 max_output,
                 max_file_size,
-                max_disk
+                max_disk,
+                max_body,
+                max_concurrent_exec
             );
             commands::handle_agent_command(
                 *port,
@@ -207,6 +211,8 @@ fn main() {
                 *max_output,
                 *max_file_size,
                 *max_disk,
+                *max_body,
+                *max_concurrent_exec,
                 *allow_cors,
                 *verbose,
             )


### PR DESCRIPTION
The agent server had two unbounded ingress paths that could exhaust process memory or threads regardless of the per-session resource limits:

- `read_body` did an unbounded `read_to_string`, so a large POST could OOM the process before any file-size limit engaged.
- Every exec spawned a fresh 64 MB-stack thread with no global ceiling. `max_sessions` bounds session count, not concurrent executions, so N sessions each firing execs could exhaust threads and memory.

Body cap: `read_body` now reads via `Read::take(limit + 1)` and rejects oversize bodies with 413 before buffering past the cap (`Content-Length` is never trusted). The body is read once, up front, in `handle_request` so the cap applies uniformly to every POST route.

Concurrency cap: a non-blocking counting semaphore (`ExecSlots`) bounds in-flight exec workers. `handle_exec` acquires an RAII permit before spawning and returns 429 on saturation. The permit is moved into the worker and released on execution completion -- not when the HTTP response returns -- so a timed-out-but-still-running worker keeps its slot until cancellation halts it.

Both limits are configurable, with 0 meaning unlimited:

    wasmrun agent --max-body 16 --max-concurrent-exec 50

Adds `PayloadTooLarge` (413) and `TooManyRequests` (429) to `ApiError`; both limits print in the startup banner. Docs and CHANGELOG updated, including backfilled entries for the already-merged per-session resource limits and timeout-cancellation work.