### PR TITLE
feat(agent): add observability metrics and access log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Agent Observability**: runtime metrics and a structured access log so an operator can see health, load, and failures without a debugger
+  - `GET /api/v1/metrics` returns **Prometheus** text exposition by default (scrape-ready) or JSON with `?format=json`
+  - Counters: executions by result (`success`/`error`/`timeout`), execution duration sum + count (for an average), output-truncated count, sessions created, and requests rejected before doing work by reason (`concurrency` 429, `payload` 413, `unauthorized` 401)
+  - Live gauges sampled at scrape time (no mirrored state, no drift): active sessions, total sessions, in-flight execs, and total session disk footprint
+  - Every request emits a one-line `key=value` access log to stderr (`ts`/`id`/`method`/`path`/`status`/`dur_ms`/`tenant`) and carries an `X-Request-Id` response header for correlation; `--verbose` adds a request-received line
+  - When `--auth` is enabled, `/metrics` is gated like any endpoint and limited to **global aggregates** — per-session rows (disk + configured memory cap, JSON only) are exposed solely in open mode, so no tenant can infer another's footprint
+  - Dependency-free: hand-rolled `AtomicU64` registry and exposition text, no new metrics crate
 - **Authentication & Tenant Isolation (opt-in)**: run one agent server shared by independent tenants who authenticate with API keys and cannot see each other's sessions
   - `--auth <path>` enables API-key auth from a TOML config of `[[tenants]]` (`id` + `key_sha256`); without it the server stays fully **open**, exactly as before (back-compat — existing clients need no header)
   - Keys are stored **SHA-256-hashed** (hex), never in plaintext; `--hash-key <KEY>` prints the hash and exits so operators can populate the config

--- a/docs/docs/exec/agent.md
+++ b/docs/docs/exec/agent.md
@@ -26,7 +26,7 @@ wasmrun agent [OPTIONS]
 | `--max-body` | `32` | Maximum accepted request body size (MB) |
 | `--max-concurrent-exec` | `100` | Maximum executions in flight across all sessions |
 | `--allow-cors` | off | Enable wildcard CORS |
-| `-v, --verbose` | off | Log all incoming requests |
+| `-v, --verbose` | off | Add a request-received line per request (a structured access log is always emitted — see [Observability](./usage/agent-observability.md)) |
 | `--auth <PATH>` | off | Path to a TOML auth config; enables API-key auth & tenant isolation (omit = open) |
 | `--hash-key <KEY>` | — | Print `sha256(KEY)` for the auth config and exit (does not start the server) |
 
