### PR TITLE
ci: run examples on PRs after format, lint and docs pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,26 +6,30 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     name: Format and Lint
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         node-version: '22'
 
     - name: Install pnpm
-      uses: pnpm/action-setup@v3
+      uses: pnpm/action-setup@v6
       with:
         version: 10
 
     - name: Cache pnpm store
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/.local/share/pnpm/store
         key: ${{ runner.os }}-pnpm-ui-${{ hashFiles('ui/pnpm-lock.yaml') }}
@@ -42,7 +46,7 @@ jobs:
         components: rustfmt, clippy
 
     - name: Cache cargo registry
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/.cargo/registry
         key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
@@ -50,7 +54,7 @@ jobs:
           ${{ runner.os }}-cargo-registry-
 
     - name: Cache cargo index
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/.cargo/git
         key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
@@ -58,7 +62,7 @@ jobs:
           ${{ runner.os }}-cargo-index-
 
     - name: Cache target directory
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: target
         key: ${{ runner.os }}-target-ci-${{ hashFiles('**/Cargo.lock') }}
@@ -76,15 +80,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         node-version: '22'
 
     - name: Install pnpm
-      uses: pnpm/action-setup@v3
+      uses: pnpm/action-setup@v6
       with:
         version: 10
 
@@ -95,7 +99,7 @@ jobs:
         echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
     - name: Setup pnpm cache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
         key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -109,3 +113,11 @@ jobs:
     - name: Build docs
       working-directory: docs
       run: pnpm run build
+
+  # On PRs, run the examples only after format, lint, and docs pass.
+  # On main, examples run via the CI -> Tests -> Examples workflow_run chain.
+  examples:
+    name: Examples
+    needs: [ci, docs]
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/examples.yml

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -137,9 +137,22 @@ jobs:
         Add-Content $env:GITHUB_PATH "$emsdkPath\node\current\bin"
       shell: powershell
 
+    # wasm-bindgen's bindgen format is unstable: the CLI version must exactly
+    # match the wasm-bindgen crate version the example was built against. When
+    # the example commits a Cargo.lock, install the CLI at the locked version;
+    # otherwise both resolve to latest and already agree.
     - name: Install wasm-bindgen-cli
       if: matrix.example.lang == 'rust'
-      run: cargo install wasm-bindgen-cli
+      run: |
+        LOCK="examples/${{ matrix.example.name }}/Cargo.lock"
+        if [ -f "$LOCK" ]; then
+          VERSION=$(grep -A 1 '^name = "wasm-bindgen"$' "$LOCK" | sed -n 's/^version = "\(.*\)"$/\1/p')
+          echo "Installing wasm-bindgen-cli $VERSION (pinned by $LOCK)"
+          cargo install wasm-bindgen-cli --version "$VERSION"
+        else
+          cargo install wasm-bindgen-cli
+        fi
+      shell: bash
 
     - name: Install Python
       if: matrix.example.lang == 'python'

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,16 +1,24 @@
 name: Examples
 
 on:
+  # On PRs, this workflow is called from ci.yml after the Format and Lint
+  # and Docs Build jobs succeed, so examples only run once those pass.
+  workflow_call:
   workflow_run:
     workflows: ["Tests"]
     types:
       - completed
     branches: [ main ]
 
+concurrency:
+  group: examples-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   examples:
     name: Test Examples
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    # The workflow_run gate only applies on main; PR runs always execute.
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     strategy:
       fail-fast: false
       matrix:
@@ -38,7 +46,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
@@ -46,7 +54,7 @@ jobs:
         targets: wasm32-unknown-unknown
 
     - name: Cache cargo registry
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/.cargo/registry
         key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
@@ -54,7 +62,7 @@ jobs:
           ${{ runner.os }}-cargo-registry-
 
     - name: Cache cargo index
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/.cargo/git
         key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
@@ -62,7 +70,7 @@ jobs:
           ${{ runner.os }}-cargo-index-
 
     - name: Cache target directory
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: target
         key: ${{ runner.os }}-target-examples-${{ hashFiles('**/Cargo.lock') }}
@@ -75,7 +83,7 @@ jobs:
     # 1.26), which TinyGo rejects: "requires go version 1.19 through 1.23".
     - name: Install Go
       if: matrix.example.lang == 'go'
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v7
       with:
         go-version: '1.24'
 
@@ -100,7 +108,7 @@ jobs:
 
     - name: Install Node.js
       if: matrix.example.lang == 'asc' || matrix.example.lang == 'nodejs'
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v7
       with:
         node-version: 'lts/*'
 
@@ -135,7 +143,7 @@ jobs:
 
     - name: Install Python
       if: matrix.example.lang == 'python'
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.x'
 

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -24,15 +24,15 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             arch: aarch64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
 
       - name: Install Pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10
 
@@ -54,7 +54,7 @@ jobs:
           cp "$DEB_FILE" "wasmrun-${VERSION}-${{ matrix.arch }}.deb"
 
       - name: Upload .deb artifacts
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           files: "wasmrun-*.deb"
           draft: ${{ contains(github.ref_name, '-') }}
