### PR TITLE
feat(agent): add per-tenant rate limiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Per-Tenant Rate Limiting (auth mode)**: throttle each tenant independently so one tenant can't exhaust a shared agent server
+  - Optional `[tenants.rate]` sub-table per `[[tenants]]` in the auth config: `max_sessions`, `max_concurrent_exec`, `max_requests_per_min` (each `0`/omitted = inherit the server-wide default)
+  - Per-tenant session cap enforced at session creation (counts only the tenant's own non-expired sessions, alongside the global `--max-sessions`); over limit returns **429**
+  - Per-tenant concurrent-exec cap via a per-tenant counting semaphore acquired alongside the global one; both release on worker completion. Saturation returns **429**
+  - Per-tenant requests/min cap (fixed window) checked at the auth gate before the body is read, covering every `/api/v1/*` route; over limit returns **429**
+  - New `ApiError::RateLimited` (429) and a `rate` reason added to the `wasmrun_agent_exec_rejected_total` metric family
+  - Open mode (no `--auth`) is unaffected — only the existing global limits apply
 - **Agent Observability**: runtime metrics and a structured access log so an operator can see health, load, and failures without a debugger
   - `GET /api/v1/metrics` returns **Prometheus** text exposition by default (scrape-ready) or JSON with `?format=json`
   - Counters: executions by result (`success`/`error`/`timeout`), execution duration sum + count (for an average), output-truncated count, sessions created, and requests rejected before doing work by reason (`concurrency` 429, `payload` 413, `unauthorized` 401)

--- a/src/agent/api.rs
+++ b/src/agent/api.rs
@@ -126,6 +126,9 @@ pub enum ApiError {
     PayloadTooLarge(usize),
     /// Too many concurrent executions in flight. Carries the configured cap.
     TooManyRequests(usize),
+    /// A per-tenant rate limit was exceeded (session count, concurrent exec, or
+    /// requests/min). Carries a human-readable reason.
+    RateLimited(String),
     #[allow(dead_code)] // TODO: Used when exec timeout triggers API-level error
     Timeout,
     Internal(String),
@@ -136,7 +139,9 @@ impl ApiError {
         match self {
             ApiError::SessionNotFound(_) | ApiError::NotFound(_) => 404,
             ApiError::SessionExpired(_) => 410,
-            ApiError::MaxSessions(_) | ApiError::TooManyRequests(_) => 429,
+            ApiError::MaxSessions(_) | ApiError::TooManyRequests(_) | ApiError::RateLimited(_) => {
+                429
+            }
             ApiError::BadRequest(_) => 400,
             ApiError::Unauthorized(_) => 401,
             ApiError::PayloadTooLarge(_) => 413,
@@ -168,6 +173,7 @@ impl std::fmt::Display for ApiError {
             ApiError::TooManyRequests(max) => {
                 write!(f, "Too many concurrent executions: limit is {max}")
             }
+            ApiError::RateLimited(reason) => write!(f, "Rate limit exceeded: {reason}"),
             ApiError::Timeout => write!(f, "Execution timed out"),
             ApiError::Internal(msg) => write!(f, "Internal error: {msg}"),
         }

--- a/src/agent/auth.rs
+++ b/src/agent/auth.rs
@@ -49,6 +49,27 @@ struct RawAuth {
 struct RawTenant {
     id: String,
     key_sha256: String,
+    /// Optional `[tenants.rate]` sub-table; absent = inherit all defaults.
+    #[serde(default)]
+    rate: Option<TenantRate>,
+}
+
+/// Per-tenant rate ceilings, from the optional `[tenants.rate]` sub-table.
+///
+/// Each field caps one dimension of a tenant's load. A value of `0` (or an
+/// omitted field) means "inherit the server-wide default" for that dimension,
+/// matching the `0 = default/unlimited` convention used by the CLI limit flags.
+#[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
+pub struct TenantRate {
+    /// Max concurrent (non-expired) sessions this tenant may hold.
+    #[serde(default)]
+    pub max_sessions: u32,
+    /// Max exec workers this tenant may run concurrently.
+    #[serde(default)]
+    pub max_concurrent_exec: u32,
+    /// Max requests this tenant may issue within a rolling one-minute window.
+    #[serde(default)]
+    pub max_requests_per_min: u32,
 }
 
 /// Resolved auth configuration: a map from key hash → tenant id.
@@ -58,6 +79,8 @@ struct RawTenant {
 pub struct AuthConfig {
     /// SHA-256 hex of the key → tenant id.
     keys: HashMap<String, String>,
+    /// Tenant id → per-tenant rate ceilings (default = all-inherit).
+    rates: HashMap<String, TenantRate>,
 }
 
 impl AuthConfig {
@@ -106,6 +129,7 @@ impl AuthConfig {
         }
 
         let mut keys: HashMap<String, String> = HashMap::with_capacity(raw.tenants.len());
+        let mut rates: HashMap<String, TenantRate> = HashMap::with_capacity(raw.tenants.len());
         let mut seen_ids: HashMap<String, ()> = HashMap::with_capacity(raw.tenants.len());
 
         for tenant in raw.tenants {
@@ -138,9 +162,11 @@ impl AuthConfig {
                     ),
                 }));
             }
+
+            rates.insert(id.to_string(), tenant.rate.unwrap_or_default());
         }
 
-        Ok(AuthConfig { keys })
+        Ok(AuthConfig { keys, rates })
     }
 
     /// Number of configured tenants.
@@ -152,6 +178,13 @@ impl AuthConfig {
     pub fn resolve(&self, presented_key: &str) -> Option<&str> {
         let hash = hash_key(presented_key);
         self.keys.get(&hash).map(|s| s.as_str())
+    }
+
+    /// Per-tenant rate ceilings for `id`. Returns `None` for an unknown tenant;
+    /// a known tenant with no `[tenants.rate]` table yields the all-inherit
+    /// default.
+    pub fn rate(&self, id: &str) -> Option<&TenantRate> {
+        self.rates.get(id)
     }
 }
 
@@ -264,6 +297,28 @@ mod tests {
     fn test_missing_file() {
         let err = AuthConfig::load(Path::new("/nonexistent/wasmrun-auth.toml")).unwrap_err();
         assert!(err.to_string().contains("not found"));
+    }
+
+    #[test]
+    fn test_parse_tenant_rate() {
+        let body = format!(
+            "[[tenants]]\nid = \"a\"\nkey_sha256 = \"{}\"\n[tenants.rate]\nmax_sessions = 5\nmax_concurrent_exec = 3\nmax_requests_per_min = 100\n\n[[tenants]]\nid = \"b\"\nkey_sha256 = \"{}\"\n",
+            hash_key("ka"),
+            hash_key("kb"),
+        );
+        let f = write_toml(&body);
+        let cfg = AuthConfig::load(f.path()).unwrap();
+
+        let ra = cfg.rate("a").unwrap();
+        assert_eq!(ra.max_sessions, 5);
+        assert_eq!(ra.max_concurrent_exec, 3);
+        assert_eq!(ra.max_requests_per_min, 100);
+
+        // A tenant without a [tenants.rate] table inherits the all-zero default.
+        assert_eq!(*cfg.rate("b").unwrap(), TenantRate::default());
+
+        // Unknown tenant id resolves to no rate.
+        assert!(cfg.rate("nope").is_none());
     }
 
     #[test]

--- a/src/agent/metrics.rs
+++ b/src/agent/metrics.rs
@@ -32,6 +32,9 @@ pub struct Metrics {
     rejected_concurrency: AtomicU64,
     rejected_payload: AtomicU64,
     rejected_unauthorized: AtomicU64,
+    /// Requests/execs rejected by a per-tenant rate cap (session count,
+    /// concurrent exec, or requests/min).
+    rejected_rate: AtomicU64,
 }
 
 /// Point-in-time gauge values, sampled from live state at scrape time rather
@@ -95,6 +98,10 @@ impl Metrics {
         self.rejected_unauthorized.fetch_add(1, ORDER);
     }
 
+    pub fn record_rejected_rate(&self) {
+        self.rejected_rate.fetch_add(1, ORDER);
+    }
+
     /// Consistent-enough snapshot of all counters for rendering.
     fn snapshot(&self) -> Snapshot {
         Snapshot {
@@ -107,6 +114,7 @@ impl Metrics {
             rejected_concurrency: self.rejected_concurrency.load(ORDER),
             rejected_payload: self.rejected_payload.load(ORDER),
             rejected_unauthorized: self.rejected_unauthorized.load(ORDER),
+            rejected_rate: self.rejected_rate.load(ORDER),
         }
     }
 
@@ -167,6 +175,7 @@ impl Metrics {
                 (&[("reason", "concurrency")], s.rejected_concurrency),
                 (&[("reason", "payload")], s.rejected_payload),
                 (&[("reason", "unauthorized")], s.rejected_unauthorized),
+                (&[("reason", "rate")], s.rejected_rate),
             ],
         );
         metric(
@@ -224,6 +233,7 @@ impl Metrics {
                 "concurrency": s.rejected_concurrency,
                 "payload": s.rejected_payload,
                 "unauthorized": s.rejected_unauthorized,
+                "rate": s.rejected_rate,
             },
             "sessions_active": g.sessions_active,
             "sessions_total": g.sessions_total,
@@ -247,6 +257,7 @@ struct Snapshot {
     rejected_concurrency: u64,
     rejected_payload: u64,
     rejected_unauthorized: u64,
+    rejected_rate: u64,
 }
 
 /// Append one Prometheus metric family: `# HELP`, `# TYPE`, then one sample
@@ -314,6 +325,8 @@ mod tests {
         m.record_rejected_concurrency();
         m.record_rejected_payload();
         m.record_rejected_unauthorized();
+        m.record_rejected_rate();
+        m.record_rejected_rate();
 
         let s = m.snapshot();
         assert_eq!(s.exec_success, 2);
@@ -325,6 +338,14 @@ mod tests {
         assert_eq!(s.rejected_concurrency, 1);
         assert_eq!(s.rejected_payload, 1);
         assert_eq!(s.rejected_unauthorized, 1);
+        assert_eq!(s.rejected_rate, 2);
+
+        // The `rate` reason surfaces in both exposition formats.
+        let g = gauges();
+        assert!(m
+            .render_prometheus(&g)
+            .contains("wasmrun_agent_exec_rejected_total{reason=\"rate\"} 2"));
+        assert_eq!(m.render_json(&g, None)["exec_rejected_total"]["rate"], 2);
     }
 
     #[test]

--- a/src/agent/server.rs
+++ b/src/agent/server.rs
@@ -1,7 +1,7 @@
 //! Agent mode: REST API server for AI agent sandbox management.
 
 use crate::agent::api::*;
-use crate::agent::auth::AuthConfig;
+use crate::agent::auth::{AuthConfig, TenantRate};
 use crate::agent::executor;
 use crate::agent::limits::{dir_size, ResourceLimits};
 use crate::agent::metrics::{Gauges, Metrics, SessionResourceRow};
@@ -15,7 +15,7 @@ use std::collections::HashMap;
 use std::io::Read;
 use std::path::{Component, Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
 use tiny_http::{Header, Method, Request, Response, Server, StatusCode};
 
@@ -127,10 +127,116 @@ impl Drop for ExecPermit {
     }
 }
 
+/// Bundles the global and per-tenant exec permits so both slots release together
+/// when the worker completes. The worker closures move this in and drop it on
+/// completion — the same RAII discipline the single global permit used before.
+struct HeldPermits {
+    _global: ExecPermit,
+    _tenant: ExecPermit,
+}
+
+/// Fixed-window per-tenant request counter for the requests/min cap.
+///
+/// `max_per_min == 0` means unlimited. The window is a simple fixed interval
+/// reset when a minute elapses — cheap and dependency-free. A burst can straddle
+/// a window boundary (up to ~2× the cap across two adjacent windows); a smoothing
+/// token-bucket is left as a later refinement.
+struct RateWindow {
+    max_per_min: u64,
+    state: Mutex<(Instant, u64)>,
+}
+
+impl RateWindow {
+    fn new(max_per_min: u64) -> Self {
+        Self {
+            max_per_min,
+            state: Mutex::new((Instant::now(), 0)),
+        }
+    }
+
+    /// Record one request. Returns `false` when it exceeds the window cap.
+    fn allow(&self) -> bool {
+        if self.max_per_min == 0 {
+            return true;
+        }
+        // Recover the guard even if poisoned: never fail-closed on a panic
+        // elsewhere (throttling is best-effort, not a correctness invariant).
+        let mut g = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        let (start, count) = &mut *g;
+        if start.elapsed() >= Duration::from_secs(60) {
+            *start = Instant::now();
+            *count = 0;
+        }
+        if *count >= self.max_per_min {
+            return false;
+        }
+        *count += 1;
+        true
+    }
+}
+
+/// Per-tenant concurrency + request-rate limiter.
+///
+/// Lazily creates a sized [`ExecSlots`] and [`RateWindow`] per tenant on first
+/// use; only consulted in auth mode (open mode has no tenant). Ceilings come from
+/// the tenant's `[tenants.rate]` table. Note: an entry is sized at first use, so
+/// a live config reload (0.20.6c) does not resize an already-created entry — a
+/// known, acceptable limitation revisited there.
+struct TenantLimiter {
+    exec: RwLock<HashMap<String, Arc<ExecSlots>>>,
+    windows: RwLock<HashMap<String, Arc<RateWindow>>>,
+}
+
+impl TenantLimiter {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            exec: RwLock::new(HashMap::new()),
+            windows: RwLock::new(HashMap::new()),
+        })
+    }
+
+    /// Get-or-create the tenant's exec slots, sized to `max` (`0` = unlimited).
+    fn exec_slots(&self, tenant: &str, max: usize) -> Arc<ExecSlots> {
+        if let Some(s) = self
+            .exec
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(tenant)
+        {
+            return s.clone();
+        }
+        self.exec
+            .write()
+            .unwrap_or_else(|e| e.into_inner())
+            .entry(tenant.to_string())
+            .or_insert_with(|| ExecSlots::new(max))
+            .clone()
+    }
+
+    /// Get-or-create the tenant's request-rate window (`max` req/min; `0` = off).
+    fn window(&self, tenant: &str, max: u64) -> Arc<RateWindow> {
+        if let Some(w) = self
+            .windows
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .get(tenant)
+        {
+            return w.clone();
+        }
+        self.windows
+            .write()
+            .unwrap_or_else(|e| e.into_inner())
+            .entry(tenant.to_string())
+            .or_insert_with(|| Arc::new(RateWindow::new(max)))
+            .clone()
+    }
+}
+
 pub struct AgentServer {
     session_manager: Arc<SessionManager>,
     config: AgentConfig,
     exec_slots: Arc<ExecSlots>,
+    tenant_limiter: Arc<TenantLimiter>,
     metrics: Arc<Metrics>,
 }
 
@@ -142,8 +248,43 @@ impl AgentServer {
             session_manager,
             config,
             exec_slots,
+            tenant_limiter: TenantLimiter::new(),
             metrics: Arc::new(Metrics::new()),
         }
+    }
+
+    /// The calling tenant's configured rate ceilings, or `None` in open mode or
+    /// for an unknown tenant.
+    fn tenant_rate(&self, caller: Option<&str>) -> Option<&TenantRate> {
+        let id = caller?;
+        self.config.auth.as_ref()?.rate(id)
+    }
+
+    /// Enforce the tenant's requests/min window. `true` = allowed. Always `true`
+    /// in open mode or when the tenant set no requests/min cap.
+    fn allow_request_rate(&self, caller: Option<&str>) -> bool {
+        let Some(tenant) = caller else {
+            return true;
+        };
+        let max = match self.tenant_rate(caller).map(|r| r.max_requests_per_min) {
+            Some(m) if m != 0 => m as u64,
+            _ => return true,
+        };
+        self.tenant_limiter.window(tenant, max).allow()
+    }
+
+    /// Acquire a per-tenant exec slot. Returns a no-op permit in open mode or
+    /// when the tenant has no concurrent-exec cap; `None` when the tenant is
+    /// saturated (caller → 429).
+    fn try_tenant_exec_permit(&self, caller: Option<&str>) -> Option<ExecPermit> {
+        let Some(tenant) = caller else {
+            return Some(ExecPermit { slots: None });
+        };
+        let max = match self.tenant_rate(caller).map(|r| r.max_concurrent_exec) {
+            Some(m) if m != 0 => m as usize,
+            _ => return Some(ExecPermit { slots: None }),
+        };
+        self.tenant_limiter.exec_slots(tenant, max).try_acquire()
     }
 
     pub fn start(self) -> Result<()> {
@@ -320,6 +461,15 @@ impl AgentServer {
             },
         };
 
+        // Per-tenant requests/min throttle (auth mode only). Checked here — after
+        // the tenant resolves, before the body is read — so a flood is rejected
+        // cheaply and the cap covers every `/api/v1/*` route uniformly.
+        if !self.allow_request_rate(tenant) {
+            self.metrics.record_rejected_rate();
+            let err = ApiError::RateLimited("requests-per-minute exceeded".into());
+            return self.respond_json(request, Err::<serde_json::Value, _>(err), &log);
+        }
+
         let segments: Vec<&str> = path
             .trim_start_matches(API_PREFIX)
             .trim_matches('/')
@@ -488,12 +638,18 @@ impl AgentServer {
         limits: ResourceLimits,
         owner: Option<&str>,
     ) -> std::result::Result<CreateSessionResponse, ApiError> {
+        // Resolve the calling tenant's per-tenant session ceiling (auth mode
+        // only; `0`/absent = inherit, i.e. no per-tenant cap beyond the global).
+        let owner_session_cap = self
+            .tenant_rate(owner)
+            .and_then(|r| (r.max_sessions != 0).then_some(r.max_sessions as usize));
         let id = self
             .session_manager
             .create_session_with_limits(
                 self.config.session_config.default_timeout,
                 limits,
                 owner.map(String::from),
+                owner_session_cap,
             )
             .map_err(map_session_err)?;
         self.metrics.record_session_created();
@@ -587,6 +743,22 @@ impl AgentServer {
                 self.metrics.record_rejected_concurrency();
                 return Err(ApiError::TooManyRequests(self.config.max_concurrent_exec));
             }
+        };
+        // Per-tenant concurrent-exec cap (auth mode only). Acquired after the
+        // global slot; both are bundled so they release together on worker
+        // completion (a timed-out-but-running worker keeps both until cancelled).
+        let tenant_permit = match self.try_tenant_exec_permit(caller) {
+            Some(p) => p,
+            None => {
+                self.metrics.record_rejected_rate();
+                return Err(ApiError::RateLimited(
+                    "per-tenant concurrent execution limit reached".into(),
+                ));
+            }
+        };
+        let permit = HeldPermits {
+            _global: permit,
+            _tenant: tenant_permit,
         };
 
         let (tx, rx) = std::sync::mpsc::channel::<std::result::Result<i32, ApiError>>();
@@ -1092,6 +1264,9 @@ fn map_session_err(e: SessionError) -> ApiError {
         SessionError::NotFound { id } => ApiError::SessionNotFound(id),
         SessionError::Expired { id } => ApiError::SessionExpired(id),
         SessionError::MaxSessionsReached { max } => ApiError::MaxSessions(max),
+        SessionError::TenantMaxSessionsReached { max } => {
+            ApiError::RateLimited(format!("tenant session limit reached ({max})"))
+        }
         SessionError::IoError { message } => ApiError::Internal(message),
         SessionError::LockError => ApiError::Internal("Lock error".into()),
     }
@@ -1304,6 +1479,121 @@ mod tests {
             max_concurrent_exec: 100,
             auth: Some(Arc::new(auth_config_for(tenants))),
         })