@@ -177,6 +177,17 @@ Available tools: `create_session`, `execute_code`, `write_file`, `read_file`, `l
 
 Each tool includes a description, parameter schema with types, and required fields — ready to pass to an LLM as function definitions.
 
+## Observability
+
+The server exposes runtime metrics at `GET /api/v1/metrics` (Prometheus text by default, JSON with `?format=json`) and writes a structured, request-id-tagged access-log line to stderr for every request. See [Observability](./usage/agent-observability.md) for the full metric set and log format.
+
+```sh
+curl http://localhost:8430/api/v1/metrics
+# wasmrun_agent_exec_total{result="success"} 12
+# wasmrun_agent_sessions_active 3
+# ...
+```
+
 ## API Reference
 
 See the usage sub-pages for full endpoint documentation:
@@ -185,3 +196,4 @@ See the usage sub-pages for full endpoint documentation:
 - [Execution](./usage/agent-exec.md) — run WASM with timeout and structured output
 - [File Operations](./usage/agent-files.md) — write, read, list, delete
 - [Environment Variables](./usage/agent-environment.md) — set and get per-session env
+- [Observability](./usage/agent-observability.md) — metrics endpoint and access log

--- a/docs/docs/exec/usage/agent-observability.md
+++ b/docs/docs/exec/usage/agent-observability.md
@@ -1,0 +1,123 @@
+---
+sidebar_position: 9
+title: Agent Observability
+---
+
+# Observability
+
+The agent server exposes runtime metrics for scraping and emits a structured access log for every request, so you can answer "is it healthy, how busy is it, what's failing" without attaching a debugger.
+
+## Metrics
+
+```
+GET /api/v1/metrics
+```
+
+Returns server metrics in **Prometheus text exposition format** by default, or as JSON with `?format=json`.
+
+```sh
+# Prometheus (default) — point a Prometheus/Grafana scraper here
+curl http://localhost:8430/api/v1/metrics
+
+# JSON — convenient for ad-hoc inspection or a custom dashboard
+curl "http://localhost:8430/api/v1/metrics?format=json"
+```
+
+**Prometheus response** (`Content-Type: text/plain; version=0.0.4`):
+
+```
+# HELP wasmrun_agent_exec_total Total code executions by terminal result.
+# TYPE wasmrun_agent_exec_total counter
+wasmrun_agent_exec_total{result="success"} 12
+wasmrun_agent_exec_total{result="error"} 1
+wasmrun_agent_exec_total{result="timeout"} 0
+# HELP wasmrun_agent_exec_duration_ms_sum Sum of execution wall-clock durations in milliseconds.
+# TYPE wasmrun_agent_exec_duration_ms_sum counter
+wasmrun_agent_exec_duration_ms_sum 4200
+...
+# HELP wasmrun_agent_sessions_active Currently active (non-expired) sessions.
+# TYPE wasmrun_agent_sessions_active gauge
+wasmrun_agent_sessions_active 3
+```
+
+**JSON response** (`?format=json`):
+
+```json
+{
+  "exec_total": { "success": 12, "error": 1, "timeout": 0 },
+  "exec_duration_ms_sum": 4200,
+  "exec_duration_ms_count": 13,
+  "output_truncated_total": 0,
+  "sessions_created_total": 20,
+  "exec_rejected_total": { "concurrency": 0, "payload": 0, "unauthorized": 0 },
+  "sessions_active": 3,
+  "sessions_total": 3,
+  "exec_in_flight": 1,
+  "sessions_disk_bytes": 16384
+}
+```
+
+### Metrics reference
+
+| Metric | Type | Meaning |
+|--------|------|---------|
+| `wasmrun_agent_exec_total{result}` | counter | Executions by terminal result: `success` (ran to completion), `error` (failed to run), `timeout` |
+| `wasmrun_agent_exec_duration_ms_sum` | counter | Sum of execution wall-clock durations (ms) |
+| `wasmrun_agent_exec_duration_ms_count` | counter | Number of executions in the sum — pair with `_sum` for the average |
+| `wasmrun_agent_output_truncated_total` | counter | Executions whose captured output hit the `--max-output` cap |
+| `wasmrun_agent_sessions_created_total` | counter | Sessions created since startup |
+| `wasmrun_agent_exec_rejected_total{reason}` | counter | Requests rejected before doing work, by `reason`: `concurrency` (429), `payload` (413), `unauthorized` (401) |
+| `wasmrun_agent_sessions_active` | gauge | Active (non-expired) sessions right now |
+| `wasmrun_agent_sessions_total` | gauge | Sessions tracked, including expired-but-not-yet-cleaned |
+| `wasmrun_agent_exec_in_flight` | gauge | Exec workers currently running |
+| `wasmrun_agent_sessions_disk_bytes` | gauge | Total on-disk footprint across active sessions (bytes) |
+
+Average execution duration is `exec_duration_ms_sum / exec_duration_ms_count`.
+
+### Authentication
+
+When [`--auth`](../agent.md#authentication) is enabled, `/metrics` requires a valid API key like every other endpoint, and the scrape is limited to **global aggregates** — no per-tenant or per-session data — so one tenant cannot infer another's activity. A missing or invalid key returns **401** (and increments `exec_rejected_total{reason="unauthorized"}`).
+
+### Per-session breakdown (open mode only)
+
+In open mode (no `--auth`), the JSON format adds a `sessions` array with each active session's disk footprint and configured memory cap:
+
+```json
+{
+  "...": "...",
+  "sessions": [
+    { "id": "a1b2c3...", "disk_bytes": 8192, "memory_cap_pages": 4096 }
+  ]
+}
+```
+
+`memory_cap_pages` is in WASM pages (64 KiB each); `null` means unlimited. This breakdown is **not** emitted in the Prometheus format (session ids would be unbounded-cardinality labels) and is withheld entirely when auth is enabled — leaving only the aggregate `sessions_disk_bytes` gauge.
+
+## Access Log
+
+The server writes one structured `key=value` line to **stderr** for every request, always on:
+
+```
+ts=2026-06-13T11:18:55.354+00:00 id=d5aafbe6c56c32ec method=POST path=/api/v1/sessions status=200 dur_ms=1 tenant=-
+```
+
+| Field | Meaning |
+|-------|---------|
+| `ts` | RFC 3339 timestamp |
+| `id` | Request id — also returned as the `X-Request-Id` response header |
+| `method` | HTTP method |
+| `path` | Request path |
+| `status` | HTTP status code |
+| `dur_ms` | Handling duration in milliseconds |
+| `tenant` | Authenticated tenant id, or `-` in open mode / before auth resolves |
+
+Running with [`-v, --verbose`](../agent.md#starting-the-server) adds a request-received line (`→ METHOD url (id=...)`) ahead of each response line; the structured access line is emitted either way.
+
+### Request correlation
+
+Every response carries an `X-Request-Id` header matching the `id` in the access log, so a client can tie a response back to its server-side log line:
+
+```sh
+curl -i http://localhost:8430/api/v1/metrics | grep -i x-request-id
+# X-Request-Id: 37dffe5b315dcd30
+```

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -64,6 +64,7 @@ const sidebars: SidebarsConfig = {
             'exec/usage/agent-exec',
             'exec/usage/agent-files',
             'exec/usage/agent-environment',
+            'exec/usage/agent-observability',
           ],
         },
       ],

--- a/src/agent/metrics.rs
+++ b/src/agent/metrics.rs
@@ -1,0 +1,392 @@
+//! Agent mode: lightweight, dependency-free metrics registry.
+//!
+//! Cumulative counters are stored as [`AtomicU64`]; point-in-time gauges
+//! (active sessions, in-flight execs, total session disk) are sampled from
+//! live state at scrape time and passed into the render functions. Keeping
+//! gauges out of the counter set means there is a single source of truth and
+//! no drift between a mirrored counter and the thing it tracks.
+//!
+//! Output is hand-rendered: Prometheus text exposition format (the scrape
+//! default) or flat JSON (`?format=json`). No `prometheus`/`metrics` crate —
+//! this matches the rest of the agent layer, which hand-rolls its primitives.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// All metric values use `Relaxed` ordering: each counter is independent and
+/// we need atomicity of the increment, not ordering relative to other counters
+/// or to surrounding program state. A scrape may observe a set of counters that
+/// were never simultaneously "true", which is fine for monitoring.
+const ORDER: Ordering = Ordering::Relaxed;
+
+/// Cumulative, monotonic counters incremented at request choke points.
+#[derive(Default)]
+pub struct Metrics {
+    exec_success: AtomicU64,
+    exec_error: AtomicU64,
+    exec_timeout: AtomicU64,
+    /// Sum of execution wall-clock durations (ms) across all terminal outcomes.
+    /// Paired with the derived exec count to form a Prometheus summary.
+    exec_duration_ms_sum: AtomicU64,
+    output_truncated: AtomicU64,
+    sessions_created: AtomicU64,
+    rejected_concurrency: AtomicU64,
+    rejected_payload: AtomicU64,
+    rejected_unauthorized: AtomicU64,
+}
+
+/// Point-in-time gauge values, sampled from live state at scrape time rather
+/// than mirrored into counters.
+pub struct Gauges {
+    pub sessions_active: u64,
+    pub sessions_total: u64,
+    pub exec_in_flight: u64,
+    pub sessions_disk_bytes: u64,
+}
+
+/// Per-session resource row for the JSON metrics breakdown. Exposed in JSON
+/// format only, and only in open (no-auth) mode — in auth mode per-session
+/// rows would leak one tenant's footprint to another, so the scrape is capped
+/// at global aggregates (see 0.20.5 Q2/Q3 in the implementation plan).
+#[derive(serde::Serialize)]
+pub struct SessionResourceRow {
+    pub id: String,
+    pub disk_bytes: u64,
+    /// Configured memory ceiling in WASM pages (64 KiB each); `None` = unlimited.
+    pub memory_cap_pages: Option<u32>,
+}
+
+impl Metrics {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn record_exec_success(&self, dur_ms: u64) {
+        self.exec_success.fetch_add(1, ORDER);
+        self.exec_duration_ms_sum.fetch_add(dur_ms, ORDER);
+    }
+
+    pub fn record_exec_error(&self, dur_ms: u64) {
+        self.exec_error.fetch_add(1, ORDER);
+        self.exec_duration_ms_sum.fetch_add(dur_ms, ORDER);
+    }
+
+    pub fn record_exec_timeout(&self, dur_ms: u64) {
+        self.exec_timeout.fetch_add(1, ORDER);
+        self.exec_duration_ms_sum.fetch_add(dur_ms, ORDER);
+    }
+
+    pub fn record_output_truncated(&self) {
+        self.output_truncated.fetch_add(1, ORDER);
+    }
+
+    pub fn record_session_created(&self) {
+        self.sessions_created.fetch_add(1, ORDER);
+    }
+
+    pub fn record_rejected_concurrency(&self) {
+        self.rejected_concurrency.fetch_add(1, ORDER);
+    }
+
+    pub fn record_rejected_payload(&self) {
+        self.rejected_payload.fetch_add(1, ORDER);
+    }
+
+    pub fn record_rejected_unauthorized(&self) {
+        self.rejected_unauthorized.fetch_add(1, ORDER);
+    }
+
+    /// Consistent-enough snapshot of all counters for rendering.
+    fn snapshot(&self) -> Snapshot {
+        Snapshot {
+            exec_success: self.exec_success.load(ORDER),
+            exec_error: self.exec_error.load(ORDER),
+            exec_timeout: self.exec_timeout.load(ORDER),
+            exec_duration_ms_sum: self.exec_duration_ms_sum.load(ORDER),
+            output_truncated: self.output_truncated.load(ORDER),
+            sessions_created: self.sessions_created.load(ORDER),
+            rejected_concurrency: self.rejected_concurrency.load(ORDER),
+            rejected_payload: self.rejected_payload.load(ORDER),
+            rejected_unauthorized: self.rejected_unauthorized.load(ORDER),
+        }
+    }
+
+    /// Render the Prometheus text exposition format (the scrape default).
+    /// `per_session` rows are intentionally not emitted here — Prometheus
+    /// labels on session ids would be unbounded-cardinality, and per-session
+    /// data is withheld in auth mode anyway.
+    pub fn render_prometheus(&self, g: &Gauges) -> String {
+        let s = self.snapshot();
+        let exec_count = s.exec_success + s.exec_error + s.exec_timeout;
+        let mut out = String::with_capacity(2048);
+
+        metric(
+            &mut out,
+            "wasmrun_agent_exec_total",
+            "Total code executions by terminal result.",
+            "counter",
+            &[
+                (&[("result", "success")], s.exec_success),
+                (&[("result", "error")], s.exec_error),
+                (&[("result", "timeout")], s.exec_timeout),
+            ],
+        );
+        metric(
+            &mut out,
+            "wasmrun_agent_exec_duration_ms_sum",
+            "Sum of execution wall-clock durations in milliseconds.",
+            "counter",
+            &[(&[], s.exec_duration_ms_sum)],
+        );
+        metric(
+            &mut out,
+            "wasmrun_agent_exec_duration_ms_count",
+            "Count of executions contributing to the duration sum.",
+            "counter",
+            &[(&[], exec_count)],
+        );
+        metric(
+            &mut out,
+            "wasmrun_agent_output_truncated_total",
+            "Executions whose captured output hit the output cap.",
+            "counter",
+            &[(&[], s.output_truncated)],
+        );
+        metric(
+            &mut out,
+            "wasmrun_agent_sessions_created_total",
+            "Total sessions created since startup.",
+            "counter",
+            &[(&[], s.sessions_created)],
+        );
+        metric(
+            &mut out,
+            "wasmrun_agent_exec_rejected_total",
+            "Executions/requests rejected before doing work, by reason.",
+            "counter",
+            &[
+                (&[("reason", "concurrency")], s.rejected_concurrency),
+                (&[("reason", "payload")], s.rejected_payload),
+                (&[("reason", "unauthorized")], s.rejected_unauthorized),
+            ],
+        );
+        metric(
+            &mut out,
+            "wasmrun_agent_sessions_active",
+            "Currently active (non-expired) sessions.",
+            "gauge",
+            &[(&[], g.sessions_active)],
+        );
+        metric(
+            &mut out,
+            "wasmrun_agent_sessions_total",
+            "Total sessions tracked, including expired-but-not-cleaned.",
+            "gauge",
+            &[(&[], g.sessions_total)],
+        );
+        metric(
+            &mut out,
+            "wasmrun_agent_exec_in_flight",
+            "Exec workers currently running.",
+            "gauge",
+            &[(&[], g.exec_in_flight)],
+        );
+        metric(
+            &mut out,
+            "wasmrun_agent_sessions_disk_bytes",
+            "Total on-disk footprint across active sessions in bytes.",
+            "gauge",
+            &[(&[], g.sessions_disk_bytes)],
+        );
+        out
+    }
+
+    /// Render a flat JSON object. `per_session` is included only when the
+    /// caller passes `Some` (open mode); in auth mode it is `None` so the
+    /// scrape stays at global aggregates.
+    pub fn render_json(
+        &self,
+        g: &Gauges,
+        per_session: Option<Vec<SessionResourceRow>>,
+    ) -> serde_json::Value {
+        let s = self.snapshot();
+        let exec_count = s.exec_success + s.exec_error + s.exec_timeout;
+        let mut obj = serde_json::json!({
+            "exec_total": {
+                "success": s.exec_success,
+                "error": s.exec_error,
+                "timeout": s.exec_timeout,
+            },
+            "exec_duration_ms_sum": s.exec_duration_ms_sum,
+            "exec_duration_ms_count": exec_count,
+            "output_truncated_total": s.output_truncated,
+            "sessions_created_total": s.sessions_created,
+            "exec_rejected_total": {
+                "concurrency": s.rejected_concurrency,
+                "payload": s.rejected_payload,
+                "unauthorized": s.rejected_unauthorized,
+            },
+            "sessions_active": g.sessions_active,
+            "sessions_total": g.sessions_total,
+            "exec_in_flight": g.exec_in_flight,
+            "sessions_disk_bytes": g.sessions_disk_bytes,
+        });
+        if let Some(rows) = per_session {
+            obj["sessions"] = serde_json::to_value(rows).unwrap_or(serde_json::Value::Null);
+        }
+        obj
+    }
+}
+
+struct Snapshot {
+    exec_success: u64,
+    exec_error: u64,
+    exec_timeout: u64,
+    exec_duration_ms_sum: u64,
+    output_truncated: u64,
+    sessions_created: u64,
+    rejected_concurrency: u64,
+    rejected_payload: u64,
+    rejected_unauthorized: u64,
+}
+
+/// Append one Prometheus metric family: `# HELP`, `# TYPE`, then one sample
+/// line per label-set. An empty label slice renders a bare metric line.
+fn metric(
+    out: &mut String,
+    name: &str,
+    help: &str,
+    kind: &str,
+    samples: &[(&[(&str, &str)], u64)],
+) {
+    out.push_str("# HELP ");
+    out.push_str(name);
+    out.push(' ');
+    out.push_str(help);
+    out.push('\n');
+    out.push_str("# TYPE ");
+    out.push_str(name);
+    out.push(' ');
+    out.push_str(kind);
+    out.push('\n');
+    for (labels, value) in samples {
+        out.push_str(name);
+        if !labels.is_empty() {
+            out.push('{');
+            for (i, (k, v)) in labels.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                out.push_str(k);
+                out.push_str("=\"");
+                out.push_str(v);
+                out.push('"');
+            }
+            out.push('}');
+        }
+        out.push(' ');
+        out.push_str(&value.to_string());
+        out.push('\n');
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gauges() -> Gauges {
+        Gauges {
+            sessions_active: 2,
+            sessions_total: 3,
+            exec_in_flight: 1,
+            sessions_disk_bytes: 4096,
+        }
+    }
+
+    #[test]
+    fn counters_increment() {
+        let m = Metrics::new();
+        m.record_exec_success(10);
+        m.record_exec_success(20);
+        m.record_exec_error(5);
+        m.record_exec_timeout(30);
+        m.record_output_truncated();
+        m.record_session_created();
+        m.record_rejected_concurrency();
+        m.record_rejected_payload();
+        m.record_rejected_unauthorized();
+
+        let s = m.snapshot();
+        assert_eq!(s.exec_success, 2);
+        assert_eq!(s.exec_error, 1);
+        assert_eq!(s.exec_timeout, 1);
+        assert_eq!(s.exec_duration_ms_sum, 65); // 10+20+5+30
+        assert_eq!(s.output_truncated, 1);
+        assert_eq!(s.sessions_created, 1);
+        assert_eq!(s.rejected_concurrency, 1);
+        assert_eq!(s.rejected_payload, 1);
+        assert_eq!(s.rejected_unauthorized, 1);
+    }
+
+    #[test]
+    fn prometheus_render_is_well_formed() {
+        let m = Metrics::new();
+        m.record_exec_success(40);
+        m.record_exec_error(10);
+        let text = m.render_prometheus(&gauges());
+
+        // Every metric family has a HELP and TYPE line.
+        let help = text.matches("# HELP ").count();
+        let typ = text.matches("# TYPE ").count();
+        assert_eq!(help, typ);
+        assert!(help >= 10);
+
+        // Labeled and gauge samples present with expected values.
+        assert!(text.contains("wasmrun_agent_exec_total{result=\"success\"} 1"));
+        assert!(text.contains("wasmrun_agent_exec_total{result=\"error\"} 1"));
+        assert!(text.contains("wasmrun_agent_exec_duration_ms_sum 50"));
+        assert!(text.contains("wasmrun_agent_exec_duration_ms_count 2"));
+        assert!(text.contains("wasmrun_agent_sessions_active 2"));
+        assert!(text.contains("wasmrun_agent_exec_in_flight 1"));
+        assert!(text.contains("wasmrun_agent_sessions_disk_bytes 4096"));
+
+        // No sample line should be empty or malformed (each ends in a number).
+        for line in text.lines() {
+            if line.starts_with('#') || line.is_empty() {
+                continue;
+            }
+            let last = line.rsplit(' ').next().unwrap();
+            assert!(last.parse::<u64>().is_ok(), "bad sample line: {line}");
+        }
+    }
+
+    #[test]
+    fn json_render_shape() {
+        let m = Metrics::new();
+        m.record_exec_success(40);
+        m.record_exec_timeout(60);
+        let v = m.render_json(&gauges(), None);
+
+        assert_eq!(v["exec_total"]["success"], 1);
+        assert_eq!(v["exec_total"]["timeout"], 1);
+        assert_eq!(v["exec_duration_ms_sum"], 100);
+        assert_eq!(v["exec_duration_ms_count"], 2);
+        assert_eq!(v["sessions_active"], 2);
+        assert_eq!(v["sessions_disk_bytes"], 4096);
+        // Per-session omitted when None (auth mode / aggregates only).
+        assert!(v.get("sessions").is_none());
+    }
+
+    #[test]
+    fn json_render_includes_per_session_when_present() {
+        let m = Metrics::new();
+        let rows = vec![SessionResourceRow {
+            id: "abc".into(),
+            disk_bytes: 1024,
+            memory_cap_pages: Some(4096),
+        }];
+        let v = m.render_json(&gauges(), Some(rows));
+        assert_eq!(v["sessions"][0]["id"], "abc");
+        assert_eq!(v["sessions"][0]["disk_bytes"], 1024);
+        assert_eq!(v["sessions"][0]["memory_cap_pages"], 4096);
+    }
+}

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -8,6 +8,7 @@ pub mod api;
 pub mod auth;
 pub mod executor;
 pub mod limits;