@@ -74,15 +74,15 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             arch: aarch64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
 
       - name: Install Pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10
 
@@ -109,7 +109,7 @@ jobs:
           cp "$RPM_FILE" "wasmrun-${VERSION}-${{ matrix.arch }}.rpm"
 
       - name: Upload .rpm artifacts
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           files: "wasmrun-*.rpm"
           draft: ${{ contains(github.ref_name, '-') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,13 +14,13 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
 
     - name: Cache cargo registry
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/.cargo/registry
         key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
@@ -28,7 +28,7 @@ jobs:
           ${{ runner.os }}-cargo-registry-
 
     - name: Cache cargo index
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/.cargo/git
         key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
@@ -36,7 +36,7 @@ jobs:
           ${{ runner.os }}-cargo-index-
 
     - name: Cache target directory
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: target
         key: ${{ runner.os }}-target-test-${{ hashFiles('**/Cargo.lock') }}

--- a/examples/web-leptos/src/lib.rs
+++ b/examples/web-leptos/src/lib.rs
@@ -57,7 +57,7 @@ fn HomePage() -> impl IntoView {
                         placeholder="Enter your name"
                         prop:value=name
                         on:input=move |ev| {
-                            set_name(event_target_value(&ev));
+                            set_name.set(event_target_value(&ev));
                         }
                     />
                     <button on:click=move |_| {
@@ -124,7 +124,7 @@ fn Counter() -> impl IntoView {
                             prop:value=step
                             on:input=move |ev| {
                                 if let Ok(new_step) = event_target_value(&ev).parse::<i32>() {
-                                    set_step(new_step);
+                                    set_step.set(new_step);
                                 }
                             }
                         />
@@ -141,7 +141,7 @@ fn Counter() -> impl IntoView {
                     
                     <button
                         class="reset"
-                        on:click=move |_| set_count(0)
+                        on:click=move |_| set_count.set(0)
                     >
                         "Reset"
                     </button>
@@ -177,7 +177,7 @@ fn TodoApp() -> impl IntoView {
     let (new_todo, set_new_todo) = create_signal(String::new());
     let (next_id, set_next_id) = create_signal(1);
 
-    let add_todo = move |_| {
+    let add_todo = move || {
         console::log_1(&"[LEPTOS-WEB] add_todo() function called (running from web-leptos)".into());
         let text = new_todo.get().trim().to_string();
         if !text.is_empty() {
@@ -189,7 +189,7 @@ fn TodoApp() -> impl IntoView {
             };
             set_todos.update(|todos| todos.push(todo));
             set_next_id.update(|id| *id += 1);
-            set_new_todo(String::new());
+            set_new_todo.set(String::new());
             console::log_1(&"[LEPTOS-WEB] add_todo() todo added successfully".into());
         } else {
             console::log_1(&"[LEPTOS-WEB] add_todo() empty text, not adding".into());
@@ -227,15 +227,15 @@ fn TodoApp() -> impl IntoView {
                         placeholder="Add a new todo..."
                         prop:value=new_todo
                         on:input=move |ev| {
-                            set_new_todo(event_target_value(&ev));
+                            set_new_todo.set(event_target_value(&ev));
                         }
                         on:keydown=move |ev| {
                             if ev.key() == "Enter" {
-                                add_todo(ev);
+                                add_todo();
                             }
                         }
                     />
-                    <button on:click=add_todo>"Add Todo"</button>
+                    <button on:click=move |_| add_todo()>"Add Todo"</button>
                 </div>
 
                 <div class="todo-stats">
@@ -248,8 +248,9 @@ fn TodoApp() -> impl IntoView {
                         key=|todo| todo.id
                         children=move |todo: TodoItem| {
                             let id = todo.id;
+                            let completed = todo.completed;
                             view! {
-                                <div class=("todo-item", move || if todo.completed { "completed" } else { "" })>
+                                <div class="todo-item" class:completed=completed>
                                     <input
                                         type="checkbox"
                                         prop:checked=todo.completed


### PR DESCRIPTION
Examples only ran on main after Tests, so a broken example (web-leptos) only surfaced post-merge. Make `examples.yml` reusable via `workflow_call` and call it from `ci.yml` with `needs: [ci, docs]`, so PRs build every example only once Format and Lint and Docs Build succeed. On main the CI -> Tests -> Examples `workflow_run` chain is unchanged.

Fix web-leptos so the example compiles on stable: leptos 0.6 signal setters need `.set()` (calling them as functions is nightly-only), `add_todo` is now a zero-arg closure shared by the click and keydown handlers, and the completed class uses `class:completed` instead of the tuple syntax.

Also bump every node20/node16 action to its node24 major (`checkout@v7`, `cache@v6`, `setup-node@v7`, `setup-go@v7`, `setup-python@v6`, `pnpm/action-setup@v6`, `action-gh-release@v3`) to clear the "Node.js 20 is deprecated" warnings, and cancel superseded CI runs on PRs via a concurrency group.