### PR TITLE
docs: document AUR package and fix docs site nav and baseUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@
 cargo install wasmrun
 ```
 
+On Arch Linux, install from the [AUR](https://aur.archlinux.org/packages/wasmrun-bin) (community-maintained):
+
+```sh
+yay -S wasmrun-bin
+```
+
 For other installation methods (DEB, RPM, from source), see the [Installation Guide](https://wasmrun.readthedocs.io/en/latest/docs/installation).
 
 ### Basic Usage

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -73,6 +73,34 @@ sudo yum install ./wasmrun-*.rpm
 - Rocky Linux 8+
 - AlmaLinux 8+
 
+### Arch Linux (AUR)
+
+For Arch Linux and Arch-based distributions, Wasmrun is available on the [AUR](https://aur.archlinux.org/packages/wasmrun-bin) as a community-maintained package that installs the prebuilt binary.
+
+Using an AUR helper such as [`yay`](https://github.com/Jguer/yay) or [`paru`](https://github.com/Morganamilo/paru):
+
+```sh
+yay -S wasmrun-bin
+# or
+paru -S wasmrun-bin
+```
+
+Or install manually with `makepkg`:
+
+```sh
+git clone https://aur.archlinux.org/wasmrun-bin.git
+cd wasmrun-bin
+makepkg -si
+```
+
+**Supported distributions:**
+- Arch Linux
+- Manjaro
+- EndeavourOS
+- Other Arch-based distributions
+
+**Note:** The AUR package is maintained by the community and may lag slightly behind the latest release.
+
 ## From Source
 
 Build and install Wasmrun from source for the latest development version or if prebuilt packages aren't available for your platform:
@@ -153,6 +181,14 @@ For DEB/RPM packages:
 1. Download the latest package from GitHub Releases
 2. Install it (will upgrade existing installation)
 
+For the AUR package, update with your AUR helper:
+
+```sh
+yay -S wasmrun-bin
+# or
+paru -S wasmrun-bin
+```
+
 ### From Source
 
 ```sh
@@ -226,6 +262,12 @@ sudo apt remove wasmrun
 sudo rpm -e wasmrun
 # or
 sudo dnf remove wasmrun
+```
+
+### Arch Linux (AUR)
+
+```sh
+sudo pacman -R wasmrun-bin
 ```
 
 ## Next Steps

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -2,13 +2,20 @@ import type { Config } from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 import { themes as prismThemes } from 'prism-react-renderer';
 
+// ReadTheDocs serves the site under /<language>/<version>/ (e.g. /en/latest/)
+// and sets these env vars only inside its build environment. Everywhere else
+// — the local dev server and local production builds (`pnpm build && serve`) —
+// the site is served from the root, so baseUrl must stay '/'. Keying off
+// NODE_ENV is wrong because any production build sets it, including local ones.
+const isReadTheDocs = process.env.READTHEDOCS === 'True';
+const rtdLanguage = process.env.READTHEDOCS_LANGUAGE || 'en';
+const rtdVersion = process.env.READTHEDOCS_VERSION || 'latest';
+
 const config: Config = {
   title: 'Wasmrun',
   tagline: 'WebAssembly Runtime',
   url: 'https://wasmrun.readthedocs.io',
-  baseUrl: process.env.NODE_ENV === 'production'
-    ? `/en/${process.env.READTHEDOCS_VERSION || 'latest'}/`
-    : '/',
+  baseUrl: isReadTheDocs ? `/${rtdLanguage}/${rtdVersion}/` : '/',
 
   favicon: 'img/favicon.ico',
   organizationName: 'anistark',

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -326,10 +326,10 @@ article span {
   background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="%232d5016"><path d="M21.327 8.566c0-4.339-2.843-5.61-2.843-5.61-1.433-.658-3.894-.935-6.451-.956h-.063c-2.557.021-5.016.298-6.45.956 0 0-2.843 1.272-2.843 5.61 0 .993-.019 2.181.012 3.441.103 4.243.778 8.425 4.701 9.463 1.809.479 3.362.579 4.612.51 2.268-.126 3.541-.809 3.541-.809l-.075-1.646s-1.621.511-3.441.449c-1.804-.062-3.707-.194-3.999-2.409a4.523 4.523 0 01-.04-.621s1.77.433 4.014.536c1.372.063 2.658-.08 3.965-.236 2.506-.299 4.688-1.843 4.962-3.254.434-2.223.398-5.424.398-5.424zm-3.353 5.59h-2.081V9.057c0-1.075-.452-1.62-1.357-1.62-1 0-1.501.647-1.501 1.927v2.791h-2.069V9.364c0-1.28-.501-1.927-1.502-1.927-.905 0-1.357.546-1.357 1.62v5.099H6.026V8.903c0-1.074.273-1.927.823-2.558.566-.631 1.307-.955 2.228-.955 1.065 0 1.872.409 2.405 1.228l.518.869.519-.869c.533-.819 1.34-1.228 2.405-1.228.92 0 1.662.324 2.228.955.549.631.822 1.484.822 2.558v5.253z"/></svg>');
 }
 
+/* Hamburger toggle: theme its colors only. Leave visibility to the
+   Docusaurus/Infima defaults — hidden on desktop, shown below 996px. */
 .navbar__toggle {
   color: var(--ifm-font-color-base) !important;
-  display: block !important;
-  visibility: visible !important;
 }
 
 .navbar__toggle svg {
@@ -377,12 +377,11 @@ article span {
 }
 
 @media (max-width: 996px) {
-  .navbar__item {
-    display: flex !important;
-  }
-
+  /* Below 996px the nav links collapse into the slide-in sidebar drawer,
+     so keep them out of the top bar (Infima default). Only the hamburger
+     stays — make sure it is shown and stays clickable. */
   .navbar__toggle {
-    display: block !important;
+    display: inherit;
     opacity: 1 !important;
     pointer-events: auto !important;
   }


### PR DESCRIPTION
Three documentation changes bundled together:

- AUR availability: Wasmrun is now on the AUR as the community- maintained (@Dominiquini) `wasmrun-bin` package. 🙌🏼 Document install (`yay`/`paru` or manual `makepkg`), update, and uninstall flows in the installation guide, and add a short Arch note to the README. closes #18 

- Mobile navbar: the custom CSS forced `.navbar__toggle` visible with `display: block !important` at every breakpoint and forced `.navbar__item` into the top bar below 996px. This left a dead hamburger on desktop and crammed all nav links into the mobile bar. Drop both overrides so Infima defaults apply — hamburger hidden on desktop, links collapse into the slide-in drawer on mobile.

- baseUrl: the Docusaurus baseUrl keyed off `NODE_ENV`, so any production build (including a local `pnpm build && serve`) wrongly got the ReadTheDocs `/en/latest/` path and failed to load. Key off the `READTHEDOCS` env vars instead so local builds serve from `/` while ReadTheDocs keeps its `/<lang>/<version>/` path.