+pub mod metrics;
 pub mod server;
 pub mod session;
 pub mod shell;

--- a/src/agent/server.rs
+++ b/src/agent/server.rs
@@ -4,6 +4,7 @@ use crate::agent::api::*;
 use crate::agent::auth::AuthConfig;
 use crate::agent::executor;
 use crate::agent::limits::{dir_size, ResourceLimits};
+use crate::agent::metrics::{Gauges, Metrics, SessionResourceRow};
 use crate::agent::session::{SessionConfig, SessionError, SessionManager, SessionState};
 use crate::agent::shell;
 use crate::agent::tools;
@@ -80,6 +81,12 @@ impl ExecSlots {
         })
     }
 
+    /// Current number of exec workers holding a slot. Read live for the
+    /// `exec_in_flight` metrics gauge.
+    fn in_flight(&self) -> u64 {
+        self.in_flight.load(Ordering::Acquire) as u64
+    }
+
     /// Try to take a slot. Returns `None` when saturated (caller → 429).
     fn try_acquire(self: &Arc<Self>) -> Option<ExecPermit> {
         if self.max == 0 {
@@ -124,6 +131,7 @@ pub struct AgentServer {
     session_manager: Arc<SessionManager>,
     config: AgentConfig,
     exec_slots: Arc<ExecSlots>,
+    metrics: Arc<Metrics>,
 }
 
 impl AgentServer {
@@ -134,6 +142,7 @@ impl AgentServer {
             session_manager,
             config,
             exec_slots,
+            metrics: Arc::new(Metrics::new()),
         }
     }
 
@@ -234,9 +243,13 @@ impl AgentServer {
         println!("     POST   /sessions/:id/env       set env vars");
         println!("     GET    /sessions/:id/env       get env vars");
         println!("     GET    /tools                  LLM tool schemas");
+        println!("     GET    /metrics                metrics (Prometheus | ?format=json)");
         println!();
     }
 
+    /// CORS headers shared by every response. The `Content-Type` is added
+    /// per-response by [`send`](Self::send) so the metrics endpoint can return
+    /// `text/plain` while everything else returns `application/json`.
     fn cors_headers(&self) -> Vec<Header> {
         let origin = if self.config.allow_cors {
             "*"
@@ -255,43 +268,58 @@ impl AgentServer {
                 &b"Content-Type, Authorization"[..],
             )
             .unwrap(),
-            Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..]).unwrap(),
         ]
     }
 
     fn handle_request(&self, mut request: Request) -> Result<()> {
         let method = request.method().clone();
         let url = request.url().to_string();
+        let (path, query) = split_url(&url);
+
+        // Per-request context for the structured access log + `X-Request-Id`.
+        // Built up front so even early returns (OPTIONS, 401, 413) are logged
+        // and carry the id header. `tenant` is filled in after auth resolves.
+        let mut log = ReqLog {
+            id: generate_request_id(),
+            method: method.as_str().to_string(),
+            path: path.clone(),
+            tenant: "-".to_string(),
+            start: Instant::now(),
+        };
 
         if self.config.verbose {
-            eprintln!("{method} {url}");
+            eprintln!("→ {method} {url} (id={})", log.id);
         }
 
         if method == Method::Options {
-            return self.respond_empty(request, 204);
+            return self.respond_empty(request, 204, &log);
         }
 
         // Authentication gate. Resolved once here — after the OPTIONS
         // short-circuit, before routing — so every handler receives an
         // already-validated caller. `None` means open mode (no auth config);
         // `Some(tenant)` is the authenticated tenant id. Auth applies to all
-        // `/api/v1/*` routes including `/tools` (simplest and most secure; it
-        // can be exempted later if a public tool catalog is wanted).
+        // `/api/v1/*` routes including `/tools` and `/metrics` (simplest and
+        // most secure; the metrics scrape is capped at global aggregates so a
+        // tenant key cannot read another tenant's per-session data).
         let tenant: Option<&str> = match &self.config.auth {
             None => None,
             Some(auth) => match bearer_token(&request).and_then(|key| auth.resolve(key)) {
-                Some(t) => Some(t),
+                Some(t) => {
+                    log.tenant = t.to_string();
+                    Some(t)
+                }
                 None => {
+                    self.metrics.record_rejected_unauthorized();
                     let err = ApiError::Unauthorized(
                         "missing or invalid API key (expected 'Authorization: Bearer <key>')"
                             .into(),
                     );
-                    return self.respond_json(request, Err::<serde_json::Value, _>(err));
+                    return self.respond_json(request, Err::<serde_json::Value, _>(err), &log);
                 }
             },
         };
 
-        let (path, query) = split_url(&url);
         let segments: Vec<&str> = path
             .trim_start_matches(API_PREFIX)
             .trim_matches('/')
@@ -305,60 +333,126 @@ impl AgentServer {
         let body = if method == Method::Post {
             match read_body(request.as_reader(), self.config.max_body_bytes) {
                 Ok(b) => b,
-                Err(e) => return self.respond_json(request, Err::<serde_json::Value, _>(e)),
+                Err(e) => {
+                    if matches!(e, ApiError::PayloadTooLarge(_)) {
+                        self.metrics.record_rejected_payload();
+                    }
+                    return self.respond_json(request, Err::<serde_json::Value, _>(e), &log);
+                }
             }
         } else {
             String::new()
         };
 
-        let result = match (method, segments.as_slice()) {
+        match (method, segments.as_slice()) {
             (Method::Get, ["tools"]) => {
                 let params = parse_query(&query);
                 let format = params.get("format").map(|s| s.as_str()).unwrap_or("openai");
-                self.respond_json(request, self.handle_get_tools(format))
+                self.respond_json(request, self.handle_get_tools(format), &log)
             }
-            (Method::Post, ["sessions"]) => {
-                self.respond_json(request, self.handle_create_session_with_body(&body, tenant))
+            (Method::Get, ["metrics"]) => {
+                let params = parse_query(&query);
+                // Prometheus text exposition is the scrape default; `?format=json`
+                // returns the same data as a flat JSON object.
+                match params.get("format").map(|s| s.as_str()) {
+                    Some("json") => {
+                        self.respond_json(request, Ok::<_, ApiError>(self.metrics_json()), &log)
+                    }
+                    _ => self.send(
+                        request,
+                        200,
+                        self.metrics_prometheus(),
+                        "text/plain; version=0.0.4; charset=utf-8",
+                        &log,
+                    ),
+                }
             }
+            (Method::Post, ["sessions"]) => self.respond_json(
+                request,
+                self.handle_create_session_with_body(&body, tenant),
+                &log,
+            ),
             (Method::Get, ["sessions", id]) => {
-                self.respond_json(request, self.handle_get_session(id, tenant))
+                self.respond_json(request, self.handle_get_session(id, tenant), &log)
             }
             (Method::Delete, ["sessions", id]) => {
-                self.respond_json(request, self.handle_delete_session(id, tenant))
+                self.respond_json(request, self.handle_delete_session(id, tenant), &log)
             }
             (Method::Post, ["sessions", id, "exec"]) => {
-                self.respond_json(request, self.handle_exec(id, &body, tenant))
+                self.respond_json(request, self.handle_exec(id, &body, tenant), &log)
             }
             (Method::Post, ["sessions", id, "files"]) => {
-                self.respond_json(request, self.handle_write_file(id, &body, tenant))
+                self.respond_json(request, self.handle_write_file(id, &body, tenant), &log)
             }
             (Method::Get, ["sessions", id, "files"]) => {
                 let params = parse_query(&query);
                 let path = params.get("path").map(|s| s.as_str()).unwrap_or("/");
                 if params.get("list").map(|v| v == "true").unwrap_or(false) {
-                    self.respond_json(request, self.handle_list_files(id, path, tenant))
+                    self.respond_json(request, self.handle_list_files(id, path, tenant), &log)
                 } else {
-                    self.respond_json(request, self.handle_read_file(id, path, tenant))
+                    self.respond_json(request, self.handle_read_file(id, path, tenant), &log)
                 }
             }
             (Method::Delete, ["sessions", id, "files"]) => {
                 let params = parse_query(&query);
                 let path = params.get("path").map(|s| s.as_str()).unwrap_or("");
-                self.respond_json(request, self.handle_delete_file(id, path, tenant))
+                self.respond_json(request, self.handle_delete_file(id, path, tenant), &log)
             }
             (Method::Post, ["sessions", id, "env"]) => {
-                self.respond_json(request, self.handle_set_env(id, &body, tenant))
+                self.respond_json(request, self.handle_set_env(id, &body, tenant), &log)
             }
             (Method::Get, ["sessions", id, "env"]) => {
-                self.respond_json(request, self.handle_get_env(id, tenant))
+                self.respond_json(request, self.handle_get_env(id, tenant), &log)
             }
             _ => {
                 let err = ApiError::NotFound(format!("Unknown endpoint: {path}"));
-                self.respond_json(request, Err::<serde_json::Value, _>(err))
+                self.respond_json(request, Err::<serde_json::Value, _>(err), &log)
             }
-        };
+        }
+    }
 
-        result
+    /// Sample the live gauge values at scrape time.
+    fn current_gauges(&self) -> Gauges {
+        Gauges {
+            sessions_active: self.session_manager.active_count() as u64,
+            sessions_total: self.session_manager.total_count() as u64,
+            exec_in_flight: self.exec_slots.in_flight(),
+            sessions_disk_bytes: self.session_manager.total_disk_bytes(),
+        }
+    }
+
+    fn metrics_prometheus(&self) -> String {
+        self.metrics.render_prometheus(&self.current_gauges())
+    }
+
+    fn metrics_json(&self) -> serde_json::Value {
+        // Compute per-session reports once and derive the disk gauge from them.
+        let reports = self.session_manager.session_reports();
+        let disk: u64 = reports.iter().map(|r| r.disk_bytes).sum();
+        let gauges = Gauges {
+            sessions_active: self.session_manager.active_count() as u64,
+            sessions_total: self.session_manager.total_count() as u64,
+            exec_in_flight: self.exec_slots.in_flight(),
+            sessions_disk_bytes: disk,
+        };
+        // Per-session rows are exposed only in open mode. In auth mode they
+        // would leak one tenant's footprint to another, so the scrape stays at
+        // global aggregates (0.20.5 Q2/Q3).
+        let per_session = if self.config.auth.is_none() {
+            Some(
+                reports
+                    .into_iter()
+                    .map(|r| SessionResourceRow {
+                        id: r.id,
+                        disk_bytes: r.disk_bytes,
+                        memory_cap_pages: r.memory_cap_pages,
+                    })
+                    .collect(),
+            )
+        } else {
+            None
+        };
+        self.metrics.render_json(&gauges, per_session)
     }
 
     // ── Session endpoints ─────────────────────────────────────────
@@ -402,6 +496,7 @@ impl AgentServer {
                 owner.map(String::from),
             )
             .map_err(map_session_err)?;
+        self.metrics.record_session_created();
         Ok(CreateSessionResponse {
             session_id: id,
             created_at: chrono::Utc::now().to_rfc3339(),
@@ -486,10 +581,13 @@ impl AgentServer {
         // this HTTP response returns) — a timed-out-but-still-running worker keeps
         // its slot until cooperative cancellation actually stops it. On saturation
         // reject with 429 before spawning a fresh 64 MB-stack thread.
-        let permit = self
-            .exec_slots
-            .try_acquire()
-            .ok_or(ApiError::TooManyRequests(self.config.max_concurrent_exec))?;
+        let permit = match self.exec_slots.try_acquire() {
+            Some(p) => p,
+            None => {
+                self.metrics.record_rejected_concurrency();
+                return Err(ApiError::TooManyRequests(self.config.max_concurrent_exec));
+            }
+        };
 
         let (tx, rx) = std::sync::mpsc::channel::<std::result::Result<i32, ApiError>>();
         // Cooperative cancellation: the worker runs detached, so if the
@@ -611,17 +709,23 @@ impl AgentServer {
                 // for the shell path, which isn't a long-running interpreter.)
                 cancel.store(true, Ordering::Relaxed);
                 duration_ms = start.elapsed().as_millis() as u64;
+                let truncated = read_env_truncated(&wasi_env);
+                self.metrics.record_exec_timeout(duration_ms);
+                if truncated {
+                    self.metrics.record_output_truncated();
+                }
                 return Ok(ExecResponse {
                     stdout: read_env_stdout(&wasi_env),
                     stderr: read_env_stderr(&wasi_env),
                     exit_code: -1,
                     duration_ms,
-                    output_truncated: read_env_truncated(&wasi_env),
+                    output_truncated: truncated,
                     error: Some(format!("Execution timed out after {timeout_secs}s")),
                 });
             }
             Err(_) => {
                 duration_ms = start.elapsed().as_millis() as u64;
+                self.metrics.record_exec_error(duration_ms);
                 return Ok(ExecResponse {
                     stdout: String::new(),
                     stderr: String::new(),
@@ -633,23 +737,33 @@ impl AgentServer {
             }
         };
 
+        let truncated = read_env_truncated(&wasi_env);
+        if truncated {
+            self.metrics.record_output_truncated();
+        }
         match exec_result {
-            Ok(exit_code) => Ok(ExecResponse {
-                stdout: read_env_stdout(&wasi_env),
-                stderr: read_env_stderr(&wasi_env),
-                exit_code,
-                duration_ms,
-                output_truncated: read_env_truncated(&wasi_env),
-                error: None,
-            }),
-            Err(e) => Ok(ExecResponse {
-                stdout: read_env_stdout(&wasi_env),
-                stderr: read_env_stderr(&wasi_env),
-                exit_code: -1,
-                duration_ms,
-                output_truncated: read_env_truncated(&wasi_env),
-                error: Some(e.to_string()),
-            }),
+            Ok(exit_code) => {
+                self.metrics.record_exec_success(duration_ms);
+                Ok(ExecResponse {
+                    stdout: read_env_stdout(&wasi_env),
+                    stderr: read_env_stderr(&wasi_env),
+                    exit_code,
+                    duration_ms,
+                    output_truncated: truncated,
+                    error: None,
+                })
+            }
+            Err(e) => {
+                self.metrics.record_exec_error(duration_ms);
+                Ok(ExecResponse {
+                    stdout: read_env_stdout(&wasi_env),
+                    stderr: read_env_stderr(&wasi_env),
+                    exit_code: -1,
+                    duration_ms,
+                    output_truncated: truncated,
+                    error: Some(e.to_string()),
+                })
+            }
         }
     }
 
@@ -839,6 +953,7 @@ impl AgentServer {
         &self,
         request: Request,
         result: std::result::Result<T, ApiError>,
+        log: &ReqLog,
     ) -> Result<()> {
         let (status, body) = match result {
             Ok(data) => (200, serde_json::to_string(&data).unwrap_or_default()),
@@ -848,20 +963,35 @@ impl AgentServer {
                 (code, body)
             }
         };
+        self.send(request, status, body, "application/json", log)
+    }
+
+    fn respond_empty(&self, request: Request, status: u16, log: &ReqLog) -> Result<()> {
+        self.send(request, status, String::new(), "application/json", log)
+    }
+
+    /// Send a response with the given status/body/content-type, attaching CORS
+    /// and the `X-Request-Id` header, and emit the structured access-log line.
+    /// Every response in the server funnels through here so logging and the id
+    /// header are uniform across all routes and early returns.
+    fn send(
+        &self,
+        request: Request,
+        status: u16,
+        body: String,
+        content_type: &str,
+        log: &ReqLog,
+    ) -> Result<()> {
+        log.emit(status);
         let mut response = Response::from_string(body).with_status_code(StatusCode(status));
         for h in self.cors_headers() {
             response = response.with_header(h);
         }
-        request
-            .respond(response)
-            .map_err(|e| WasmrunError::from(format!("Response error: {e}")))
-    }
-
-    fn respond_empty(&self, request: Request, status: u16) -> Result<()> {
-        let mut response = Response::from_string("").with_status_code(StatusCode(status));
-        for h in self.cors_headers() {
-            response = response.with_header(h);
-        }
+        response = response.with_header(
+            Header::from_bytes(&b"Content-Type"[..], content_type.as_bytes()).unwrap(),
+        );
+        response = response
+            .with_header(Header::from_bytes(&b"X-Request-Id"[..], log.id.as_bytes()).unwrap());
         request
             .respond(response)
             .map_err(|e| WasmrunError::from(format!("Response error: {e}")))
@@ -869,6 +999,60 @@ impl AgentServer {
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────
+
+/// Per-request context for the always-on structured access log and the
+/// `X-Request-Id` response header. One is built at the top of every request
+/// and carried through to whichever response path runs.
+struct ReqLog {
+    id: String,
+    method: String,
+    path: String,
+    /// Authenticated tenant id, or `"-"` in open mode / before auth resolves.
+    tenant: String,
+    start: Instant,
+}
+
+impl ReqLog {
+    /// Emit the one-line `key=value` access record to stderr (always on).
+    /// Greppable and dependency-free; `--verbose` adds the request-received
+    /// line separately at the top of `handle_request`.
+    fn emit(&self, status: u16) {
+        let dur_ms = self.start.elapsed().as_millis();
+        let ts = chrono::Utc::now().to_rfc3339();
+        eprintln!(
+            "ts={ts} id={id} method={method} path={path} status={status} dur_ms={dur_ms} tenant={tenant}",
+            id = self.id,
+            method = self.method,
+            path = self.path,
+            tenant = self.tenant,
+        );
+    }
+}
+
+/// Generate a short random hex request id (16 chars) for access logs and the
+/// `X-Request-Id` header. Mirrors the session-id generator's xorshift mixing;
+/// not cryptographically secure — only needs to be unique enough to correlate
+/// a log line with a response.
+fn generate_request_id() -> String {
+    use std::sync::atomic::AtomicU64;
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos() as u64;
+    let count = COUNTER.fetch_add(1, Ordering::Relaxed);
+
+    let mut state = nanos ^ (count.wrapping_mul(0x9E37_79B9_7F4A_7C15));
+    let mut s = String::with_capacity(16);
+    for _ in 0..8 {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        s.push_str(&format!("{:02x}", state & 0xFF));
+    }
+    s
+}
 
 /// Format a memory page count as a human-readable MB string for the banner.
 fn fmt_pages_mb(pages: Option<u32>) -> String {
@@ -1084,6 +1268,24 @@ mod tests {
         let mut f = tempfile::NamedTempFile::new().unwrap();
         std::io::Write::write_all(&mut f, toml.as_bytes()).unwrap();
         AuthConfig::load(f.path()).unwrap()
+    }
+
+    /// An open-mode (no-auth) server bound to a specific `port`, for HTTP tests.
+    fn open_server(port: u16) -> AgentServer {
+        AgentServer::new(AgentConfig {
+            port,
+            session_config: SessionConfig {
+                default_timeout: Duration::from_secs(60),
+                max_sessions: 10,
+                cleanup_interval: Duration::from_secs(300),
+                limits: crate::agent::limits::ResourceLimits::default(),
+            },
+            allow_cors: true,
+            verbose: false,
+            max_body_bytes: Some(32 * 1024 * 1024),
+            max_concurrent_exec: 100,
+            auth: None,
+        })
     }
 
     /// A server on `port` with auth enabled for the given `(key, tenant_id)` pairs.
@@ -2355,6 +2557,238 @@ mod tests {
                     .call()
             ),
             200
+        );
+    }
+
+    // ── Observability / metrics (0.20.5) ──────────────────────────
+
+    #[test]
+    fn test_metrics_exec_success_recorded() {
+        let server = test_server();
+        let id = server.handle_create_session().unwrap().session_id;
+        let work_dir = server
+            .session_manager
+            .get_session(&id, None, |s| s.work_dir().to_path_buf())
+            .unwrap();
+        std::fs::write(work_dir.join("hello.wasm"), hello_wasm()).unwrap();
+
+        server
+            .handle_exec(&id, r#"{"wasm_path": "hello.wasm"}"#, None)
+            .unwrap();
+
+        let v = server.metrics_json();
+        assert_eq!(v["exec_total"]["success"], 1);
+        assert_eq!(v["exec_total"]["error"], 0);
+        assert_eq!(v["exec_total"]["timeout"], 0);
+        assert_eq!(v["exec_duration_ms_count"], 1);
+        server.session_manager.destroy_all().unwrap();
+    }
+
+    #[test]
+    fn test_metrics_session_created_and_active_gauge() {
+        let server = test_server();
+        let a = server.handle_create_session().unwrap().session_id;
+        let _b = server.handle_create_session().unwrap().session_id;
+
+        let v = server.metrics_json();
+        assert_eq!(v["sessions_created_total"], 2);
+        assert_eq!(v["sessions_active"], 2);
+
+        // Destroying one drops the active gauge but not the cumulative counter.
+        server.handle_delete_session(&a, None).unwrap();
+        let v = server.metrics_json();
+        assert_eq!(v["sessions_created_total"], 2);
+        assert_eq!(v["sessions_active"], 1);
+        server.session_manager.destroy_all().unwrap();
+    }
+
+    #[test]
+    fn test_metrics_concurrency_rejection_recorded() {
+        let server = test_server_with_concurrency(1);
+        let id = server.handle_create_session().unwrap().session_id;
+        let work_dir = server
+            .session_manager
+            .get_session(&id, None, |s| s.work_dir().to_path_buf())
+            .unwrap();
+        std::fs::write(work_dir.join("hello.wasm"), hello_wasm()).unwrap();
+
+        // Hold the only slot so the exec is rejected with 429.
+        let held = server.exec_slots.try_acquire().unwrap();
+        let err = server
+            .handle_exec(&id, r#"{"wasm_path": "hello.wasm"}"#, None)
+            .unwrap_err();
+        assert_eq!(err.status_code(), 429);
+        drop(held);
+
+        let v = server.metrics_json();
+        assert_eq!(v["exec_rejected_total"]["concurrency"], 1);
+        server.session_manager.destroy_all().unwrap();
+    }
+
+    #[test]
+    fn test_metrics_json_includes_per_session_in_open_mode() {
+        let server = test_server(); // open mode (auth = None)
+        let id = server.handle_create_session().unwrap().session_id;
+        server
+            .handle_write_file(&id, r#"{"path": "a.txt", "content": "hello"}"#, None)
+            .unwrap();
+
+        let v = server.metrics_json();
+        let sessions = v["sessions"].as_array().expect("per-session rows present");
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0]["id"], id);
+        assert!(sessions[0]["disk_bytes"].as_u64().unwrap() >= 5); // "hello"
+                                                                   // Aggregate disk gauge reflects the written file too.
+        assert!(v["sessions_disk_bytes"].as_u64().unwrap() >= 5);
+        server.session_manager.destroy_all().unwrap();
+    }
+
+    #[test]
+    fn test_metrics_json_omits_per_session_in_auth_mode() {
+        // Per-session rows are withheld in auth mode (Q2: aggregates only).
+        let server = auth_server(0, &[("key_a", "alice")]);
+        let id = server
+            .handle_create_session_with_body("", Some("alice"))
+            .unwrap()
+            .session_id;
+        server
+            .handle_write_file(&id, r#"{"path": "a.txt", "content": "hi"}"#, Some("alice"))
+            .unwrap();
+
+        let v = server.metrics_json();
+        assert!(
+            v.get("sessions").is_none(),
+            "per-session rows must be hidden in auth mode"
+        );
+        // Global aggregates are still present.
+        assert_eq!(v["sessions_active"], 1);
+        server.session_manager.destroy_all().unwrap();
+    }
+
+    #[test]
+    fn test_metrics_prometheus_render_contains_families() {
+        let server = test_server();
+        let _ = server.handle_create_session().unwrap();
+        let text = server.metrics_prometheus();
+        assert!(text.contains("# TYPE wasmrun_agent_exec_total counter"));
+        assert!(text.contains("wasmrun_agent_sessions_created_total 1"));
+        assert!(text.contains("wasmrun_agent_sessions_active 1"));
+        assert!(text.contains("# TYPE wasmrun_agent_sessions_active gauge"));
+        server.session_manager.destroy_all().unwrap();
+    }
+
+    /// Spin up a real server on `port` and wait until it accepts connections.
+    fn wait_until_ready(port: u16) {
+        let probe = format!("http://127.0.0.1:{port}/api/v1/metrics");
+        for _ in 0..100 {
+            match ureq::get(&probe).call() {
+                Err(ureq::Error::Io(_)) => std::thread::sleep(Duration::from_millis(20)),
+                _ => break,
+            }
+        }
+    }
+
+    #[test]
+    fn test_metrics_over_http_open_mode() {
+        use std::io::Read;
+        let port = std::net::TcpListener::bind("127.0.0.1:0")
+            .unwrap()
+            .local_addr()
+            .unwrap()
+            .port();
+        std::thread::spawn(move || {
+            let _ = open_server(port).start();
+        });
+        wait_until_ready(port);
+
+        let metrics = format!("http://127.0.0.1:{port}/api/v1/metrics");
+
+        // Default: Prometheus text exposition + X-Request-Id header.
+        let resp = ureq::get(&metrics).call().unwrap();
+        assert_eq!(resp.status().as_u16(), 200);
+        let ctype = resp
+            .headers()
+            .get("Content-Type")
+            .and_then(|h| h.to_str().ok())
+            .unwrap_or("")
+            .to_string();
+        assert!(ctype.starts_with("text/plain"), "got content-type {ctype}");
+        assert!(
+            resp.headers().get("X-Request-Id").is_some(),
+            "X-Request-Id header missing"
+        );
+        let mut resp = resp;
+        let mut body = String::new();
+        resp.body_mut()
+            .as_reader()
+            .read_to_string(&mut body)
+            .unwrap();
+        assert!(body.contains("wasmrun_agent_exec_total"));
+        assert!(body.contains("# HELP wasmrun_agent_sessions_active"));
+
+        // JSON variant parses and carries the same families.
+        let mut resp = ureq::get(format!("{metrics}?format=json")).call().unwrap();
+        assert_eq!(resp.status().as_u16(), 200);
+        let ctype = resp
+            .headers()
+            .get("Content-Type")
+            .and_then(|h| h.to_str().ok())
+            .unwrap_or("")
+            .to_string();
+        assert!(ctype.starts_with("application/json"), "got {ctype}");
+        let mut body = String::new();
+        resp.body_mut()
+            .as_reader()
+            .read_to_string(&mut body)
+            .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert!(v["exec_total"].is_object());
+        assert!(v["sessions_active"].is_u64());
+    }
+
+    #[test]
+    fn test_metrics_auth_gated_and_counts_unauthorized() {
+        use std::io::Read;
+        let port = std::net::TcpListener::bind("127.0.0.1:0")
+            .unwrap()
+            .local_addr()
+            .unwrap()
+            .port();
+        std::thread::spawn(move || {
+            let _ = auth_server(port, &[("key_a", "alice")]).start();
+        });
+
+        let base = format!("http://127.0.0.1:{port}/api/v1");
+        // Wait until accepting (a 401 counts as ready).
+        for _ in 0..100 {
+            match ureq::get(format!("{base}/metrics")).call() {
+                Err(ureq::Error::Io(_)) => std::thread::sleep(Duration::from_millis(20)),
+                _ => break,
+            }
+        }
+
+        // No key → 401 (this also bumps the unauthorized rejection counter).
+        assert_eq!(
+            http_status(ureq::get(format!("{base}/metrics")).call()),
+            401
+        );
+
+        // Valid key → 200 JSON; unauthorized counter recorded; no per-session rows.
+        let mut resp = ureq::get(format!("{base}/metrics?format=json"))
+            .header("Authorization", "Bearer key_a")
+            .call()
+            .unwrap();
+        assert_eq!(resp.status().as_u16(), 200);
+        let mut body = String::new();
+        resp.body_mut()
+            .as_reader()
+            .read_to_string(&mut body)
+            .unwrap();
+        let v: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert!(v["exec_rejected_total"]["unauthorized"].as_u64().unwrap() >= 1);
+        assert!(
+            v.get("sessions").is_none(),
+            "auth mode must not expose per-session rows"
         );
     }
 }

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -469,9 +469,45 @@ impl SessionManager {
     }
 
     /// Get the total number of sessions (including expired ones not yet cleaned up).
-    #[allow(dead_code)] // TODO: Used by agent metrics
     pub fn total_count(&self) -> usize {
         self.sessions.read().map(|s| s.len()).unwrap_or(0)
+    }
+
+    /// Per-session resource report (id, disk footprint, configured memory cap)
+    /// for active sessions. Used by the JSON metrics breakdown.
+    ///
+    /// The work dirs are collected under the read lock and the (potentially
+    /// slow) filesystem walks run *after* the lock is released, so a metrics
+    /// scrape never blocks session creation/access while walking the FS.
+    pub fn session_reports(&self) -> Vec<SessionReport> {
+        let dirs: Vec<(String, std::path::PathBuf, Option<u32>)> = match self.sessions.read() {
+            Ok(sessions) => sessions
+                .values()
+                .filter(|s| !s.is_expired())
+                .map(|s| {
+                    (
+                        s.id().to_string(),
+                        s.work_dir().to_path_buf(),
+                        s.limits().max_memory_pages,
+                    )
+                })
+                .collect(),
+            Err(_) => return Vec::new(),
+        };
+        dirs.into_iter()
+            .map(|(id, dir, memory_cap_pages)| SessionReport {
+                id,
+                disk_bytes: crate::agent::limits::dir_size(&dir),
+                memory_cap_pages,
+            })
+            .collect()
+    }
+
+    /// Total on-disk footprint across active sessions, in bytes. Sums the
+    /// per-session reports; see [`session_reports`](Self::session_reports) for
+    /// the locking strategy.
+    pub fn total_disk_bytes(&self) -> u64 {
+        self.session_reports().iter().map(|r| r.disk_bytes).sum()
     }
 
     /// Start the background cleanup thread.
@@ -534,6 +570,15 @@ pub struct SessionInfo {
     pub created_at_elapsed: Duration,
     pub last_accessed_elapsed: Duration,
     pub timeout: Duration,
+}
+
+/// Per-session resource footprint, produced by
+/// [`SessionManager::session_reports`] for the metrics endpoint.
+#[derive(Debug, Clone)]
+pub struct SessionReport {
+    pub id: String,
+    pub disk_bytes: u64,
+    pub memory_cap_pages: Option<u32>,
 }
 
 // ── Errors ────────────────────────────────────────────────────────────


### PR DESCRIPTION
Operators running `wasmrun agent` had no runtime signal — no way to see how many sessions exist, how execs are faring, or what's being rejected without attaching a debugger. This adds a scrape-friendly metrics endpoint and an always-on structured access log. Dependency-free, matching the house style (hand-rolled `AtomicU64` registry + hand-written exposition text, no `prometheus`/`metrics` crate).

## Metrics endpoint

`GET /api/v1/metrics` returns Prometheus text by default (scrape-ready) or JSON with `?format=json`, mirroring the existing `/tools?format=…` pattern:

    curl http://localhost:8430/api/v1/metrics
    curl "http://localhost:8430/api/v1/metrics?format=json"

It exposes **counters** (executions by `success`/`error`/`timeout`, duration sum+count, output truncations, sessions created, and rejections by reason: `concurrency`/`payload`/`unauthorized`) and live **gauges** (active sessions, total sessions, in-flight execs, total session disk). Gauges are sampled from `SessionManager`/`ExecSlots` at scrape time rather than mirrored into counters, so they can't drift.

## Access log

Every request now emits one `key=value` line to stderr (`ts`/`id`/`method`/`path`/`status`/`dur_ms`/`tenant`) and carries an `X-Request-Id` response header for correlation; `--verbose` adds a request-received line. All responses funnel through one `send()` helper, which also lets `/metrics` return `text/plain` while other routes stay JSON.

## Auth interaction

When `--auth` is enabled, `/metrics` is gated like any endpoint and limited to global aggregates; per-session rows (disk + memory cap, JSON only) are exposed solely in open mode, so no tenant can infer another's footprint. Per-tenant metering is deferred to 0.20.6.

## Testing

- 4 unit tests in `metrics.rs` (counter increments, Prometheus well-formedness, JSON shape, per-session presence) + 8 in `server.rs` (exec/session counters, rejection counts, per-session open-vs-auth, content-type/`X-Request-Id`/format selection over real HTTP, auth gate).
- Full suite green after rebasing onto `main`: **643 unit + 16 integration tests pass**; `cargo fmt --check` and `cargo clippy --all-targets` clean.

Implements 0.20.5 in `plan/EXEC_AGENT_IMPLEMENTATION.md`.