+    }
+
+    /// A server whose auth config is loaded from a full TOML body (so tests can
+    /// include `[tenants.rate]` sub-tables). Generous server-wide caps so the
+    /// per-tenant ceilings are what's actually exercised.
+    fn auth_server_from_toml(toml: &str) -> AgentServer {
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        std::io::Write::write_all(&mut f, toml.as_bytes()).unwrap();
+        let auth = AuthConfig::load(f.path()).unwrap();
+        AgentServer::new(AgentConfig {
+            port: 0,
+            session_config: SessionConfig {
+                default_timeout: Duration::from_secs(60),
+                max_sessions: 100,
+                cleanup_interval: Duration::from_secs(300),
+                limits: crate::agent::limits::ResourceLimits::default(),
+            },
+            allow_cors: true,
+            verbose: false,
+            max_body_bytes: Some(32 * 1024 * 1024),
+            max_concurrent_exec: 100,
+            auth: Some(Arc::new(auth)),
+        })
+    }
+
+    #[test]
+    fn test_tenant_session_cap_enforced() {
+        use crate::agent::auth::hash_key;
+        let toml = format!(
+            "[[tenants]]\nid = \"alice\"\nkey_sha256 = \"{}\"\n[tenants.rate]\nmax_sessions = 2\n\n[[tenants]]\nid = \"bob\"\nkey_sha256 = \"{}\"\n",
+            hash_key("k_alice"),
+            hash_key("k_bob"),
+        );
+        let server = auth_server_from_toml(&toml);
+
+        // alice capped at 2; the 3rd create is a 429-class RateLimited error.
+        assert!(server
+            .handle_create_session_with_body("", Some("alice"))
+            .is_ok());
+        assert!(server
+            .handle_create_session_with_body("", Some("alice"))
+            .is_ok());
+        let err = server
+            .handle_create_session_with_body("", Some("alice"))
+            .unwrap_err();
+        assert!(matches!(err, ApiError::RateLimited(_)));
+        assert_eq!(err.status_code(), 429);
+
+        // bob has no per-tenant cap — unaffected by alice's ceiling.
+        for _ in 0..5 {
+            assert!(server
+                .handle_create_session_with_body("", Some("bob"))
+                .is_ok());
+        }
+    }
+
+    #[test]
+    fn test_tenant_concurrent_exec_permit_saturates() {
+        use crate::agent::auth::hash_key;
+        let toml = format!(
+            "[[tenants]]\nid = \"alice\"\nkey_sha256 = \"{}\"\n[tenants.rate]\nmax_concurrent_exec = 1\n\n[[tenants]]\nid = \"bob\"\nkey_sha256 = \"{}\"\n",
+            hash_key("a"),
+            hash_key("b"),
+        );
+        let server = auth_server_from_toml(&toml);
+
+        // alice's single slot: first acquire succeeds, second saturates.
+        let p1 = server.try_tenant_exec_permit(Some("alice"));
+        assert!(p1.is_some());
+        assert!(server.try_tenant_exec_permit(Some("alice")).is_none());
+
+        // bob (no cap) always gets a no-op permit; open mode (None) too.
+        assert!(server.try_tenant_exec_permit(Some("bob")).is_some());
+        assert!(server.try_tenant_exec_permit(None).is_some());
+
+        // Releasing alice's permit frees her slot.
+        drop(p1);
+        assert!(server.try_tenant_exec_permit(Some("alice")).is_some());
+    }
+
+    #[test]
+    fn test_tenant_requests_per_min_window() {
+        use crate::agent::auth::hash_key;
+        let toml = format!(
+            "[[tenants]]\nid = \"alice\"\nkey_sha256 = \"{}\"\n[tenants.rate]\nmax_requests_per_min = 2\n",
+            hash_key("a"),
+        );
+        let server = auth_server_from_toml(&toml);
+
+        assert!(server.allow_request_rate(Some("alice")));
+        assert!(server.allow_request_rate(Some("alice")));
+        assert!(!server.allow_request_rate(Some("alice"))); // 3rd within the window
+                                                            // Open-mode caller is never throttled.
+        assert!(server.allow_request_rate(None));
+    }
+
+    #[test]
+    fn test_rate_window_basic_and_reset() {
+        let w = RateWindow::new(1);
+        assert!(w.allow());
+        assert!(!w.allow());
+        // Rewind the window start so the next call sees a fresh minute.
+        {
+            let mut g = w.state.lock().unwrap();
+            g.0 = Instant::now() - Duration::from_secs(61);
+        }
+        assert!(w.allow());
+    }
+
+    #[test]
+    fn test_rate_window_unlimited() {
+        let w = RateWindow::new(0);
+        for _ in 0..1000 {
+            assert!(w.allow());
+        }
     }
 
     // Hand-built WASM that calls fd_write to print "Hello, World!\n"
