### PR TITLE
feat(agent): add opt-in API-key auth and tenant isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Authentication & Tenant Isolation (opt-in)**: run one agent server shared by independent tenants who authenticate with API keys and cannot see each other's sessions
+  - `--auth <path>` enables API-key auth from a TOML config of `[[tenants]]` (`id` + `key_sha256`); without it the server stays fully **open**, exactly as before (back-compat — existing clients need no header)
+  - Keys are stored **SHA-256-hashed** (hex), never in plaintext; `--hash-key <KEY>` prints the hash and exits so operators can populate the config
+  - Every `/api/v1/*` request (including `/tools`) must present `Authorization: Bearer <key>`; missing, malformed, or unknown keys return **401 Unauthorized**. The presented key is hashed and matched by map lookup, sidestepping secret-timing attacks without a constant-time compare
+  - Sessions are **owned** by the tenant that created them; any cross-tenant access returns **404 Not Found** (identical to a nonexistent session, so existence isn't leaked), enforced centrally in the session manager
+  - The auth config is validated at startup (non-empty unique ids, unique 64-char-hex hashes); an invalid or missing config **aborts startup** rather than silently running open. The banner shows `Auth: enabled (N tenants)` or `disabled (open)`
+  - New `ApiError::Unauthorized` (401). Per-tenant rate limiting is deferred to a later release
 - **Request Body & Execution Concurrency Limits**: bound the server's memory and thread footprint regardless of client behavior
   - `--max-body` flag (default 32 MB, `0` = unlimited): oversized request bodies are rejected with **413 Payload Too Large** before being fully buffered — the body is read via `Read::take(limit + 1)` and the `Content-Length` header is never trusted
   - `--max-concurrent-exec` flag (default 100, `0` = unlimited): a global cap on in-flight exec workers across all sessions; saturation returns **429 Too Many Requests** before a fresh 64 MB-stack thread is spawned

--- a/docs/docs/exec/agent.md
+++ b/docs/docs/exec/agent.md
@@ -27,10 +27,70 @@ wasmrun agent [OPTIONS]
 | `--max-concurrent-exec` | `100` | Maximum executions in flight across all sessions |
 | `--allow-cors` | off | Enable wildcard CORS |
 | `-v, --verbose` | off | Log all incoming requests |
+| `--auth <PATH>` | off | Path to a TOML auth config; enables API-key auth & tenant isolation (omit = open) |
+| `--hash-key <KEY>` | — | Print `sha256(KEY)` for the auth config and exit (does not start the server) |
 
 For every size/count limit, `0` means **unlimited**. Memory, fuel, output, file-size, and disk caps are **per session** and can be overridden per session at creation (see [Sessions](./usage/agent-sessions.md)); body size and exec concurrency are **server-wide** ingress guards.
 
 All endpoints are under `http://<host>:<port>/api/v1/`.
+
+## Authentication
+
+By default the server is **open** — any caller can create and access any session. Pass `--auth <path>` to require an API key on every request and isolate sessions per tenant. Without `--auth`, behavior is exactly as before (no header needed).
+
+```sh
+wasmrun agent --port 8430 --auth ./auth.toml
+# banner shows:  Auth:  enabled (2 tenants)
+```
+
+### Config file
+
+The auth config is a TOML file listing tenants. Keys are stored **hashed** (SHA-256, hex) — never in plaintext:
+
+```toml
+[[tenants]]
+id = "copilot"
+key_sha256 = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+
+[[tenants]]
+id = "ci"
+key_sha256 = "60303ae22b998861bce3b28f33eec1be758a213c86c93c076dbe9f558c11c752"
+```
+
+Each `id` and `key_sha256` must be unique, and `key_sha256` must be 64 lowercase hex characters. Invalid or missing config **aborts startup** — the server never silently runs open when auth was requested. Restrict the file so other users can't read the hashes:
+
+```sh
+chmod 600 auth.toml
+```
+
+### Generating a key hash
+
+Generate a high-entropy random key, then hash it for the config:
+
+```sh
+KEY=$(openssl rand -hex 32)
+wasmrun agent --hash-key "$KEY"
+# → 4b4090ccee1e713c3d411b96a4226b90bd0f0deb34e02d19475a951316fd04ee
+```
+
+Put the hash in `key_sha256`, hand the raw `$KEY` to that tenant, and keep the raw key out of the config.
+
+### Making authenticated requests
+
+Send the raw key as a Bearer token on every `/api/v1/*` request (including `/tools`):
+
+```sh
+curl -X POST http://localhost:8430/api/v1/sessions \
+  -H "Authorization: Bearer $KEY"
+```
+
+A missing, malformed, or unknown key returns **401 Unauthorized**.
+
+### Tenant isolation
+
+Each session is owned by the tenant that created it. A tenant can only see and operate on its own sessions — any request targeting another tenant's session returns **404 Not Found**, identical to a nonexistent session so existence isn't leaked.
+
+> Per-tenant rate limiting is not yet implemented.
 
 ## How It Works
 

--- a/docs/docs/exec/usage/agent-exec.md
+++ b/docs/docs/exec/usage/agent-exec.md
@@ -196,7 +196,8 @@ Execution is bounded by the per-session resource limits and server-wide ingress 
 | Status | When |
 |--------|------|
 | 400 | Bad request — no input mode given, unknown language, invalid `files`/`entry`, or path traversal |
-| 404 | Session not found |
+| 401 | Auth enabled (`--auth`) but the API key is missing, malformed, or unknown |
+| 404 | Session not found — or owned by another tenant (cross-tenant access is hidden as 404) |
 | 410 | Session expired |
 | 413 | Request body exceeded `--max-body` |
 | 429 | `--max-concurrent-exec` reached — too many executions already in flight; retry after backoff |

--- a/docs/docs/exec/usage/agent-files.md
+++ b/docs/docs/exec/usage/agent-files.md
@@ -84,3 +84,7 @@ Deletes files or directories (recursive for directories).
 - Leading `/` is stripped (treated as session root)
 - Path traversal (`../`) is rejected with 400 Bad Request
 - Files are only accessible within the session's isolated directory
+
+## Authentication & Tenant Scoping
+
+When the server runs with [`--auth`](../agent.md#authentication), every file request must carry a valid `Authorization: Bearer <key>` header — a missing, malformed, or unknown key returns **401 Unauthorized**. File operations are scoped to the calling tenant's own sessions; targeting a session owned by another tenant returns **404 Not Found**, the same as a nonexistent session.

--- a/docs/docs/exec/usage/agent-sessions.md
+++ b/docs/docs/exec/usage/agent-sessions.md
@@ -82,7 +82,10 @@ Destroys the session and cleans up its filesystem.
 
 | Status | When |
 |--------|------|
-| 404 | Session not found |
+| 401 | Auth enabled (`--auth`) but the API key is missing, malformed, or unknown |
+| 404 | Session not found — or owned by another tenant (see below) |
 | 410 | Session expired |
 | 413 | Request body exceeded the server's `--max-body` limit |
 | 429 | Maximum concurrent sessions reached |
+
+When the server is started with [`--auth`](../agent.md#authentication), each session is owned by the tenant that created it. A request for a session owned by a different tenant returns **404** — identical to a nonexistent session — so existence isn't leaked across tenants.

--- a/src/agent/api.rs
+++ b/src/agent/api.rs
@@ -119,6 +119,8 @@ pub enum ApiError {
     SessionExpired(String),
     MaxSessions(usize),
     BadRequest(String),
+    /// Authentication required but missing/malformed/unknown API key.
+    Unauthorized(String),
     NotFound(String),
     /// Request body exceeded the configured size cap. Carries the limit (bytes).
     PayloadTooLarge(usize),
@@ -136,6 +138,7 @@ impl ApiError {
             ApiError::SessionExpired(_) => 410,
             ApiError::MaxSessions(_) | ApiError::TooManyRequests(_) => 429,
             ApiError::BadRequest(_) => 400,
+            ApiError::Unauthorized(_) => 401,
             ApiError::PayloadTooLarge(_) => 413,
             ApiError::Timeout => 408,
             ApiError::Internal(_) => 500,
@@ -157,6 +160,7 @@ impl std::fmt::Display for ApiError {
             ApiError::SessionExpired(id) => write!(f, "Session expired: {id}"),
             ApiError::MaxSessions(max) => write!(f, "Maximum sessions reached: {max}"),
             ApiError::BadRequest(msg) => write!(f, "Bad request: {msg}"),
+            ApiError::Unauthorized(msg) => write!(f, "Unauthorized: {msg}"),
             ApiError::NotFound(msg) => write!(f, "Not found: {msg}"),
             ApiError::PayloadTooLarge(max) => {
                 write!(f, "Request body too large: exceeds {max} byte limit")

--- a/src/agent/auth.rs
+++ b/src/agent/auth.rs
@@ -1,0 +1,276 @@
+//! Agent mode: API-key authentication and tenant mapping.
+//!
+//! Auth is **opt-in**: it is wired into the server only when the operator passes
+//! `--auth <path>`. Without it the server stays fully open (back-compat).
+//!
+//! Keys are never stored in plaintext. The config file holds the **SHA-256 hash**
+//! (hex) of each tenant's key; at request time the presented key is hashed and
+//! matched against the stored hashes via a map lookup. Because the lookup key is a
+//! one-way hash of the secret, this sidesteps secret-timing attacks without a
+//! manual constant-time compare. Keys must be high-entropy random strings.
+//!
+//! Use `wasmrun agent --hash-key <KEY>` to print the hash for a key.
+//!
+//! ## Config schema
+//!
+//! ```toml
+//! [[tenants]]
+//! id = "copilot"
+//! key_sha256 = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+//!
+//! [[tenants]]
+//! id = "ci"
+//! key_sha256 = "60303ae22b998861bce3b28f33eec1be758a213c86c93c076dbe9f558c11c752"
+//! ```
+
+use crate::error::{ConfigError, WasmrunError};
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::path::Path;
+
+/// Compute the hex-encoded SHA-256 hash of an API key.
+///
+/// This is the value stored in the auth config's `key_sha256` field. The
+/// `--hash-key` CLI helper prints exactly this.
+pub fn hash_key(key: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let hash = Sha256::digest(key.as_bytes());
+    hash.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+/// Raw TOML shape for `[[tenants]]` entries, before validation/inversion.
+#[derive(Debug, Deserialize)]
+struct RawAuth {
+    #[serde(default)]
+    tenants: Vec<RawTenant>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawTenant {
+    id: String,
+    key_sha256: String,
+}
+
+/// Resolved auth configuration: a map from key hash → tenant id.
+///
+/// Built once at startup and shared (behind an `Arc`) across all requests.
+#[derive(Debug, Clone)]
+pub struct AuthConfig {
+    /// SHA-256 hex of the key → tenant id.
+    keys: HashMap<String, String>,
+}
+
+impl AuthConfig {
+    /// Load and validate an auth config from a TOML file.
+    ///
+    /// Validates that every tenant has a non-empty id and a 64-char lowercase
+    /// hex `key_sha256`, and that there are no duplicate ids or duplicate
+    /// hashes. Returns a clear error otherwise — startup should abort rather
+    /// than silently run open when auth was requested.
+    pub fn load(path: &Path) -> Result<Self, WasmrunError> {
+        if !path.exists() {
+            return Err(WasmrunError::Config(ConfigError::FileNotFound {
+                path: path.display().to_string(),
+            }));
+        }
+        if path.is_dir() {
+            return Err(WasmrunError::Config(ConfigError::InvalidValue {
+                message: format!(
+                    "Auth config path is a directory, not a file: {}",
+                    path.display()
+                ),
+            }));
+        }
+
+        let content = std::fs::read_to_string(path).map_err(|e| {
+            WasmrunError::Config(ConfigError::ParseError {
+                message: format!("Failed to read auth config file: {e}"),
+            })
+        })?;
+
+        let raw: RawAuth = toml::from_str(&content).map_err(|e| {
+            WasmrunError::Config(ConfigError::ParseError {
+                message: format!("Failed to parse auth config TOML: {e}"),
+            })
+        })?;
+
+        Self::from_raw(raw)
+    }
+
+    /// Validate raw tenants and invert into the hash → id map.
+    fn from_raw(raw: RawAuth) -> Result<Self, WasmrunError> {
+        if raw.tenants.is_empty() {
+            return Err(WasmrunError::Config(ConfigError::InvalidValue {
+                message: "Auth config has no [[tenants]] entries".to_string(),
+            }));
+        }
+
+        let mut keys: HashMap<String, String> = HashMap::with_capacity(raw.tenants.len());
+        let mut seen_ids: HashMap<String, ()> = HashMap::with_capacity(raw.tenants.len());
+
+        for tenant in raw.tenants {
+            let id = tenant.id.trim();
+            if id.is_empty() {
+                return Err(WasmrunError::Config(ConfigError::InvalidValue {
+                    message: "Auth config has a tenant with an empty id".to_string(),
+                }));
+            }
+
+            let hash = tenant.key_sha256.trim();
+            if !is_sha256_hex(hash) {
+                return Err(WasmrunError::Config(ConfigError::InvalidValue {
+                    message: format!(
+                        "Tenant '{id}' has an invalid key_sha256 (expected 64 lowercase hex chars)"
+                    ),
+                }));
+            }
+
+            if seen_ids.insert(id.to_string(), ()).is_some() {
+                return Err(WasmrunError::Config(ConfigError::InvalidValue {
+                    message: format!("Auth config has duplicate tenant id '{id}'"),
+                }));
+            }
+
+            if keys.insert(hash.to_string(), id.to_string()).is_some() {
+                return Err(WasmrunError::Config(ConfigError::InvalidValue {
+                    message: format!(
+                        "Auth config has duplicate key_sha256 (shared by tenant '{id}')"
+                    ),
+                }));
+            }
+        }
+
+        Ok(AuthConfig { keys })
+    }
+
+    /// Number of configured tenants.
+    pub fn tenant_count(&self) -> usize {
+        self.keys.len()
+    }
+
+    /// Resolve a presented API key to its tenant id, or `None` if unknown.
+    pub fn resolve(&self, presented_key: &str) -> Option<&str> {
+        let hash = hash_key(presented_key);
+        self.keys.get(&hash).map(|s| s.as_str())
+    }
+}
+
+/// True if `s` is exactly 64 lowercase hex characters (a SHA-256 hex digest).
+fn is_sha256_hex(s: &str) -> bool {
+    s.len() == 64
+        && s.bytes()
+            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn test_hash_key_known_vector() {
+        // sha256("foo") — standard vector.
+        assert_eq!(
+            hash_key("foo"),
+            "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae"
+        );
+        // sha256("") — empty string vector.
+        assert_eq!(
+            hash_key(""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+
+    fn write_toml(body: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        f.write_all(body.as_bytes()).unwrap();
+        f
+    }
+
+    #[test]
+    fn test_load_valid_and_resolve() {
+        let body = format!(
+            "[[tenants]]\nid = \"copilot\"\nkey_sha256 = \"{}\"\n\n[[tenants]]\nid = \"ci\"\nkey_sha256 = \"{}\"\n",
+            hash_key("sk_copilot"),
+            hash_key("sk_ci")
+        );
+        let f = write_toml(&body);
+        let cfg = AuthConfig::load(f.path()).unwrap();
+
+        assert_eq!(cfg.tenant_count(), 2);
+        assert_eq!(cfg.resolve("sk_copilot"), Some("copilot"));
+        assert_eq!(cfg.resolve("sk_ci"), Some("ci"));
+        assert_eq!(cfg.resolve("sk_unknown"), None);
+        assert_eq!(cfg.resolve(""), None);
+    }
+
+    #[test]
+    fn test_reject_duplicate_id() {
+        let body = format!(
+            "[[tenants]]\nid = \"dup\"\nkey_sha256 = \"{}\"\n\n[[tenants]]\nid = \"dup\"\nkey_sha256 = \"{}\"\n",
+            hash_key("a"),
+            hash_key("b")
+        );
+        let f = write_toml(&body);
+        let err = AuthConfig::load(f.path()).unwrap_err();
+        assert!(err.to_string().contains("duplicate tenant id"));
+    }
+
+    #[test]
+    fn test_reject_duplicate_hash() {
+        let body = format!(
+            "[[tenants]]\nid = \"a\"\nkey_sha256 = \"{0}\"\n\n[[tenants]]\nid = \"b\"\nkey_sha256 = \"{0}\"\n",
+            hash_key("same")
+        );
+        let f = write_toml(&body);
+        let err = AuthConfig::load(f.path()).unwrap_err();
+        assert!(err.to_string().contains("duplicate key_sha256"));
+    }
+
+    #[test]
+    fn test_reject_malformed_hash() {
+        let body = "[[tenants]]\nid = \"a\"\nkey_sha256 = \"not-a-real-hash\"\n";
+        let f = write_toml(body);
+        let err = AuthConfig::load(f.path()).unwrap_err();
+        assert!(err.to_string().contains("invalid key_sha256"));
+    }
+
+    #[test]
+    fn test_reject_empty_id() {
+        let body = format!(
+            "[[tenants]]\nid = \"\"\nkey_sha256 = \"{}\"\n",
+            hash_key("x")
+        );
+        let f = write_toml(&body);
+        let err = AuthConfig::load(f.path()).unwrap_err();
+        assert!(err.to_string().contains("empty id"));
+    }
+
+    #[test]
+    fn test_reject_no_tenants() {
+        let f = write_toml("");
+        let err = AuthConfig::load(f.path()).unwrap_err();
+        assert!(err.to_string().contains("no [[tenants]]"));
+    }
+
+    #[test]
+    fn test_reject_malformed_toml() {
+        let f = write_toml("this is not valid toml = = =");
+        let err = AuthConfig::load(f.path()).unwrap_err();
+        assert!(err.to_string().contains("parse"));
+    }
+
+    #[test]
+    fn test_missing_file() {
+        let err = AuthConfig::load(Path::new("/nonexistent/wasmrun-auth.toml")).unwrap_err();
+        assert!(err.to_string().contains("not found"));
+    }
+
+    #[test]
+    fn test_is_sha256_hex() {
+        assert!(is_sha256_hex(&hash_key("anything")));
+        assert!(!is_sha256_hex("short"));
+        assert!(!is_sha256_hex(&"A".repeat(64))); // uppercase rejected
+        assert!(!is_sha256_hex(&"g".repeat(64))); // non-hex rejected
+    }
+}

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -5,6 +5,7 @@
 //! filesystem, environment, and output buffers.
 
 pub mod api;
+pub mod auth;
 pub mod executor;
 pub mod limits;
 pub mod server;

--- a/src/agent/server.rs
+++ b/src/agent/server.rs
@@ -1,6 +1,7 @@
 //! Agent mode: REST API server for AI agent sandbox management.
 
 use crate::agent::api::*;
+use crate::agent::auth::AuthConfig;
 use crate::agent::executor;
 use crate::agent::limits::{dir_size, ResourceLimits};
 use crate::agent::session::{SessionConfig, SessionError, SessionManager, SessionState};
@@ -38,6 +39,10 @@ pub struct AgentConfig {
     /// sessions. `0` = unlimited. Bounds thread / stack / memory footprint
     /// independently of `max_sessions` (which only bounds session count).
     pub max_concurrent_exec: usize,
+    /// API-key authentication. `None` = open mode (no auth; back-compat). When
+    /// `Some`, every `/api/v1/*` request must present a valid `Bearer` key and
+    /// sessions are isolated per tenant.
+    pub auth: Option<Arc<AuthConfig>>,
 }
 
 impl Default for AgentConfig {
@@ -49,6 +54,7 @@ impl Default for AgentConfig {
             verbose: false,
             max_body_bytes: Some(DEFAULT_MAX_BODY_BYTES),
             max_concurrent_exec: DEFAULT_MAX_CONCURRENT_EXEC,
+            auth: None,
         }
     }
 }
@@ -208,6 +214,13 @@ impl AgentServer {
             "   Max concurrent:  {}",
             fmt_count(self.config.max_concurrent_exec, "exec(s)")
         );
+        match &self.config.auth {
+            Some(auth) => println!(
+                "   Auth:            enabled ({} tenants)",
+                auth.tenant_count()
+            ),
+            None => println!("   Auth:            disabled (open)"),
+        }
         println!("   CORS:            {cors}");
         println!();
         println!("   Endpoints:");
@@ -258,6 +271,26 @@ impl AgentServer {
             return self.respond_empty(request, 204);
         }
 
+        // Authentication gate. Resolved once here — after the OPTIONS
+        // short-circuit, before routing — so every handler receives an
+        // already-validated caller. `None` means open mode (no auth config);
+        // `Some(tenant)` is the authenticated tenant id. Auth applies to all
+        // `/api/v1/*` routes including `/tools` (simplest and most secure; it
+        // can be exempted later if a public tool catalog is wanted).
+        let tenant: Option<&str> = match &self.config.auth {
+            None => None,
+            Some(auth) => match bearer_token(&request).and_then(|key| auth.resolve(key)) {
+                Some(t) => Some(t),
+                None => {
+                    let err = ApiError::Unauthorized(
+                        "missing or invalid API key (expected 'Authorization: Bearer <key>')"
+                            .into(),
+                    );
+                    return self.respond_json(request, Err::<serde_json::Value, _>(err));
+                }
+            },
+        };
+
         let (path, query) = split_url(&url);
         let segments: Vec<&str> = path
             .trim_start_matches(API_PREFIX)
@@ -285,39 +318,39 @@ impl AgentServer {
                 self.respond_json(request, self.handle_get_tools(format))
             }
             (Method::Post, ["sessions"]) => {
-                self.respond_json(request, self.handle_create_session_with_body(&body))
+                self.respond_json(request, self.handle_create_session_with_body(&body, tenant))
             }
             (Method::Get, ["sessions", id]) => {
-                self.respond_json(request, self.handle_get_session(id))
+                self.respond_json(request, self.handle_get_session(id, tenant))
             }
             (Method::Delete, ["sessions", id]) => {
-                self.respond_json(request, self.handle_delete_session(id))
+                self.respond_json(request, self.handle_delete_session(id, tenant))
             }
             (Method::Post, ["sessions", id, "exec"]) => {
-                self.respond_json(request, self.handle_exec(id, &body))
+                self.respond_json(request, self.handle_exec(id, &body, tenant))
             }
             (Method::Post, ["sessions", id, "files"]) => {
-                self.respond_json(request, self.handle_write_file(id, &body))
+                self.respond_json(request, self.handle_write_file(id, &body, tenant))
             }
             (Method::Get, ["sessions", id, "files"]) => {
                 let params = parse_query(&query);
                 let path = params.get("path").map(|s| s.as_str()).unwrap_or("/");
                 if params.get("list").map(|v| v == "true").unwrap_or(false) {
-                    self.respond_json(request, self.handle_list_files(id, path))
+                    self.respond_json(request, self.handle_list_files(id, path, tenant))
                 } else {
-                    self.respond_json(request, self.handle_read_file(id, path))
+                    self.respond_json(request, self.handle_read_file(id, path, tenant))
                 }
             }
             (Method::Delete, ["sessions", id, "files"]) => {
                 let params = parse_query(&query);
                 let path = params.get("path").map(|s| s.as_str()).unwrap_or("");
-                self.respond_json(request, self.handle_delete_file(id, path))
+                self.respond_json(request, self.handle_delete_file(id, path, tenant))
             }
             (Method::Post, ["sessions", id, "env"]) => {
-                self.respond_json(request, self.handle_set_env(id, &body))
+                self.respond_json(request, self.handle_set_env(id, &body, tenant))
             }
             (Method::Get, ["sessions", id, "env"]) => {
-                self.respond_json(request, self.handle_get_env(id))
+                self.respond_json(request, self.handle_get_env(id, tenant))
             }
             _ => {
                 let err = ApiError::NotFound(format!("Unknown endpoint: {path}"));
@@ -332,14 +365,16 @@ impl AgentServer {
 
     #[allow(dead_code)] // Used by tests; the HTTP route uses the _with_body variant.
     pub fn handle_create_session(&self) -> std::result::Result<CreateSessionResponse, ApiError> {
-        self.create_session_with_limits(self.config.session_config.limits.clone())
+        self.create_session_with_limits(self.config.session_config.limits.clone(), None)
     }
 
     /// Create a session, applying any per-session limit overrides supplied in
-    /// the (optional) request body on top of the server defaults.
+    /// the (optional) request body on top of the server defaults. `caller` is the
+    /// authenticated tenant that will own the session (`None` in open mode).
     pub fn handle_create_session_with_body(
         &self,
         body: &str,
+        caller: Option<&str>,
     ) -> std::result::Result<CreateSessionResponse, ApiError> {
         let limits = if body.trim().is_empty() {
             self.config.session_config.limits.clone()
@@ -351,16 +386,21 @@ impl AgentServer {
                 None => self.config.session_config.limits.clone(),
             }
         };
-        self.create_session_with_limits(limits)
+        self.create_session_with_limits(limits, caller)
     }
 
     fn create_session_with_limits(
         &self,
         limits: ResourceLimits,
+        owner: Option<&str>,
     ) -> std::result::Result<CreateSessionResponse, ApiError> {
         let id = self
             .session_manager
-            .create_session_with_limits(self.config.session_config.default_timeout, limits)
+            .create_session_with_limits(
+                self.config.session_config.default_timeout,
+                limits,
+                owner.map(String::from),
+            )
             .map_err(map_session_err)?;
         Ok(CreateSessionResponse {
             session_id: id,
@@ -371,9 +411,10 @@ impl AgentServer {
     pub fn handle_get_session(
         &self,
         id: &str,
+        caller: Option<&str>,
     ) -> std::result::Result<SessionStatusResponse, ApiError> {
         self.session_manager
-            .get_session(id, |s| SessionStatusResponse {
+            .get_session(id, caller, |s| SessionStatusResponse {
                 session_id: s.id().to_string(),
                 state: match s.state() {
                     SessionState::Active => "active".into(),
@@ -389,9 +430,10 @@ impl AgentServer {
     pub fn handle_delete_session(
         &self,
         id: &str,
+        caller: Option<&str>,
     ) -> std::result::Result<MessageResponse, ApiError> {
         self.session_manager
-            .destroy_session(id)
+            .destroy_session(id, caller)
             .map_err(map_session_err)?;
         Ok(MessageResponse {
             message: format!("Session {id} destroyed"),
@@ -400,13 +442,18 @@ impl AgentServer {
 
     // ── Exec endpoint ─────────────────────────────────────────────
 
-    pub fn handle_exec(&self, id: &str, body: &str) -> std::result::Result<ExecResponse, ApiError> {
+    pub fn handle_exec(
+        &self,
+        id: &str,
+        body: &str,
+        caller: Option<&str>,
+    ) -> std::result::Result<ExecResponse, ApiError> {
         let req: ExecRequest =
             serde_json::from_str(body).map_err(|e| ApiError::BadRequest(e.to_string()))?;
 
         let (wasi_env, work_dir, limits) = self
             .session_manager
-            .get_session(id, |s| {
+            .get_session(id, caller, |s| {
                 (s.wasi_env(), s.work_dir().to_path_buf(), s.limits().clone())
             })
             .map_err(map_session_err)?;
@@ -612,13 +659,16 @@ impl AgentServer {
         &self,
         id: &str,
         body: &str,
+        caller: Option<&str>,
     ) -> std::result::Result<MessageResponse, ApiError> {
         let req: WriteFileRequest =
             serde_json::from_str(body).map_err(|e| ApiError::BadRequest(e.to_string()))?;
 
         let (work_dir, limits) = self
             .session_manager
-            .get_session(id, |s| (s.work_dir().to_path_buf(), s.limits().clone()))
+            .get_session(id, caller, |s| {
+                (s.work_dir().to_path_buf(), s.limits().clone())
+            })
             .map_err(map_session_err)?;
 
         let resolved = resolve_session_path(&work_dir, &req.path)?;
@@ -646,10 +696,11 @@ impl AgentServer {
         &self,
         id: &str,
         path: &str,
+        caller: Option<&str>,
     ) -> std::result::Result<ReadFileResponse, ApiError> {
         let work_dir = self
             .session_manager
-            .get_session(id, |s| s.work_dir().to_path_buf())
+            .get_session(id, caller, |s| s.work_dir().to_path_buf())
             .map_err(map_session_err)?;
 
         let resolved = resolve_session_path(&work_dir, path)?;
@@ -666,10 +717,11 @@ impl AgentServer {
         &self,
         id: &str,
         path: &str,
+        caller: Option<&str>,
     ) -> std::result::Result<ListFilesResponse, ApiError> {
         let work_dir = self
             .session_manager
-            .get_session(id, |s| s.work_dir().to_path_buf())
+            .get_session(id, caller, |s| s.work_dir().to_path_buf())
             .map_err(map_session_err)?;
 
         let resolved = resolve_session_path(&work_dir, path)?;
@@ -696,6 +748,7 @@ impl AgentServer {
         &self,
         id: &str,
         path: &str,
+        caller: Option<&str>,
     ) -> std::result::Result<MessageResponse, ApiError> {
         if path.is_empty() {
             return Err(ApiError::BadRequest("Missing path parameter".into()));
@@ -703,7 +756,7 @@ impl AgentServer {
 
         let work_dir = self
             .session_manager
-            .get_session(id, |s| s.work_dir().to_path_buf())
+            .get_session(id, caller, |s| s.work_dir().to_path_buf())
             .map_err(map_session_err)?;
 
         let resolved = resolve_session_path(&work_dir, path)?;
@@ -727,12 +780,13 @@ impl AgentServer {
         &self,
         id: &str,
         body: &str,
+        caller: Option<&str>,
     ) -> std::result::Result<MessageResponse, ApiError> {
         let vars: HashMap<String, String> =
             serde_json::from_str(body).map_err(|e| ApiError::BadRequest(e.to_string()))?;
 
         self.session_manager
-            .get_session(id, |s| {
+            .get_session(id, caller, |s| {
                 for (k, v) in &vars {
                     s.set_env(k, v);
                 }
@@ -744,10 +798,14 @@ impl AgentServer {
         })
     }
 
-    pub fn handle_get_env(&self, id: &str) -> std::result::Result<EnvVarsResponse, ApiError> {
+    pub fn handle_get_env(
+        &self,
+        id: &str,
+        caller: Option<&str>,
+    ) -> std::result::Result<EnvVarsResponse, ApiError> {
         let env = self
             .session_manager
-            .get_session(id, |s| {
+            .get_session(id, caller, |s| {
                 let wasi = s.wasi_env();
                 let locked = wasi.lock().unwrap();
                 locked
@@ -853,6 +911,24 @@ fn map_session_err(e: SessionError) -> ApiError {
         SessionError::IoError { message } => ApiError::Internal(message),
         SessionError::LockError => ApiError::Internal("Lock error".into()),
     }
+}
+
+/// Extract the bearer token from a request's `Authorization` header.
+///
+/// Returns `Some(token)` only for a well-formed `Authorization: Bearer <token>`
+/// with a non-empty token. The header name and the `Bearer` scheme are matched
+/// case-insensitively (per RFC 7235); the token itself is taken verbatim.
+fn bearer_token(request: &Request) -> Option<&str> {
+    let header = request
+        .headers()
+        .iter()
+        .find(|h| h.field.equiv("Authorization"))?;
+    let (scheme, token) = header.value.as_str().split_once(' ')?;
+    if !scheme.eq_ignore_ascii_case("Bearer") {
+        return None;
+    }
+    let token = token.trim();
+    (!token.is_empty()).then_some(token)
 }
 
 fn resolve_session_path(
@@ -988,6 +1064,43 @@ mod tests {
             verbose: false,
             max_body_bytes: Some(32 * 1024 * 1024),
             max_concurrent_exec,
+            auth: None,
+        })
+    }
+
+    /// Build an `AuthConfig` for the given `(key, tenant_id)` pairs by round-
+    /// tripping through a TOML file (exercises the real `load` path).
+    fn auth_config_for(tenants: &[(&str, &str)]) -> AuthConfig {
+        use crate::agent::auth::hash_key;
+        let toml = tenants
+            .iter()
+            .map(|(key, id)| {
+                format!(
+                    "[[tenants]]\nid = \"{id}\"\nkey_sha256 = \"{}\"\n",
+                    hash_key(key)
+                )
+            })
+            .collect::<String>();
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        std::io::Write::write_all(&mut f, toml.as_bytes()).unwrap();
+        AuthConfig::load(f.path()).unwrap()
+    }
+
+    /// A server on `port` with auth enabled for the given `(key, tenant_id)` pairs.
+    fn auth_server(port: u16, tenants: &[(&str, &str)]) -> AgentServer {
+        AgentServer::new(AgentConfig {
+            port,
+            session_config: SessionConfig {
+                default_timeout: Duration::from_secs(60),
+                max_sessions: 10,
+                cleanup_interval: Duration::from_secs(300),
+                limits: crate::agent::limits::ResourceLimits::default(),
+            },
+            allow_cors: true,
+            verbose: false,
+            max_body_bytes: Some(32 * 1024 * 1024),
+            max_concurrent_exec: 100,
+            auth: Some(Arc::new(auth_config_for(tenants))),
         })
     }
 
@@ -1040,7 +1153,7 @@ mod tests {
     fn test_get_session() {
         let server = test_server();
         let id = server.handle_create_session().unwrap().session_id;
-        let resp = server.handle_get_session(&id).unwrap();
+        let resp = server.handle_get_session(&id, None).unwrap();
         assert_eq!(resp.session_id, id);
         assert_eq!(resp.state, "active");
         server.session_manager.destroy_all().unwrap();
@@ -1050,14 +1163,14 @@ mod tests {
     fn test_delete_session() {
         let server = test_server();
         let id = server.handle_create_session().unwrap().session_id;
-        server.handle_delete_session(&id).unwrap();
-        assert!(server.handle_get_session(&id).is_err());
+        server.handle_delete_session(&id, None).unwrap();
+        assert!(server.handle_get_session(&id, None).is_err());
     }
 
     #[test]
     fn test_session_not_found() {
         let server = test_server();
-        let err = server.handle_get_session("nonexistent").unwrap_err();
+        let err = server.handle_get_session("nonexistent", None).unwrap_err();
         assert_eq!(err.status_code(), 404);
     }
 
@@ -1069,10 +1182,14 @@ mod tests {
         let id = server.handle_create_session().unwrap().session_id;
 
         server
-            .handle_write_file(&id, r#"{"path": "test.txt", "content": "hello agent"}"#)
+            .handle_write_file(
+                &id,
+                r#"{"path": "test.txt", "content": "hello agent"}"#,
+                None,
+            )
             .unwrap();
 
-        let resp = server.handle_read_file(&id, "test.txt").unwrap();
+        let resp = server.handle_read_file(&id, "test.txt", None).unwrap();
         assert_eq!(resp.content, "hello agent");
 
         server.session_manager.destroy_all().unwrap();
@@ -1084,10 +1201,16 @@ mod tests {
         let id = server.handle_create_session().unwrap().session_id;
 
         server
-            .handle_write_file(&id, r#"{"path": "sub/dir/file.txt", "content": "nested"}"#)
+            .handle_write_file(
+                &id,
+                r#"{"path": "sub/dir/file.txt", "content": "nested"}"#,
+                None,
+            )
             .unwrap();
 
-        let resp = server.handle_read_file(&id, "sub/dir/file.txt").unwrap();
+        let resp = server
+            .handle_read_file(&id, "sub/dir/file.txt", None)
+            .unwrap();
         assert_eq!(resp.content, "nested");
 
         server.session_manager.destroy_all().unwrap();
@@ -1099,13 +1222,13 @@ mod tests {
         let id = server.handle_create_session().unwrap().session_id;
 
         server
-            .handle_write_file(&id, r#"{"path": "a.txt", "content": "a"}"#)
+            .handle_write_file(&id, r#"{"path": "a.txt", "content": "a"}"#, None)
             .unwrap();
         server
-            .handle_write_file(&id, r#"{"path": "b.txt", "content": "bb"}"#)
+            .handle_write_file(&id, r#"{"path": "b.txt", "content": "bb"}"#, None)
             .unwrap();
 
-        let resp = server.handle_list_files(&id, "/").unwrap();
+        let resp = server.handle_list_files(&id, "/", None).unwrap();
         assert_eq!(resp.entries.len(), 2);
 
         let names: Vec<&str> = resp.entries.iter().map(|e| e.name.as_str()).collect();
@@ -1121,11 +1244,11 @@ mod tests {
         let id = server.handle_create_session().unwrap().session_id;
 
         server
-            .handle_write_file(&id, r#"{"path": "del.txt", "content": "x"}"#)
+            .handle_write_file(&id, r#"{"path": "del.txt", "content": "x"}"#, None)
             .unwrap();
 
-        server.handle_delete_file(&id, "del.txt").unwrap();
-        assert!(server.handle_read_file(&id, "del.txt").is_err());
+        server.handle_delete_file(&id, "del.txt", None).unwrap();
+        assert!(server.handle_read_file(&id, "del.txt", None).is_err());
 
         server.session_manager.destroy_all().unwrap();
     }
@@ -1134,7 +1257,7 @@ mod tests {
     fn test_read_nonexistent_file() {
         let server = test_server();
         let id = server.handle_create_session().unwrap().session_id;
-        let err = server.handle_read_file(&id, "nope.txt").unwrap_err();
+        let err = server.handle_read_file(&id, "nope.txt", None).unwrap_err();
         assert_eq!(err.status_code(), 404);
         server.session_manager.destroy_all().unwrap();
     }
@@ -1144,7 +1267,7 @@ mod tests {
         let server = test_server();
         let id = server.handle_create_session().unwrap().session_id;
         let err = server
-            .handle_read_file(&id, "../../../etc/passwd")
+            .handle_read_file(&id, "../../../etc/passwd", None)
             .unwrap_err();
         assert_eq!(err.status_code(), 400);
         server.session_manager.destroy_all().unwrap();
@@ -1158,10 +1281,10 @@ mod tests {
         let id = server.handle_create_session().unwrap().session_id;
 
         server
-            .handle_set_env(&id, r#"{"FOO": "bar", "BAZ": "qux"}"#)
+            .handle_set_env(&id, r#"{"FOO": "bar", "BAZ": "qux"}"#, None)
             .unwrap();
 
-        let resp = server.handle_get_env(&id).unwrap();
+        let resp = server.handle_get_env(&id, None).unwrap();
         assert_eq!(resp.env.get("FOO").unwrap(), "bar");
         assert_eq!(resp.env.get("BAZ").unwrap(), "qux");
 
@@ -1179,12 +1302,12 @@ mod tests {
         let wasm = hello_wasm();
         let work_dir = server
             .session_manager
-            .get_session(&id, |s| s.work_dir().to_path_buf())
+            .get_session(&id, None, |s| s.work_dir().to_path_buf())
             .unwrap();
         std::fs::write(work_dir.join("hello.wasm"), &wasm).unwrap();
 
         let resp = server
-            .handle_exec(&id, r#"{"wasm_path": "hello.wasm"}"#)
+            .handle_exec(&id, r#"{"wasm_path": "hello.wasm"}"#, None)
             .unwrap();
 
         assert_eq!(resp.stdout, "Hello, World!\n");
@@ -1201,7 +1324,7 @@ mod tests {
         let id = server.handle_create_session().unwrap().session_id;
 
         let err = server
-            .handle_exec(&id, r#"{"wasm_path": "nope.wasm"}"#)
+            .handle_exec(&id, r#"{"wasm_path": "nope.wasm"}"#, None)
             .unwrap_err();
         assert_eq!(err.status_code(), 404);
 
@@ -1213,7 +1336,7 @@ mod tests {
         let server = test_server();
         let id = server.handle_create_session().unwrap().session_id;
 
-        let err = server.handle_exec(&id, r#"{}"#).unwrap_err();
+        let err = server.handle_exec(&id, r#"{}"#, None).unwrap_err();
         assert_eq!(err.status_code(), 400);
         assert!(err.to_string().contains("wasm_path") || err.to_string().contains("source"));
 
@@ -1227,7 +1350,11 @@ mod tests {
 
         // Python is not supported yet — should fail immediately without network I/O
         let err = server
-            .handle_exec(&id, r#"{"source": "print('hello')", "language": "python"}"#)
+            .handle_exec(
+                &id,
+                r#"{"source": "print('hello')", "language": "python"}"#,
+                None,
+            )
             .unwrap_err();
         assert_eq!(err.status_code(), 400);
         assert!(err.to_string().contains("python"));
@@ -1241,7 +1368,7 @@ mod tests {
         let id = server.handle_create_session().unwrap().session_id;
 
         let body = r#"{"files": {"main.js": "console.log(1)"}}"#;
-        let err = server.handle_exec(&id, body).unwrap_err();
+        let err = server.handle_exec(&id, body, None).unwrap_err();
         assert_eq!(err.status_code(), 400);
         assert!(err.to_string().contains("entry"));
 
@@ -1254,7 +1381,7 @@ mod tests {
         let id = server.handle_create_session().unwrap().session_id;
 
         let body = r#"{"files": {"main.js": "x"}, "entry": "missing.js"}"#;
-        let err = server.handle_exec(&id, body).unwrap_err();
+        let err = server.handle_exec(&id, body, None).unwrap_err();
         assert_eq!(err.status_code(), 400);
         assert!(err.to_string().contains("missing.js"));
 
@@ -1267,7 +1394,7 @@ mod tests {
         let id = server.handle_create_session().unwrap().session_id;
 
         let body = r#"{"files": {"a.py": "print(1)"}, "entry": "a.py", "language": "python"}"#;
-        let err = server.handle_exec(&id, body).unwrap_err();
+        let err = server.handle_exec(&id, body, None).unwrap_err();
         assert_eq!(err.status_code(), 400);
         assert!(err.to_string().contains("python"));
 
@@ -1296,7 +1423,7 @@ mod tests {
             "entry": "main.js",
             "timeout": 60
         }"#;
-        let resp = server.handle_exec(&id, body).unwrap();
+        let resp = server.handle_exec(&id, body, None).unwrap();
         assert_eq!(
             resp.exit_code, 0,
             "exit_code != 0; stderr: {}; error: {:?}",
@@ -1309,7 +1436,7 @@ mod tests {
         );
 
         // Verify the sibling file was actually written to the session FS
-        let extra = server.handle_read_file(&id, "extra.js").unwrap();
+        let extra = server.handle_read_file(&id, "extra.js", None).unwrap();
         assert!(extra.content.contains("sibling file"));
 
         server.session_manager.destroy_all().unwrap();
@@ -1324,7 +1451,7 @@ mod tests {
         // return Ok (any runtime fetch failure surfaces as ExecResponse.error,
         // not an ApiError from handle_exec itself).
         let body = r#"{"files": {"main.js": "console.log('ok')"}, "entry": "main.js"}"#;
-        let result = server.handle_exec(&id, body);
+        let result = server.handle_exec(&id, body, None);
         assert!(
             result.is_ok(),
             "valid files+entry should not return ApiError, got: {result:?}"
@@ -1343,7 +1470,7 @@ mod tests {
         // but we verify the request parses and reaches the execution stage (not a 400).
         // The exec thread may return an Internal error if the runtime is unavailable, which
         // surfaces as ExecResponse.error — not an ApiError from handle_exec itself.
-        let result = server.handle_exec(&id, r#"{"source": "1+1"}"#);
+        let result = server.handle_exec(&id, r#"{"source": "1+1"}"#, None);
         assert!(
             result.is_ok(),
             "default language should not return ApiError"
@@ -1360,7 +1487,7 @@ mod tests {
         let id = server.handle_create_session().unwrap().session_id;
 
         let resp = server
-            .handle_exec(&id, r#"{"command": "echo hello"}"#)
+            .handle_exec(&id, r#"{"command": "echo hello"}"#, None)
             .unwrap();
         assert_eq!(resp.exit_code, 0);
         assert_eq!(resp.stdout, "hello\n");
@@ -1378,13 +1505,14 @@ mod tests {
             .handle_exec(
                 &id,
                 r#"{"command": "echo persisted > log.txt && cat log.txt"}"#,
+                None,
             )
             .unwrap();
         assert_eq!(resp.exit_code, 0);
         assert_eq!(resp.stdout, "persisted\n");
 
         // Verify the file is actually in the session work_dir
-        let content = server.handle_read_file(&id, "log.txt").unwrap();
+        let content = server.handle_read_file(&id, "log.txt", None).unwrap();
         assert_eq!(content.content, "persisted\n");
 
         server.session_manager.destroy_all().unwrap();
@@ -1400,6 +1528,7 @@ mod tests {
             .handle_exec(
                 &id,
                 r#"{"command": "echo first", "wasm_path": "nope.wasm"}"#,
+                None,
             )
             .unwrap();
         assert_eq!(resp.exit_code, 0);
@@ -1415,10 +1544,10 @@ mod tests {
 
         // Export via shell, then verify it shows up through the env endpoint.
         server
-            .handle_exec(&id, r#"{"command": "export GREETING=hi"}"#)
+            .handle_exec(&id, r#"{"command": "export GREETING=hi"}"#, None)
             .unwrap();
 
-        let env = server.handle_get_env(&id).unwrap();
+        let env = server.handle_get_env(&id, None).unwrap();
         assert_eq!(env.env.get("GREETING").map(|s| s.as_str()), Some("hi"));
 
         server.session_manager.destroy_all().unwrap();
@@ -1431,7 +1560,7 @@ mod tests {
 
         // Unclosed quote → parse error → BadRequest
         let resp = server
-            .handle_exec(&id, r#"{"command": "echo \"oops"}"#)
+            .handle_exec(&id, r#"{"command": "echo \"oops"}"#, None)
             .unwrap();
         // Parse error is surfaced via ExecResponse.error from the exec thread.
         assert_eq!(resp.exit_code, -1);
@@ -1448,19 +1577,19 @@ mod tests {
         let wasm = hello_wasm();
         let work_dir = server
             .session_manager
-            .get_session(&id, |s| s.work_dir().to_path_buf())
+            .get_session(&id, None, |s| s.work_dir().to_path_buf())
             .unwrap();
         std::fs::write(work_dir.join("hello.wasm"), &wasm).unwrap();
 
         // First exec
         let resp1 = server
-            .handle_exec(&id, r#"{"wasm_path": "hello.wasm"}"#)
+            .handle_exec(&id, r#"{"wasm_path": "hello.wasm"}"#, None)
             .unwrap();
         assert_eq!(resp1.stdout, "Hello, World!\n");
 
         // Second exec should not accumulate
         let resp2 = server
-            .handle_exec(&id, r#"{"wasm_path": "hello.wasm"}"#)
+            .handle_exec(&id, r#"{"wasm_path": "hello.wasm"}"#, None)
             .unwrap();
         assert_eq!(resp2.stdout, "Hello, World!\n");
 
@@ -1477,43 +1606,45 @@ mod tests {
         let id = server.handle_create_session().unwrap().session_id;
 
         // 2. Set env
-        server.handle_set_env(&id, r#"{"APP": "test"}"#).unwrap();
+        server
+            .handle_set_env(&id, r#"{"APP": "test"}"#, None)
+            .unwrap();
 
         // 3. Write WASM file
         let wasm = hello_wasm();
         let work_dir = server
             .session_manager
-            .get_session(&id, |s| s.work_dir().to_path_buf())
+            .get_session(&id, None, |s| s.work_dir().to_path_buf())
             .unwrap();
         std::fs::write(work_dir.join("hello.wasm"), &wasm).unwrap();
 
         // 4. Write a data file
         server
-            .handle_write_file(&id, r#"{"path": "data.txt", "content": "test data"}"#)
+            .handle_write_file(&id, r#"{"path": "data.txt", "content": "test data"}"#, None)
             .unwrap();
 
         // 5. List files
-        let files = server.handle_list_files(&id, "/").unwrap();
+        let files = server.handle_list_files(&id, "/", None).unwrap();
         assert!(files.entries.len() >= 2);
 
         // 6. Execute WASM
         let exec = server
-            .handle_exec(&id, r#"{"wasm_path": "hello.wasm"}"#)
+            .handle_exec(&id, r#"{"wasm_path": "hello.wasm"}"#, None)
             .unwrap();
         assert_eq!(exec.stdout, "Hello, World!\n");
         assert_eq!(exec.exit_code, 0);
 
         // 7. Read file back
-        let content = server.handle_read_file(&id, "data.txt").unwrap();
+        let content = server.handle_read_file(&id, "data.txt", None).unwrap();
         assert_eq!(content.content, "test data");
 
         // 8. Check env
-        let env = server.handle_get_env(&id).unwrap();
+        let env = server.handle_get_env(&id, None).unwrap();
         assert_eq!(env.env.get("APP").unwrap(), "test");
 
         // 9. Destroy
-        server.handle_delete_session(&id).unwrap();
-        assert!(server.handle_get_session(&id).is_err());
+        server.handle_delete_session(&id, None).unwrap();
+        assert!(server.handle_get_session(&id, None).is_err());
     }
 
     // ── Concurrent sessions ───────────────────────────────────────
@@ -1532,22 +1663,22 @@ mod tests {
 
                     // Each session writes its own file
                     let body = format!(r#"{{"path": "id.txt", "content": "session-{i}"}}"#);
-                    srv.handle_write_file(&id, &body).unwrap();
+                    srv.handle_write_file(&id, &body, None).unwrap();
 
                     // Write and exec WASM
                     let work_dir = srv
                         .session_manager
-                        .get_session(&id, |s| s.work_dir().to_path_buf())
+                        .get_session(&id, None, |s| s.work_dir().to_path_buf())
                         .unwrap();
                     std::fs::write(work_dir.join("hello.wasm"), &wasm).unwrap();
 
                     let exec = srv
-                        .handle_exec(&id, r#"{"wasm_path": "hello.wasm"}"#)
+                        .handle_exec(&id, r#"{"wasm_path": "hello.wasm"}"#, None)
                         .unwrap();
                     assert_eq!(exec.stdout, "Hello, World!\n");
 
                     // Verify isolation
-                    let content = srv.handle_read_file(&id, "id.txt").unwrap();
+                    let content = srv.handle_read_file(&id, "id.txt", None).unwrap();
                     assert_eq!(content.content, format!("session-{i}"));
 
                     id
@@ -1686,7 +1817,7 @@ mod tests {
     fn make_session_with_limits(server: &AgentServer, limits: ResourceLimits) -> String {
         server
             .session_manager
-            .create_session_with_limits(Duration::from_secs(60), limits)
+            .create_session_with_limits(Duration::from_secs(60), limits, None)
             .unwrap()
     }
 
@@ -1695,13 +1826,13 @@ mod tests {
         let server = test_server();
         let body = r#"{"limits":{"max_fuel":500,"max_output_mb":0,"max_file_size_mb":1}}"#;
         let id = server
-            .handle_create_session_with_body(body)
+            .handle_create_session_with_body(body, None)
             .unwrap()
             .session_id;
 
         let limits = server
             .session_manager
-            .get_session(&id, |s| s.limits().clone())
+            .get_session(&id, None, |s| s.limits().clone())
             .unwrap();
         assert_eq!(limits.max_fuel, Some(500));
         assert_eq!(limits.max_output_bytes, None); // 0 disables the cap
@@ -1719,12 +1850,12 @@ mod tests {
     fn test_create_session_empty_body_uses_defaults() {
         let server = test_server();
         let id = server
-            .handle_create_session_with_body("")
+            .handle_create_session_with_body("", None)
             .unwrap()
             .session_id;
         let limits = server
             .session_manager
-            .get_session(&id, |s| s.limits().clone())
+            .get_session(&id, None, |s| s.limits().clone())
             .unwrap();
         assert_eq!(limits, server.config.session_config.limits);
         server.session_manager.destroy_all().unwrap();
@@ -1734,7 +1865,7 @@ mod tests {
     fn test_create_session_invalid_limits_body_returns_400() {
         let server = test_server();
         let err = server
-            .handle_create_session_with_body(r#"{"limits": "not-an-object"}"#)
+            .handle_create_session_with_body(r#"{"limits": "not-an-object"}"#, None)
             .unwrap_err();
         assert_eq!(err.status_code(), 400);
     }
@@ -1753,6 +1884,7 @@ mod tests {
             .handle_write_file(
                 &id,
                 r#"{"path": "big.txt", "content": "this is more than ten bytes"}"#,
+                None,
             )
             .unwrap_err();
         assert_eq!(err.status_code(), 400);
@@ -1773,11 +1905,11 @@ mod tests {
 
         // First 5-byte file fits (5 <= 10).
         server
-            .handle_write_file(&id, r#"{"path": "a.txt", "content": "12345"}"#)
+            .handle_write_file(&id, r#"{"path": "a.txt", "content": "12345"}"#, None)
             .unwrap();
         // Second 6-byte file pushes total to 11 > 10 → rejected.
         let err = server
-            .handle_write_file(&id, r#"{"path": "b.txt", "content": "678901"}"#)
+            .handle_write_file(&id, r#"{"path": "b.txt", "content": "678901"}"#, None)
             .unwrap_err();
         assert_eq!(err.status_code(), 400);
         assert!(err.to_string().contains("Disk usage limit"));
@@ -1796,7 +1928,7 @@ mod tests {
 
         // "echo hello" emits "hello\n" (6 bytes); capped to 3.
         let resp = server
-            .handle_exec(&id, r#"{"command": "echo hello"}"#)
+            .handle_exec(&id, r#"{"command": "echo hello"}"#, None)
             .unwrap();
         assert_eq!(resp.stdout, "hel");
         assert!(resp.output_truncated);
@@ -1815,13 +1947,13 @@ mod tests {
 
         let work_dir = server
             .session_manager
-            .get_session(&id, |s| s.work_dir().to_path_buf())
+            .get_session(&id, None, |s| s.work_dir().to_path_buf())
             .unwrap();
         std::fs::write(work_dir.join("loop.wasm"), infinite_loop_wasm()).unwrap();
 
         // With a fuel cap the runaway loop aborts well before the exec timeout.
         let resp = server
-            .handle_exec(&id, r#"{"wasm_path": "loop.wasm", "timeout": 30}"#)
+            .handle_exec(&id, r#"{"wasm_path": "loop.wasm", "timeout": 30}"#, None)
             .unwrap();
         assert_eq!(resp.exit_code, -1);
         let err = resp.error.unwrap_or_default();
@@ -1848,13 +1980,13 @@ mod tests {
 
         let work_dir = server
             .session_manager
-            .get_session(&id, |s| s.work_dir().to_path_buf())
+            .get_session(&id, None, |s| s.work_dir().to_path_buf())
             .unwrap();
         std::fs::write(work_dir.join("loop.wasm"), infinite_loop_wasm()).unwrap();
         std::fs::write(work_dir.join("hello.wasm"), hello_wasm()).unwrap();
 
         let resp = server
-            .handle_exec(&id, r#"{"wasm_path": "loop.wasm", "timeout": 1}"#)
+            .handle_exec(&id, r#"{"wasm_path": "loop.wasm", "timeout": 1}"#, None)
             .unwrap();
         assert_eq!(resp.exit_code, -1);
         assert!(
@@ -1867,7 +1999,7 @@ mod tests {
         // The session is still usable: a normal exec runs and returns promptly,
         // which it could not if the runaway worker were still pinning the core.
         let ok = server
-            .handle_exec(&id, r#"{"wasm_path": "hello.wasm", "timeout": 10}"#)
+            .handle_exec(&id, r#"{"wasm_path": "hello.wasm", "timeout": 10}"#, None)
             .unwrap();
         assert_eq!(ok.stdout, "Hello, World!\n");
         assert_eq!(ok.exit_code, 0);
@@ -1936,14 +2068,14 @@ mod tests {
         let id = server.handle_create_session().unwrap().session_id;
         let work_dir = server
             .session_manager
-            .get_session(&id, |s| s.work_dir().to_path_buf())
+            .get_session(&id, None, |s| s.work_dir().to_path_buf())
             .unwrap();
         std::fs::write(work_dir.join("hello.wasm"), hello_wasm()).unwrap();
 
         // Hold the only slot to simulate a worker already in flight.
         let held = server.exec_slots.try_acquire().unwrap();
         let err = server
-            .handle_exec(&id, r#"{"wasm_path": "hello.wasm"}"#)
+            .handle_exec(&id, r#"{"wasm_path": "hello.wasm"}"#, None)
             .unwrap_err();
         assert_eq!(err.status_code(), 429);
         assert!(matches!(err, ApiError::TooManyRequests(1)));
@@ -1951,7 +2083,7 @@ mod tests {
         // Releasing the slot lets the next exec through.
         drop(held);
         let ok = server
-            .handle_exec(&id, r#"{"wasm_path": "hello.wasm"}"#)
+            .handle_exec(&id, r#"{"wasm_path": "hello.wasm"}"#, None)
             .unwrap();
         assert_eq!(ok.exit_code, 0);
 
@@ -1967,13 +2099,13 @@ mod tests {
         let id = server.handle_create_session().unwrap().session_id;
         let work_dir = server
             .session_manager
-            .get_session(&id, |s| s.work_dir().to_path_buf())
+            .get_session(&id, None, |s| s.work_dir().to_path_buf())
             .unwrap();
         std::fs::write(work_dir.join("hello.wasm"), hello_wasm()).unwrap();
 
         for _ in 0..3 {
             let ok = server
-                .handle_exec(&id, r#"{"wasm_path": "hello.wasm"}"#)
+                .handle_exec(&id, r#"{"wasm_path": "hello.wasm"}"#, None)
                 .unwrap();
             assert_eq!(ok.exit_code, 0);
         }
@@ -1981,5 +2113,248 @@ mod tests {
         assert!(server.exec_slots.try_acquire().is_some());
 
         server.session_manager.destroy_all().unwrap();
+    }
+
+    // ── Authentication & tenant isolation ─────────────────────────
+
+    #[test]
+    fn test_disabled_auth_stamps_no_owner() {
+        // Open mode (no auth): sessions have no owner; the keyless path is
+        // unchanged. (The rest of the suite exercises this implicitly.)
+        let server = test_server();
+        let id = server.handle_create_session().unwrap().session_id;
+        let owner = server
+            .session_manager
+            .get_session(&id, None, |s| s.owner().map(str::to_string))
+            .unwrap();
+        assert_eq!(owner, None);
+        server.session_manager.destroy_all().unwrap();
+    }
+
+    #[test]
+    fn test_handler_tenant_isolation() {
+        let server = test_server();
+
+        // Tenant "alice" creates and populates a session.
+        let id = server
+            .handle_create_session_with_body("", Some("alice"))
+            .unwrap()
+            .session_id;
+        let owner = server
+            .session_manager
+            .get_session(&id, Some("alice"), |s| s.owner().map(str::to_string))
+            .unwrap();
+        assert_eq!(owner, Some("alice".to_string()));
+
+        server
+            .handle_write_file(&id, r#"{"path": "a.txt", "content": "hi"}"#, Some("alice"))
+            .unwrap();
+        assert!(server.handle_get_session(&id, Some("alice")).is_ok());
+        assert!(server.handle_read_file(&id, "a.txt", Some("alice")).is_ok());
+
+        // Tenant "bob" sees 404 on every operation against alice's session.
+        let bob = Some("bob");
+        assert_eq!(
+            server
+                .handle_get_session(&id, bob)
+                .unwrap_err()
+                .status_code(),
+            404
+        );
+        assert_eq!(
+            server
+                .handle_exec(&id, r#"{"command": "echo hi"}"#, bob)
+                .unwrap_err()
+                .status_code(),
+            404
+        );
+        assert_eq!(
+            server
+                .handle_read_file(&id, "a.txt", bob)
+                .unwrap_err()
+                .status_code(),
+            404
+        );
+        assert_eq!(
+            server
+                .handle_write_file(&id, r#"{"path": "x", "content": "y"}"#, bob)
+                .unwrap_err()
+                .status_code(),
+            404
+        );
+        assert_eq!(
+            server
+                .handle_list_files(&id, "/", bob)
+                .unwrap_err()
+                .status_code(),
+            404
+        );
+        assert_eq!(
+            server
+                .handle_delete_file(&id, "a.txt", bob)
+                .unwrap_err()
+                .status_code(),
+            404
+        );
+        assert_eq!(
+            server
+                .handle_set_env(&id, r#"{"K": "V"}"#, bob)
+                .unwrap_err()
+                .status_code(),
+            404
+        );
+        assert_eq!(
+            server.handle_get_env(&id, bob).unwrap_err().status_code(),
+            404
+        );
+        assert_eq!(
+            server
+                .handle_delete_session(&id, bob)
+                .unwrap_err()
+                .status_code(),
+            404
+        );
+
+        // Open-mode caller (None) is also blocked from an owned session.
+        assert_eq!(
+            server
+                .handle_get_session(&id, None)
+                .unwrap_err()
+                .status_code(),
+            404
+        );
+
+        // bob's failed delete did not destroy the session; alice still owns it.
+        assert!(server.handle_delete_session(&id, Some("alice")).is_ok());
+
+        server.session_manager.destroy_all().unwrap();
+    }
+
+    /// Status code of a ureq result, treating 4xx/5xx (returned as `Err`) and
+    /// 2xx alike so assertions can compare the numeric code.
+    fn http_status(r: std::result::Result<ureq::http::Response<ureq::Body>, ureq::Error>) -> u16 {
+        match r {
+            Ok(resp) => resp.status().as_u16(),
+            Err(ureq::Error::StatusCode(code)) => code,
+            Err(e) => panic!("transport error: {e}"),
+        }
+    }
+
+    #[test]
+    fn test_auth_gate_and_isolation_over_http() {
+        use std::io::Read;
+
+        // Grab a free port, then release it for the server to bind.
+        let port = std::net::TcpListener::bind("127.0.0.1:0")
+            .unwrap()
+            .local_addr()
+            .unwrap()
+            .port();
+
+        let server = auth_server(port, &[("key_a", "alice"), ("key_b", "bob")]);
+        std::thread::spawn(move || {
+            let _ = server.start();
+        });
+
+        let base = format!("http://127.0.0.1:{port}/api/v1");
+
+        // Wait until the listener is accepting (any HTTP response, incl. 401).
+        for _ in 0..100 {
+            match ureq::get(format!("{base}/tools")).call() {
+                Err(ureq::Error::Io(_)) => std::thread::sleep(Duration::from_millis(20)),
+                _ => break,
+            }
+        }
+
+        let sessions = format!("{base}/sessions");
+
+        // Missing header → 401.
+        assert_eq!(http_status(ureq::post(&sessions).send_empty()), 401);
+        // Wrong scheme → 401.
+        assert_eq!(
+            http_status(
+                ureq::post(&sessions)
+                    .header("Authorization", "Token key_a")
+                    .send_empty()
+            ),
+            401
+        );
+        // Unknown key → 401.
+        assert_eq!(
+            http_status(
+                ureq::post(&sessions)
+                    .header("Authorization", "Bearer nope")
+                    .send_empty()
+            ),
+            401
+        );
+        // /tools is gated too: no key → 401, valid key → 200.
+        assert_eq!(http_status(ureq::get(format!("{base}/tools")).call()), 401);
+        assert_eq!(
+            http_status(
+                ureq::get(format!("{base}/tools"))
+                    .header("Authorization", "Bearer key_a")
+                    .call()
+            ),
+            200
+        );
+
+        // Valid key → 200; capture the session id.
+        let mut resp = ureq::post(&sessions)
+            .header("Authorization", "Bearer key_a")
+            .send_empty()
+            .unwrap();
+        let mut body = String::new();
+        resp.body_mut()
+            .as_reader()
+            .read_to_string(&mut body)
+            .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&body).unwrap();
+        let id = v["session_id"].as_str().unwrap().to_string();
+
+        let one = format!("{base}/sessions/{id}");
+
+        // Owner (alice) → 200; other tenant (bob) → 404 across read/exec/delete.
+        assert_eq!(
+            http_status(
+                ureq::get(&one)
+                    .header("Authorization", "Bearer key_a")
+                    .call()
+            ),
+            200
+        );
+        assert_eq!(
+            http_status(
+                ureq::get(&one)
+                    .header("Authorization", "Bearer key_b")
+                    .call()
+            ),
+            404
+        );
+        assert_eq!(
+            http_status(
+                ureq::post(format!("{one}/exec"))
+                    .header("Authorization", "Bearer key_b")
+                    .send(r#"{"command": "echo hi"}"#)
+            ),
+            404
+        );
+        assert_eq!(
+            http_status(
+                ureq::delete(&one)
+                    .header("Authorization", "Bearer key_b")
+                    .call()
+            ),
+            404
+        );
+        // Owner can delete its own session.
+        assert_eq!(
+            http_status(
+                ureq::delete(&one)
+                    .header("Authorization", "Bearer key_a")
+                    .call()
+            ),
+            200
+        );
     }
 }

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -82,6 +82,10 @@ pub struct Session {
     owns_work_dir: bool,
     /// Resource ceilings applied to executions in this session.
     limits: ResourceLimits,
+    /// Tenant that owns this session (the authenticated caller at creation).
+    /// `None` in open mode (no auth config). Cross-tenant access is rejected
+    /// as `NotFound` to hide the session's existence.
+    owner: Option<String>,
 }
 
 impl Session {
@@ -90,7 +94,12 @@ impl Session {
     /// The temp directory is preopened at `/` in the WASI environment,
     /// giving the sandboxed code access to a clean, isolated filesystem.
     /// `limits` configure the session's WASI output/file-size caps.
-    pub fn new(timeout: Duration, limits: ResourceLimits) -> Result<Self, SessionError> {
+    /// `owner` is the authenticated tenant id (`None` in open mode).
+    pub fn new(
+        timeout: Duration,
+        limits: ResourceLimits,
+        owner: Option<String>,
+    ) -> Result<Self, SessionError> {
         let id = generate_session_id();
         let work_dir = std::env::temp_dir().join(format!("wasmrun-session-{id}"));
 
@@ -110,6 +119,7 @@ impl Session {
             work_dir,
             owns_work_dir: true,
             limits,
+            owner,
         })
     }
 
@@ -153,6 +163,7 @@ impl Session {
             work_dir,
             owns_work_dir: false, // test manages cleanup
             limits,
+            owner: None,
         })
     }
 
@@ -189,6 +200,11 @@ impl Session {
     /// Resource ceilings applied to executions in this session.
     pub fn limits(&self) -> &ResourceLimits {
         &self.limits
+    }
+
+    /// Tenant that owns this session, or `None` in open mode.
+    pub fn owner(&self) -> Option<&str> {
+        self.owner.as_deref()
     }
 
     /// Get a clone of the WASI environment Arc for use with the executor.
@@ -321,7 +337,11 @@ impl SessionManager {
     /// Returns the session ID on success.
     #[allow(dead_code)] // Used by tests; HTTP path uses create_session_with_limits.
     pub fn create_session(&self) -> Result<String, SessionError> {
-        self.create_session_with_limits(self.config.default_timeout, self.config.limits.clone())
+        self.create_session_with_limits(
+            self.config.default_timeout,
+            self.config.limits.clone(),
+            None,
+        )
     }
 
     /// Create a new session with a custom timeout and the default limits.
@@ -329,16 +349,18 @@ impl SessionManager {
     /// Returns the session ID on success.
     #[allow(dead_code)] // Used by tests; HTTP path uses create_session_with_limits.
     pub fn create_session_with_timeout(&self, timeout: Duration) -> Result<String, SessionError> {
-        self.create_session_with_limits(timeout, self.config.limits.clone())
+        self.create_session_with_limits(timeout, self.config.limits.clone(), None)
     }
 
-    /// Create a new session with a custom timeout and resource limits.
+    /// Create a new session with a custom timeout, resource limits, and owner.
     ///
+    /// `owner` is the authenticated tenant id, or `None` in open mode.
     /// Returns the session ID on success.
     pub fn create_session_with_limits(
         &self,
         timeout: Duration,
         limits: ResourceLimits,
+        owner: Option<String>,
     ) -> Result<String, SessionError> {
         let mut sessions = self.sessions.write().map_err(|_| SessionError::LockError)?;
 
@@ -350,22 +372,30 @@ impl SessionManager {
             });
         }
 
-        let session = Session::new(timeout, limits)?;
+        let session = Session::new(timeout, limits, owner)?;
         let id = session.id().to_string();
         sessions.insert(id.clone(), session);
         Ok(id)
     }
 
-    /// Get a session by ID. Returns an error if not found or expired.
+    /// Get a session by ID. Returns an error if not found, not owned by the
+    /// caller, or expired.
     ///
-    /// Touches the session (resets idle timeout).
-    pub fn get_session<F, R>(&self, id: &str, f: F) -> Result<R, SessionError>
+    /// `caller` is the authenticated tenant id (`None` in open mode). A session
+    /// whose owner does not match `caller` is reported as `NotFound` to hide its
+    /// existence from other tenants. One equality covers all cases: open mode
+    /// (`None == None`), same tenant (`Some(x) == Some(x)`), cross tenant
+    /// (`Some(x) != Some(y)` → `NotFound`).
+    ///
+    /// Touches the session (resets idle timeout) on success.
+    pub fn get_session<F, R>(&self, id: &str, caller: Option<&str>, f: F) -> Result<R, SessionError>
     where
         F: FnOnce(&Session) -> R,
     {
         let sessions = self.sessions.read().map_err(|_| SessionError::LockError)?;
         let session = sessions
             .get(id)
+            .filter(|s| s.owner() == caller)
             .ok_or_else(|| SessionError::NotFound { id: id.to_string() })?;
 
         if session.is_expired() {
@@ -378,13 +408,19 @@ impl SessionManager {
 
     /// Destroy a session by ID. Cleans up resources.
     ///
-    /// Returns Ok(()) if the session was found and destroyed.
-    pub fn destroy_session(&self, id: &str) -> Result<(), SessionError> {
+    /// `caller` is the authenticated tenant id (`None` in open mode); a session
+    /// owned by another tenant is reported as `NotFound`. Returns `Ok(())` if the
+    /// session was found, owned by the caller, and destroyed.
+    pub fn destroy_session(&self, id: &str, caller: Option<&str>) -> Result<(), SessionError> {
         let mut sessions = self.sessions.write().map_err(|_| SessionError::LockError)?;
-        sessions
-            .remove(id)
-            .map(|_| ()) // Session::drop handles cleanup
-            .ok_or_else(|| SessionError::NotFound { id: id.to_string() })
+        match sessions.get(id) {
+            Some(s) if s.owner() == caller => {
+                sessions.remove(id); // Session::drop handles cleanup
+                Ok(())
+            }
+            // Absent or owned by another tenant → NotFound (hides existence).
+            _ => Err(SessionError::NotFound { id: id.to_string() }),
+        }
     }
 
     /// List all active (non-expired) session IDs.
@@ -707,7 +743,7 @@ mod tests {
         assert_eq!(manager.total_count(), 1);
 
         // Cleanup
-        manager.destroy_session(&id).unwrap();
+        manager.destroy_session(&id, None).unwrap();
     }
 
     #[test]
@@ -727,7 +763,7 @@ mod tests {
 
         // Cleanup
         for id in &ids {
-            manager.destroy_session(id).unwrap();
+            manager.destroy_session(id, None).unwrap();
         }
     }
 
@@ -736,17 +772,17 @@ mod tests {
         let manager = SessionManager::with_config(test_config());
         let id = manager.create_session().unwrap();
 
-        let state = manager.get_session(&id, |s| s.state()).unwrap();
+        let state = manager.get_session(&id, None, |s| s.state()).unwrap();
         assert_eq!(state, SessionState::Active);
 
         // Cleanup
-        manager.destroy_session(&id).unwrap();
+        manager.destroy_session(&id, None).unwrap();
     }
 
     #[test]
     fn test_manager_get_nonexistent_session() {
         let manager = SessionManager::with_config(test_config());
-        let result = manager.get_session("nonexistent", |s| s.state());
+        let result = manager.get_session("nonexistent", None, |s| s.state());
 
         assert!(result.is_err());
         match result.unwrap_err() {
@@ -761,14 +797,14 @@ mod tests {
         let id = manager.create_session().unwrap();
 
         assert_eq!(manager.active_count(), 1);
-        manager.destroy_session(&id).unwrap();
+        manager.destroy_session(&id, None).unwrap();
         assert_eq!(manager.active_count(), 0);
     }
 
     #[test]
     fn test_manager_destroy_nonexistent_session() {
         let manager = SessionManager::with_config(test_config());
-        let result = manager.destroy_session("nonexistent");
+        let result = manager.destroy_session("nonexistent", None);
 
         assert!(result.is_err());
         match result.unwrap_err() {
@@ -802,7 +838,7 @@ mod tests {
 
         // Cleanup
         for id in &ids {
-            manager.destroy_session(id).unwrap();
+            manager.destroy_session(id, None).unwrap();
         }
     }
 
@@ -818,14 +854,14 @@ mod tests {
         let id2 = manager.create_session().unwrap();
         assert!(manager.create_session().is_err()); // at limit
 
-        manager.destroy_session(&id1).unwrap();
+        manager.destroy_session(&id1, None).unwrap();
         let id3 = manager.create_session().unwrap(); // should succeed now
 
         assert_eq!(manager.active_count(), 2);
 
         // Cleanup
-        manager.destroy_session(&id2).unwrap();
-        manager.destroy_session(&id3).unwrap();
+        manager.destroy_session(&id2, None).unwrap();
+        manager.destroy_session(&id3, None).unwrap();
     }
 
     // ── SessionManager listing ────────────────────────────────────
@@ -847,8 +883,8 @@ mod tests {
         assert!(list.iter().all(|i| i.state == SessionState::Active));
 
         // Cleanup
-        manager.destroy_session(&id1).unwrap();
-        manager.destroy_session(&id2).unwrap();
+        manager.destroy_session(&id1, None).unwrap();
+        manager.destroy_session(&id2, None).unwrap();
     }
 
     #[test]
@@ -914,7 +950,7 @@ mod tests {
         assert_eq!(manager.active_count(), 1);
 
         // The long-lived session is still there
-        let state = manager.get_session(&long_id, |s| s.state()).unwrap();
+        let state = manager.get_session(&long_id, None, |s| s.state()).unwrap();
         assert_eq!(state, SessionState::Active);
 
         // Cleanup
@@ -948,17 +984,17 @@ mod tests {
 
         // Wait 80ms, then access — should reset timeout
         std::thread::sleep(Duration::from_millis(80));
-        manager.get_session(&id, |_| {}).unwrap(); // touch
+        manager.get_session(&id, None, |_| {}).unwrap(); // touch
 
         // Wait another 80ms — total 160ms from creation, but only 80ms from last access
         std::thread::sleep(Duration::from_millis(80));
 
         // Should still be alive because get_session touched it
-        let result = manager.get_session(&id, |s| s.state());
+        let result = manager.get_session(&id, None, |s| s.state());
         assert!(result.is_ok());
 
         // Cleanup
-        manager.destroy_session(&id).unwrap();
+        manager.destroy_session(&id, None).unwrap();
     }
 
     #[test]
@@ -972,7 +1008,7 @@ mod tests {
 
         std::thread::sleep(Duration::from_millis(80));
 
-        let result = manager.get_session(&id, |s| s.state());
+        let result = manager.get_session(&id, None, |s| s.state());
         assert!(result.is_err());
         match result.unwrap_err() {
             SessionError::Expired { .. } => {}
@@ -1053,11 +1089,11 @@ mod tests {
         let id = manager.create_session().unwrap();
 
         let work_dir = manager
-            .get_session(&id, |s| s.work_dir().to_path_buf())
+            .get_session(&id, None, |s| s.work_dir().to_path_buf())
             .unwrap();
 
         assert!(work_dir.exists());
-        manager.destroy_session(&id).unwrap();
+        manager.destroy_session(&id, None).unwrap();
         assert!(!work_dir.exists());
     }
 
@@ -1089,12 +1125,12 @@ mod tests {
 
         // Set env on session 1
         manager
-            .get_session(&id1, |s| s.set_env("ONLY_S1", "yes"))
+            .get_session(&id1, None, |s| s.set_env("ONLY_S1", "yes"))
             .unwrap();
 
         // Session 2 should not have it
         let s2_vars = manager
-            .get_session(&id2, |s| {
+            .get_session(&id2, None, |s| {
                 let env = s.wasi_env();
                 let locked = env.lock().unwrap();
                 locked.env_vars().to_vec()
@@ -1105,7 +1141,7 @@ mod tests {
 
         // Session 1 should have it
         let s1_vars = manager
-            .get_session(&id1, |s| {
+            .get_session(&id1, None, |s| {
                 let env = s.wasi_env();
                 let locked = env.lock().unwrap();
                 locked.env_vars().to_vec()
@@ -1116,5 +1152,61 @@ mod tests {
 
         // Cleanup
         manager.destroy_all().unwrap();
+    }
+
+    // ── Tenant ownership ──────────────────────────────────────────
+
+    #[test]
+    fn test_owned_session_ownership_equality() {
+        let manager = SessionManager::with_config(test_config());
+        let id = manager
+            .create_session_with_limits(
+                Duration::from_secs(60),
+                ResourceLimits::default(),
+                Some("alice".to_string()),
+            )
+            .unwrap();
+
+        // Owner is recorded on the session.
+        let owner = manager
+            .get_session(&id, Some("alice"), |s| s.owner().map(str::to_string))
+            .unwrap();
+        assert_eq!(owner, Some("alice".to_string()));
+
+        // Cross tenant → NotFound (hides existence), not Expired.
+        assert!(matches!(
+            manager.get_session(&id, Some("bob"), |_| ()),
+            Err(SessionError::NotFound { .. })
+        ));
+        // Open-mode caller (None) against an owned session → NotFound.
+        assert!(matches!(
+            manager.get_session(&id, None, |_| ()),
+            Err(SessionError::NotFound { .. })
+        ));
+
+        // Cross-tenant destroy is a no-op reported as NotFound; session survives.
+        assert!(matches!(
+            manager.destroy_session(&id, Some("bob")),
+            Err(SessionError::NotFound { .. })
+        ));
+        assert!(manager.get_session(&id, Some("alice"), |_| ()).is_ok());
+
+        // Owner can destroy.
+        assert!(manager.destroy_session(&id, Some("alice")).is_ok());
+    }
+
+    #[test]
+    fn test_open_mode_session_has_no_owner() {
+        let manager = SessionManager::with_config(test_config());
+        let id = manager.create_session().unwrap(); // owner = None
+
+        // Open-mode caller matches.
+        assert!(manager.get_session(&id, None, |_| ()).is_ok());
+        // A tenant cannot touch an unowned (open-mode) session.
+        assert!(matches!(
+            manager.get_session(&id, Some("alice"), |_| ()),
+            Err(SessionError::NotFound { .. })
+        ));
+        manager.destroy_session(&id, None).unwrap();
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -363,6 +363,22 @@ pub enum Commands {
         /// Enable verbose request logging
         #[arg(short = 'v', long, help = "Log all incoming requests")]
         verbose: bool,
+
+        /// Path to a TOML auth config enabling API-key auth and tenant isolation
+        #[arg(
+            long = "auth",
+            value_name = "PATH",
+            help = "Enable API-key auth from a TOML config (omit = open mode)"
+        )]
+        auth_config: Option<String>,
+
+        /// Print the SHA-256 hash of an API key (for the auth config) and exit
+        #[arg(
+            long,
+            value_name = "KEY",
+            help = "Print sha256(KEY) for use in the auth config, then exit"
+        )]
+        hash_key: Option<String>,
     },
 
     /// Plugin management commands

--- a/src/commands/agent.rs
+++ b/src/commands/agent.rs
@@ -1,9 +1,12 @@
 //! Agent mode: CLI command handler for `wasmrun agent`.
 
+use crate::agent::auth::{self, AuthConfig};
 use crate::agent::limits::ResourceLimits;
 use crate::agent::server::{AgentConfig, AgentServer};
 use crate::agent::session::SessionConfig;
 use crate::error::Result;
+use std::path::Path;
+use std::sync::Arc;
 use std::time::Duration;
 
 #[allow(clippy::too_many_arguments)]
@@ -20,7 +23,23 @@ pub fn handle_agent_command(
     max_concurrent_exec: usize,
     allow_cors: bool,
     verbose: bool,
+    auth_config: Option<&str>,
+    hash_key: Option<&str>,
 ) -> Result<()> {
+    // `--hash-key` is a standalone helper: print sha256(key) and exit without
+    // starting the server, so operators can populate the auth config.
+    if let Some(key) = hash_key {
+        println!("{}", auth::hash_key(key));
+        return Ok(());
+    }
+
+    // Load the auth config when requested. Abort startup on any error rather than
+    // silently running open when auth was asked for.
+    let auth = match auth_config {
+        Some(path) => Some(Arc::new(AuthConfig::load(Path::new(path))?)),
+        None => None,
+    };
+
     let limits =
         ResourceLimits::from_cli(max_memory, max_fuel, max_output, max_file_size, max_disk);
 
@@ -39,6 +58,7 @@ pub fn handle_agent_command(
         verbose,
         max_body_bytes,
         max_concurrent_exec,
+        auth,
     };
 
     let server = AgentServer::new(config);

--- a/src/main.rs
+++ b/src/main.rs
@@ -188,6 +188,8 @@ fn main() {
             max_concurrent_exec,
             allow_cors,
             verbose,
+            auth_config,
+            hash_key,
         }) => {
             debug_println!(
                 "Processing agent command: port={}, timeout={}, max_sessions={}, max_memory={}MB, max_fuel={}, max_output={}MB, max_file_size={}MB, max_disk={}MB, max_body={}MB, max_concurrent_exec={}",
@@ -215,6 +217,8 @@ fn main() {
                 *max_concurrent_exec,
                 *allow_cors,
                 *verbose,
+                auth_config.as_deref(),
+                hash_key.as_deref(),
             )
         }
 


### PR DESCRIPTION
The `wasmrun agent` server was fully open: any caller could create sessions and read/exec/delete in any session. This adds an opt-in authentication layer so one server can be shared by independent tenants who authenticate with API keys and cannot see each other's sessions. Without `--auth` the server stays fully open, exactly as before — existing clients need no header.

Enable it by pointing `--auth` at a TOML config of tenants. Keys are stored hashed (SHA-256, hex), never in plaintext; `--hash-key` prints the hash for a key and exits:

    KEY=$(openssl rand -hex 32)
    wasmrun agent --hash-key "$KEY"

    # auth.toml
    [[tenants]]
    id = "ci"
    key_sha256 = "<paste hash>"

    wasmrun agent --auth ./auth.toml

Clients then pass the raw key on every `/api/v1/*` request:

    curl -X POST .../api/v1/sessions -H "Authorization: Bearer $KEY"

A missing, malformed, or unknown key returns 401. Each session is owned by the tenant that created it; cross-tenant access returns 404 (identical to a nonexistent session, so existence isn't leaked), enforced centrally in the session manager. The auth config is validated at startup (unique ids, unique 64-char-hex hashes) and an invalid or missing config aborts startup rather than silently running open.

Per-tenant rate limiting is deferred to a later release.