### PR TITLE
ci(release): set up Node 22 for binary builds

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -26,10 +26,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Install Pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 'latest'
+          version: 10
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -71,10 +76,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
       - name: Install Pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 'latest'
+          version: 10
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
The v0.19.0 release-binaries workflow failed all four package jobs (.deb/.rpm × x86_64/aarch64) with exit code 101. The Rust build script `build.rs` runs `pnpm install` to compile the UI during `cargo deb` / `cargo rpm`, but the workflow installed pnpm with `version: 'latest'` and never set up Node.js, so it ran on the runner's stock Node 20.

The latest pnpm (v11) requires Node >=22.13 and imports the `node:sqlite` builtin that only exists in Node 22+, so `pnpm install` crashed with `ERR_UNKNOWN_BUILTIN_MODULE`, panicking the build script.

Add an `actions/setup-node@v4` step pinned to Node 22 and pin pnpm to `version: 10` in both jobs, matching the working `ci.yml` setup.

Brought up in #18 