@@ -2019,7 +2309,7 @@ mod tests {
     fn make_session_with_limits(server: &AgentServer, limits: ResourceLimits) -> String {
         server
             .session_manager
-            .create_session_with_limits(Duration::from_secs(60), limits, None)
+            .create_session_with_limits(Duration::from_secs(60), limits, None, None)
             .unwrap()
     }
 

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -341,6 +341,7 @@ impl SessionManager {
             self.config.default_timeout,
             self.config.limits.clone(),
             None,
+            None,
         )
     }
 
@@ -349,27 +350,43 @@ impl SessionManager {
     /// Returns the session ID on success.
     #[allow(dead_code)] // Used by tests; HTTP path uses create_session_with_limits.
     pub fn create_session_with_timeout(&self, timeout: Duration) -> Result<String, SessionError> {
-        self.create_session_with_limits(timeout, self.config.limits.clone(), None)
+        self.create_session_with_limits(timeout, self.config.limits.clone(), None, None)
     }
 
     /// Create a new session with a custom timeout, resource limits, and owner.
     ///
     /// `owner` is the authenticated tenant id, or `None` in open mode.
+    /// `owner_session_cap` is the tenant's per-tenant session ceiling (auth mode
+    /// only; `None` = no per-tenant cap). It is enforced *in addition to* the
+    /// server-wide `max_sessions`, counting only the calling tenant's own
+    /// non-expired sessions.
     /// Returns the session ID on success.
     pub fn create_session_with_limits(
         &self,
         timeout: Duration,
         limits: ResourceLimits,
         owner: Option<String>,
+        owner_session_cap: Option<usize>,
     ) -> Result<String, SessionError> {
         let mut sessions = self.sessions.write().map_err(|_| SessionError::LockError)?;
 
-        // Enforce max sessions limit (after removing expired ones)
+        // Enforce server-wide max sessions limit (ignoring expired ones).
         let active_count = sessions.values().filter(|s| !s.is_expired()).count();
         if active_count >= self.config.max_sessions {
             return Err(SessionError::MaxSessionsReached {
                 max: self.config.max_sessions,
             });
+        }
+
+        // Enforce the calling tenant's own session ceiling.
+        if let (Some(cap), Some(tenant)) = (owner_session_cap, owner.as_deref()) {
+            let owned = sessions
+                .values()
+                .filter(|s| !s.is_expired() && s.owner() == Some(tenant))
+                .count();
+            if owned >= cap {
+                return Err(SessionError::TenantMaxSessionsReached { max: cap });
+            }
         }
 
         let session = Session::new(timeout, limits, owner)?;
@@ -590,8 +607,10 @@ pub enum SessionError {
     NotFound { id: String },
     /// Session has expired.
     Expired { id: String },
-    /// Maximum concurrent sessions reached.
+    /// Maximum concurrent sessions reached (server-wide).
     MaxSessionsReached { max: usize },
+    /// The calling tenant's per-tenant session cap is reached.
+    TenantMaxSessionsReached { max: usize },
     /// I/O error during session setup/cleanup.
     IoError { message: String },
     /// Internal lock poisoned.
@@ -605,6 +624,9 @@ impl std::fmt::Display for SessionError {
             SessionError::Expired { id } => write!(f, "Session expired: {id}"),
             SessionError::MaxSessionsReached { max } => {
                 write!(f, "Maximum concurrent sessions reached: {max}")
+            }
+            SessionError::TenantMaxSessionsReached { max } => {
+                write!(f, "Tenant session limit reached: {max}")
             }
             SessionError::IoError { message } => write!(f, "Session I/O error: {message}"),
             SessionError::LockError => write!(f, "Internal lock error"),
@@ -1209,6 +1231,7 @@ mod tests {
                 Duration::from_secs(60),
                 ResourceLimits::default(),
                 Some("alice".to_string()),
+                None,
             )
             .unwrap();
 
@@ -1253,5 +1276,55 @@ mod tests {
             Err(SessionError::NotFound { .. })
         ));
         manager.destroy_session(&id, None).unwrap();
+    }
+
+    #[test]
+    fn test_per_tenant_session_cap() {
+        let manager = SessionManager::with_config(test_config());
+        let timeout = Duration::from_secs(60);
+        let mk = |owner: &str, cap: Option<usize>| {
+            manager.create_session_with_limits(
+                timeout,
+                ResourceLimits::default(),
+                Some(owner.to_string()),
+                cap,
+            )
+        };
+
+        // alice is capped at 2 of her own sessions.
+        let a1 = mk("alice", Some(2)).unwrap();
+        let _a2 = mk("alice", Some(2)).unwrap();
+        assert!(matches!(
+            mk("alice", Some(2)),
+            Err(SessionError::TenantMaxSessionsReached { max: 2 })
+        ));
+
+        // bob's own sessions are counted separately — alice's cap doesn't touch him.
+        assert!(mk("bob", Some(2)).is_ok());
+        assert!(mk("bob", Some(2)).is_ok());
+
+        // Freeing one of alice's sessions lets her create again.
+        manager.destroy_session(&a1, Some("alice")).unwrap();
+        assert!(mk("alice", Some(2)).is_ok());
+
+        manager.destroy_all().unwrap();
+    }
+
+    #[test]
+    fn test_no_per_tenant_cap_allows_many() {
+        let manager = SessionManager::with_config(test_config());
+        let timeout = Duration::from_secs(60);
+        // owner_session_cap = None ⇒ only the server-wide max_sessions applies.
+        for _ in 0..5 {
+            manager
+                .create_session_with_limits(
+                    timeout,
+                    ResourceLimits::default(),
+                    Some("alice".to_string()),
+                    None,
+                )
+                .unwrap();
+        }
+        manager.destroy_all().unwrap();
     }
 }


### PR DESCRIPTION
**Stack: PR 1 of 4 (0.20.6 Multi-Tenancy & Limits Hardening).** Base: `main`.

A shared agent server in auth mode had no per-tenant throttling — one tenant could create unlimited sessions, saturate the global exec-concurrency pool, or flood the server with requests, degrading every other tenant. Only server-wide caps existed. This adds independent per-tenant ceilings.

Each `[[tenants]]` entry gains an optional `[tenants.rate]` sub-table; every field defaults to `0` = inherit the server-wide limit:

    [[tenants]]
    id = "ci"
    key_sha256 = "…"
      [tenants.rate]
      max_sessions = 20
      max_concurrent_exec = 10
      max_requests_per_min = 600

- **`max_sessions`** — enforced in `SessionManager` at create time, counting only the tenant's own non-expired sessions alongside the global `--max-sessions` (`SessionError::TenantMaxSessionsReached`).
- **`max_concurrent_exec`** — reuses the `ExecSlots` semaphore, generalized into a lazy per-tenant `TenantLimiter`; the tenant permit is acquired with the global one and bundled in `HeldPermits` so both release on worker completion.
- **`max_requests_per_min`** — a fixed-window `RateWindow` checked at the auth gate after the tenant resolves and before the body is read, covering every `/api/v1/*` route.

All three over-limit cases return **429** via the new `ApiError::RateLimited`, and a `rate` reason is added to the `wasmrun_agent_exec_rejected_total` metric. Open mode (no `--auth`) is unaffected.

`[tenants.limits]` (per-tenant resource overrides) is deferred to PR 2; serde ignores the unknown sub-table for now so configs stay forward-compatible.

## Testing
651 unit + 16 integration tests pass; `cargo fmt --check` and `cargo clippy --all-targets` clean.