### PR TITLE
ci(docs): fix Read the Docs build under pnpm 11

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,10 +7,11 @@ build:
   commands:
     # Install pnpm
     - npm install -g pnpm@latest
-    # Install dependencies
-    - cd docs && pnpm install --frozen-lockfile
+    # Install dependencies. STRICT_DEP_BUILDS=false stops pnpm 11 from failing
+    # the build over ignored dependency build scripts (core-js postinstall).
+    - cd docs && PNPM_CONFIG_STRICT_DEP_BUILDS=false pnpm install --frozen-lockfile
     # Build Docusaurus site
-    - cd docs && pnpm run build
+    - cd docs && PNPM_CONFIG_STRICT_DEP_BUILDS=false pnpm run build
     # Move built files to _readthedocs/html for RTD
     - mkdir -p _readthedocs/html
     - cp -r docs/build/* _readthedocs/html/


### PR DESCRIPTION
The Read the Docs build started failing on every PR, dying in ~23s before the site ever compiled. The build config installs `pnpm@latest`, which is now pnpm 11. pnpm 11 makes ignored dependency build scripts a hard error (`ERR_PNPM_IGNORED_BUILDS`, exit 1) instead of a warning, and `core-js`/`core-js-pure` ship postinstall scripts that pnpm blocks by default. As a result `pnpm install --frozen-lockfile` exits non-zero, and `pnpm run build` fails too since pnpm 11 re-runs install as a pre-run deps check.

Set `PNPM_CONFIG_STRICT_DEP_BUILDS=false` on the install and build commands to restore the prior warn-only behavior. The env var is used rather than `.npmrc` or `pnpm-workspace.yaml` because pnpm 11 does not honor those build-script settings under `--frozen-lockfile` in this single-package setup. Verified the full pipeline (install, build, copy to `_readthedocs/html`) passes end-to-end with pnpm 11.6.0.