### PR TITLE
feat(agent): web platform globals in the JS sandbox and agent example flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Web Platform Globals in the JS Runtime (wasmhub v0.3.2)**: bump the pinned wasmhub release from v0.3.1 to v0.3.2, whose nodejs runtime adds the remaining common globals — JS/TS using them now runs unchanged in the agent sandbox
+  - `URL` / `URLSearchParams` (WHATWG parsing, relative resolution against a base, `searchParams` kept in sync with the URL)
+  - `crypto.getRandomValues` / `crypto.randomUUID`, backed by the WASI `random_get` syscall
+  - `structuredClone` (cycles, `Map`/`Set`/`Date`/`RegExp`/`ArrayBuffer`/TypedArrays; functions and symbols throw `DataCloneError`)
+  - `fetch` is now defined but rejects with a clear `network access is not supported` error (`code: 'ERR_NETWORK_UNSUPPORTED'`) instead of a bare `ReferenceError` — real network arrives with the wasmnet milestone
+  - New network-backed integration test (`--ignored`) covers all four through `/exec`
+- **Agent API Example Flows**: new `examples/agent-flows/` with runnable end-to-end scripts for a multi-file TypeScript project and an npm-dependency project against a local `wasmrun agent`
+- **`execute_code` tool schema polish**: the description now spells out the available Node built-ins and web globals and the no-network caveat, so LLM agents can discover the execution surface from `GET /api/v1/tools` alone
+
+### Changed
+- Agent docs: the JS runtime capabilities section documents the new web globals and the interim `fetch` rejection behavior
 - **npm Dependency Vendoring**: `POST /exec` accepts `"dependencies": {"lodash": "^4.17.21"}` alongside `source` or `files`; packages are installed into the session's `node_modules` before execution and resolved by the runtime's own `require()`
   - wasmrun talks to the npm registry directly (no `npm` binary on the host, keeping the zero-dependency deployment): abbreviated-metadata fetch, semver-range resolution (exact/`^`/`~`/`>=`/x-ranges/`*`/dist-tags; composite ranges rejected clearly), sha512 integrity verification, and hardened tarball extraction (traversal entries and symlinks never materialized)
   - Lifecycle scripts are **never** executed, and packages with native bindings (install scripts, `binding.gyp`, `.node` binaries) are rejected with an error naming the package — pure-JS only, matching what the sandbox can run

--- a/docs/docs/exec/usage/agent-exec.md
+++ b/docs/docs/exec/usage/agent-exec.md
@@ -216,7 +216,7 @@ Bare specifiers resolve through a `node_modules/<name>` tree, so a project can s
 
 ## JavaScript Runtime Capabilities
 
-JavaScript executes in the wasmhub `nodejs` runtime (QuickJS-based, WASI; v0.3.0+), fetched once and cached. Supported surface:
+JavaScript executes in the wasmhub `nodejs` runtime (QuickJS-based, WASI; v0.3.2+), fetched once and cached. Supported surface:
 
 **Module system (CommonJS):**
 - Relative and absolute `require()` (`./x`, `../x`), with `.js`/`.json` extension probing, `index.*` resolution, and `package.json` `main`
@@ -228,9 +228,14 @@ JavaScript executes in the wasmhub `nodejs` runtime (QuickJS-based, WASI; v0.3.0
 
 **Globals & event loop:** `process`, `setTimeout`/`setInterval`/`setImmediate`, `queueMicrotask`, `process.nextTick`, async/await with full Promise resolution (pending timers and microtasks are drained before exit), `Buffer`, `TextEncoder`/`TextDecoder`, `atob`/`btoa`.
 
+**Web platform globals:**
+- `URL` / `URLSearchParams` — WHATWG parsing, relative resolution against a base, `searchParams` kept in sync with the URL
+- `crypto.getRandomValues` / `crypto.randomUUID` — entropy comes from the WASI `random_get` syscall
+- `structuredClone` — deep clone with cycles, `Map`/`Set`/`Date`/`RegExp`/`ArrayBuffer`/TypedArrays; functions and symbols throw `DataCloneError`, matching the spec
+- `fetch` is **defined but always rejects** with a clear `network access is not supported` error (`code: 'ERR_NETWORK_UNSUPPORTED'`) — sandboxed code has no sockets yet, and a documented rejection beats a bare `ReferenceError`
+
 **Not yet available:**
-- `URL`/`URLSearchParams`, `crypto.getRandomValues`, `structuredClone` — planned runtime additions
-- `fetch` and sockets — no network from sandboxed code yet (deferred to the wasmnet milestone)
+- Network I/O — `fetch` and sockets are deferred to the wasmnet milestone (see above for the interim `fetch` behavior)
 - Native extensions / C addons — pure JS only
 - npm installation from inside the sandbox — there is no package manager in it; declare packages with the [`dependencies` field](#npm-dependencies) (vendored host-side) or ship a `node_modules` tree via `files`
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -41,6 +41,11 @@ This directory contains example projects demonstrating how to create WebAssembly
 - **Functions**: Counter, todo list, interactive forms with Leptos framework
 - **Build**: Rust Leptos framework compiled to WebAssembly
 
+### 🤖 Agent API Flows (`agent-flows/`)
+- **Features**: End-to-end Agent API request sequences — multi-file TypeScript execution and npm dependency vendoring
+- **Scripts**: `typescript-project.sh`, `npm-dependencies.sh`
+- **Run**: Start `wasmrun agent`, then run the scripts (see `agent-flows/README.md`)
+
 ## Quick Start
 
 Examples work with standard wasmrun commands:

--- a/examples/agent-flows/README.md
+++ b/examples/agent-flows/README.md
@@ -1,0 +1,42 @@
+# Agent API Example Flows
+
+Runnable end-to-end flows against the [Agent API](https://wasmrun.readthedocs.io/en/latest/docs/exec/agent) — the same request sequences an LLM agent makes through the `execute_code` tool schema (`GET /api/v1/tools`).
+
+## Prerequisites
+
+- `wasmrun agent` running locally (default port 8430):
+
+  ```sh
+  wasmrun agent
+  ```
+
+- `curl` and `jq` on your PATH.
+- Network on first run: the JS runtime (and TS transpiler) are fetched from wasmhub once, then cached. The npm flow also talks to the npm registry.
+
+## Flows
+
+### `typescript-project.sh` — multi-file TypeScript project
+
+Creates a session, executes a three-file TypeScript project in a single request (`files` + `entry` + `language: "typescript"`), and destroys the session. The `.ts` files are transpiled in-sandbox by the swc WASI transpiler; the emitted JavaScript resolves its imports through the runtime's own CommonJS `require()`.
+
+```sh
+./typescript-project.sh
+# stdout: area=78.53981633974483
+#         perimeter=31.41592653589793
+```
+
+### `npm-dependencies.sh` — npm dependency vendoring
+
+Executes JavaScript that `require()`s a real npm package (`lodash`), declared with the `dependencies` field. wasmrun resolves and fetches the package host-side (the sandbox has no network), verifies its sha512 integrity, and vendors it into the session's `node_modules` — no `npm` binary involved, lifecycle scripts never run.
+
+```sh
+./npm-dependencies.sh
+# stdout: pairs=[["a",1],["b",2]]
+#         chunked=[[1,2],[3,4],[5]]
+```
+
+## Notes
+
+- Everything a flow writes lives in the session's isolated filesystem and is deleted when the session is destroyed (or expires).
+- Sandboxed code has **no network**: `fetch()` rejects with a clear `network access is not supported` error. Dependencies must come through the `dependencies` field or be shipped inline via `files`.
+- Point the scripts at a remote server with `WASMRUN_AGENT_URL=http://host:port ./typescript-project.sh`.

--- a/examples/agent-flows/npm-dependencies.sh
+++ b/examples/agent-flows/npm-dependencies.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Agent API flow: execute JavaScript that depends on a pure-JS npm package.
+# The package is vendored host-side (the sandbox has no network).
+set -euo pipefail
+
+BASE="${WASMRUN_AGENT_URL:-http://localhost:8430}/api/v1"
+
+command -v jq >/dev/null || { echo "jq is required"; exit 1; }
+
+echo "→ creating session"
+SESSION_ID=$(curl -sf -X POST "$BASE/sessions" | jq -r .session_id)
+echo "  session: $SESSION_ID"
+
+trap 'curl -sf -X DELETE "$BASE/sessions/$SESSION_ID" > /dev/null && echo "→ session destroyed"' EXIT
+
+echo "→ executing with dependencies: { lodash: ^4.17.21 }"
+curl -sf -X POST "$BASE/sessions/$SESSION_ID/exec" \
+    -H 'Content-Type: application/json' \
+    -d @- <<'EOF' | jq -r '.stdout, (.error // empty)'
+{
+  "source": "const _ = require('lodash'); console.log('pairs=' + JSON.stringify(_.toPairs({a: 1, b: 2}))); console.log('chunked=' + JSON.stringify(_.chunk([1, 2, 3, 4, 5], 2)));",
+  "language": "javascript",
+  "dependencies": { "lodash": "^4.17.21" },
+  "timeout": 120
+}
+EOF

--- a/examples/agent-flows/typescript-project.sh
+++ b/examples/agent-flows/typescript-project.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Agent API flow: execute a multi-file TypeScript project in one request.
+set -euo pipefail
+
+BASE="${WASMRUN_AGENT_URL:-http://localhost:8430}/api/v1"
+
+command -v jq >/dev/null || { echo "jq is required"; exit 1; }
+
+echo "→ creating session"
+SESSION_ID=$(curl -sf -X POST "$BASE/sessions" | jq -r .session_id)
+echo "  session: $SESSION_ID"
+
+trap 'curl -sf -X DELETE "$BASE/sessions/$SESSION_ID" > /dev/null && echo "→ session destroyed"' EXIT
+
+echo "→ executing TypeScript project (transpiled in-sandbox, imports resolved by the runtime)"
+curl -sf -X POST "$BASE/sessions/$SESSION_ID/exec" \
+    -H 'Content-Type: application/json' \
+    -d @- <<'EOF' | jq -r '.stdout, (.error // empty)'
+{
+  "files": {
+    "main.ts": "import { circle } from './shapes'; const c = circle(5); console.log(`area=${c.area}`); console.log(`perimeter=${c.perimeter}`);",
+    "shapes.ts": "import { TWO_PI } from './constants'; export interface Circle { area: number; perimeter: number } export function circle(r: number): Circle { return { area: Math.PI * r * r, perimeter: TWO_PI * r }; }",
+    "constants.ts": "export const TWO_PI = 2 * Math.PI;"
+  },
+  "entry": "main.ts",
+  "language": "typescript",
+  "timeout": 120
+}
+EOF

--- a/src/agent/server.rs
+++ b/src/agent/server.rs
@@ -2462,6 +2462,58 @@ mod tests {
         server.session_manager.destroy_all().unwrap();
     }
 
+    /// Integration test: the 0.21.4 polyfill tail — `URL`/`URLSearchParams`,
+    /// `crypto.getRandomValues`/`randomUUID`, and `structuredClone` run
+    /// without ReferenceError, and `fetch` rejects with a clear
+    /// network-not-supported message instead of a bare ReferenceError
+    /// (wasmhub nodejs >= v0.3.2).
+    /// Ignored by default; see test_multi_file_js_require_integration.
+    #[test]
+    #[ignore]
+    fn test_js_web_globals_integration() {
+        let server = test_server();
+        let id = server.handle_create_session().unwrap().session_id;
+
+        let body = r#"{
+            "source": "const u = new URL('https://example.com:8443/a/../b?x=1'); u.searchParams.append('y', 'z z'); console.log(u.href); const r = crypto.getRandomValues(new Uint8Array(16)); console.log('rand=' + (r.length === 16 && Array.from(r).some(b => b !== 0))); console.log('uuid=' + /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(crypto.randomUUID())); const o = {a: [1, 2], m: new Map([['k', 'v']])}; o.self = o; const c = structuredClone(o); console.log('clone=' + (c.self === c && c.m.get('k') === 'v' && c.a !== o.a)); fetch('http://example.com').catch(e => console.log('fetch=' + /network/.test(e.message)));",
+            "language": "javascript",
+            "timeout": 120
+        }"#;
+        let resp = server.handle_exec(&id, body, None).unwrap();
+        assert_eq!(
+            resp.exit_code, 0,
+            "exit_code != 0; stderr: {}; error: {:?}",
+            resp.stderr, resp.error
+        );
+        assert!(
+            resp.stdout.contains("https://example.com:8443/b?x=1&y=z+z"),
+            "URL/searchParams output missing: {:?}",
+            resp.stdout
+        );
+        assert!(
+            resp.stdout.contains("rand=true"),
+            "getRandomValues output missing: {:?}",
+            resp.stdout
+        );
+        assert!(
+            resp.stdout.contains("uuid=true"),
+            "randomUUID output missing: {:?}",
+            resp.stdout
+        );
+        assert!(
+            resp.stdout.contains("clone=true"),
+            "structuredClone output missing: {:?}",
+            resp.stdout
+        );
+        assert!(
+            resp.stdout.contains("fetch=true"),
+            "fetch should reject with a clear network-unsupported error: {:?}",
+            resp.stdout
+        );
+
+        server.session_manager.destroy_all().unwrap();
+    }
+
     #[test]
     fn test_exec_typescript_language_passes_validation() {
         let server = test_server();

--- a/src/agent/tools.rs
+++ b/src/agent/tools.rs
@@ -45,7 +45,7 @@ pub fn openai_tools() -> Vec<OpenAiTool> {
             r#type: "function",
             function: OpenAiFunction {
                 name: "execute_code",
-                description: "Execute code inside a sandbox session. Provide one of: 'command' (shell-style command line with pipes, redirection, and built-ins like echo/cat/ls/pwd/cd/mkdir/rm/cp/mv/env/export), 'source'+'language' (single JavaScript or TypeScript snippet), 'files'+'entry'+'language' (multi-file JS/TS project with relative require() and node_modules resolution), or 'wasm_path' (pre-compiled WASM). TypeScript is transpiled in-sandbox before execution. Returns stdout, stderr, exit code, and duration.",
+                description: "Execute code inside a sandbox session. Provide one of: 'command' (shell-style command line with pipes, redirection, and built-ins like echo/cat/ls/pwd/cd/mkdir/rm/cp/mv/env/export), 'source'+'language' (single JavaScript or TypeScript snippet), 'files'+'entry'+'language' (multi-file JS/TS project with relative require() and node_modules resolution), or 'wasm_path' (pre-compiled WASM). TypeScript is transpiled in-sandbox before execution. JS/TS code can use Node built-ins (path, fs, os, events, util, assert, stream, buffer) and standard globals (Buffer, TextEncoder/TextDecoder, URL/URLSearchParams, crypto.getRandomValues, structuredClone, timers, async/await). The sandbox has NO network access: fetch() rejects with a clear error, and npm packages must be declared via 'dependencies' (vendored host-side). Returns stdout, stderr, exit code, and duration.",
                 parameters: json!({
                     "type": "object",
                     "properties": {

--- a/src/runtime/runtime_cache.rs
+++ b/src/runtime/runtime_cache.rs
@@ -7,8 +7,8 @@ use std::path::PathBuf;
 /// The wasmhub release wasmrun is pinned to. Must match the tag in
 /// `WASMHUB_BASE_URL`; cached runtimes downloaded from a different release
 /// are invalidated and re-fetched.
-const WASMHUB_RELEASE: &str = "v0.3.1";
-const WASMHUB_BASE_URL: &str = "https://github.com/anistark/wasmhub/releases/download/v0.3.1";
+const WASMHUB_RELEASE: &str = "v0.3.2";
+const WASMHUB_BASE_URL: &str = "https://github.com/anistark/wasmhub/releases/download/v0.3.2";
 /// Development/testing override: point runtime fetches at an alternate
 /// wasmhub-shaped host (e.g. a local HTTP server serving unreleased
 /// artifacts). When set, it also becomes the cache's release identity so


### PR DESCRIPTION
Completes the v0.21.x JS/TS ecosystem work: 0.21.4 (polyfill tail) and 0.21.5 (ergonomics/docs).

Bump the wasmhub pin to v0.3.2, whose nodejs runtime adds `URL`/`URLSearchParams`, `crypto.getRandomValues`/`randomUUID` (backed by WASI `random_get`), `structuredClone`, and a `fetch` stub that rejects with a clear network-unsupported error (`ERR_NETWORK_UNSUPPORTED`) instead of a bare `ReferenceError`. No wasmrun code path changes; the new `--ignored` test `test_js_web_globals_integration` verifies all four through `/exec`, and the existing 7 network tests stay green against the new runtime.

Ergonomics: the `execute_code` tool description now names the available built-ins/globals and the no-network caveat so LLM agents stop reaching for `npm install` or live HTTP; new `examples/agent-flows/` ships runnable curl flows for a multi-file TypeScript project and an npm-dependency (`lodash`) execution, both verified against a live `wasmrun agent`; the agent-exec docs move the web globals from "not yet available" to a supported section.

New examples:
  examples/agent-flows/typescript-project.sh
  examples/agent-flows/npm-dependencies.sh

Run against a local server started with: 

```sh
wasmrun agent
```