### PR TITLE
feat(agent): full npm range support, lockfiles, tsconfig and streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Reproducible npm installs**: every agent execution that installs dependencies now returns a `lockfile` describing the resolved tree, including transitive packages. Send it back as the request's `lockfile` to install exactly those versions again
+  - Replay walks the lockfile rather than the dependency graph, so nothing is re-resolved and no registry metadata is fetched; with a warm cache the install runs offline
+  - Tarballs are still integrity-verified and scanned for native artifacts on replay
+  - Dependencies not covered by the lockfile resolve normally on top of it, so adding one package to a pinned tree does not unpin the rest
+- **Install from `package.json`**: set `install_package_json` on an execution to install the project's declared dependencies, from an uploaded `package.json` or one already in the session. Off by default, so an uploaded `package.json` never triggers an unrequested install. `devDependencies` are ignored
+- **Streaming execution output**: set `stream` on an execution to receive Server-Sent Events as the code runs, instead of waiting for the full response. `output` events carry incremental stdout/stderr and a final `result` event carries the usual response object, so long-running code is no longer silent until it finishes
+- **Session listing**: `GET /api/v1/sessions` lists the available sessions, newest first, so an agent can reuse one instead of creating another. Scoped to the calling tenant when authentication is enabled. Exposed to LLM agents as a new `list_sessions` tool
+- **TypeScript project configuration**: a project may now ship a `tsconfig.json`, parsed as JSONC so comments and trailing commas are accepted
+  - `paths` aliases are honored, materialized so the runtime's own module resolver handles them with no rewriting of your imports
+  - Options the sandbox transpiler cannot apply (`experimentalDecorators`, `emitDecoratorMetadata`, and `jsx` modes other than the classic runtime) fail the request by name instead of silently producing broken output
+
+### Changed
+- **Full npm version-range support**: dependency ranges now accept the complete npm grammar, including comparator sets (`>=1.2.0 <2.0.0`), unions (`^1 || ^2`), hyphen ranges (`1.2.0 - 1.4.0`), and the `<`, `<=`, `>`, `=` operators. Previously these were rejected, which meant a single composite range anywhere in a transitive dependency tree failed the whole install even when every package involved was pure JavaScript
+  - Partial versions widen bounds as npm specifies, so `>1.2` excludes all of `1.2.x`
+  - Prereleases follow the npm rule: a prerelease only satisfies a range that names a prerelease of that same version, so `<2.0.0` no longer risks admitting `2.0.0-rc.1`
+  - Prerelease identifiers compare numerically, so `alpha.2` sorts below `alpha.10`
+
 ## [0.21.0](https://github.com/anistark/wasmrun/releases/tag/v0.21.0) - 2026-07-20
 
 ### Added

--- a/docs/docs/exec/agent.md
+++ b/docs/docs/exec/agent.md
@@ -183,6 +183,10 @@ curl -X POST http://localhost:8430/api/v1/sessions/a1b2c3.../exec \
   -d '{"wasm_path": "hello.wasm"}'
 # → {"stdout": "Hello, World!\n", "stderr": "", "exit_code": 0, "duration_ms": 12}
 
+# List the sessions you can reuse
+curl http://localhost:8430/api/v1/sessions
+# → {"sessions": [{"session_id": "a1b2c3...", "state": "active", ...}], "count": 1}
+
 # Clean up
 curl -X DELETE http://localhost:8430/api/v1/sessions/a1b2c3...
 ```
@@ -201,7 +205,7 @@ curl http://localhost:8430/api/v1/tools
 curl http://localhost:8430/api/v1/tools?format=anthropic
 ```
 
-Available tools: `create_session`, `execute_code`, `write_file`, `read_file`, `list_files`, `destroy_session`.
+Available tools: `create_session`, `execute_code`, `write_file`, `read_file`, `list_files`, `list_sessions`, `destroy_session`.
 
 Each tool includes a description, parameter schema with types, and required fields, ready to pass to an LLM as function definitions.
 

--- a/docs/docs/exec/usage/agent-exec.md
+++ b/docs/docs/exec/usage/agent-exec.md
@@ -28,6 +28,7 @@ These apply to every mode:
 |-------|----------|---------|-------------|
 | `timeout` | no | `30` | Execution timeout in seconds |
 | `env` | no | `{}` | Environment variables to set before execution |
+| `stream` | no | `false` | Stream output as Server-Sent Events while the code runs (see [Streaming Output](#streaming-output)) |
 
 ## Common Response
 
@@ -162,15 +163,65 @@ Declare npm packages with the `dependencies` field (works with `source` and `fil
 - Vendored files count against the session's disk and file-size limits
 - The registry defaults to `https://registry.npmjs.org` and is configurable with `wasmrun agent --npm-registry <URL>` (private registries, mirrors)
 
-**Supported version ranges:** exact (`4.17.21`), caret (`^4.17.21`), tilde (`~4.17.0`), `>=`, x-ranges (`4`, `4.17`, `4.17.x`), `*`, and dist-tags (`latest`). Composite ranges (`||`, hyphen ranges, multi-comparator) are rejected with a clear error.
+**Supported version ranges:** the full npm range grammar. Exact (`4.17.21`), caret (`^4.17.21`), tilde (`~4.17.0`), comparators (`>=`, `>`, `<=`, `<`, `=`), x-ranges (`4`, `4.17`, `4.17.x`), `*`, dist-tags (`latest`), comparator sets (`>=1.2.0 <2.0.0`), unions (`^1 || ^2`), and hyphen ranges (`1.2.0 - 1.4.0`).
+
+Prereleases follow the npm rule: `1.2.3-beta` only satisfies a range that names a prerelease of `1.2.3`, so `<2.0.0` never quietly pulls in `2.0.0-rc.1`.
 
 **Limitations:**
 
 - Pure-JS packages only: anything with an install script, `binding.gyp`, or prebuilt `.node` binaries is rejected with an error naming the package (native code can't run in the sandbox)
 - CommonJS entry points work best; packages relying on ESM-only entry, `exports` maps, or `fetch`/network at import time may not load
-- An uploaded `package.json` is inert; dependencies are only installed when the `dependencies` field is present (no surprise network fetches)
+- An uploaded `package.json` is inert unless you set `install_package_json`, so no execution turns into an unrequested network fetch. `devDependencies` are ignored: there is nothing in the sandbox to run them with yet
 
 Malformed names/ranges fail with HTTP `400` before execution; resolution or download failures surface in the response's `error` field.
+
+### Installing from package.json
+
+Set `install_package_json` to read the `dependencies` of the project's `package.json`, either one uploaded in `files` or one already written to the session:
+
+```json
+{
+  "files": {
+    "package.json": "{\"dependencies\":{\"lodash\":\"^4.17.21\"}}",
+    "main.js": "const _ = require('lodash'); console.log(_.chunk([1,2,3,4], 2));"
+  },
+  "entry": "main.js",
+  "install_package_json": true
+}
+```
+
+An explicit `dependencies` map still wins on conflict, so you can pin one package without rewriting the file.
+
+### Reproducible installs with a lockfile
+
+Version ranges resolve to whatever is newest at the time, so the same request can install different versions on different days. Every execution that installs anything returns a `lockfile` describing the resolved tree, keyed by install path:
+
+```json
+{
+  "stdout": "[[1,2],[3,4]]\n",
+  "exit_code": 0,
+  "lockfile": {
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-..."
+    }
+  }
+}
+```
+
+Send it back as the request's `lockfile` to install exactly those versions:
+
+```json
+{
+  "source": "const _ = require('lodash'); console.log(_.VERSION);",
+  "lockfile": { "node_modules/lodash": { "version": "4.17.21", "resolved": "...", "integrity": "..." } }
+}
+```
+
+Replay walks the lockfile rather than the dependency graph, so nothing is re-resolved and no registry document is fetched. With a warm package cache the whole install runs offline. Tarballs are still integrity-verified and still scanned for native artifacts. Any `dependencies` not covered by the lockfile are resolved normally on top of it, so adding one package to a pinned tree does not unpin the rest.
+
+A package skipped because an earlier execution in the same session already installed it is not in the lockfile: recording it would need the registry lookup the skip exists to avoid. Lock from a fresh session to get a complete tree.
 
 ---
 
@@ -238,6 +289,68 @@ JavaScript executes in the [wasmhub `nodejs` runtime](https://anistark.github.io
 - Network I/O: `fetch` and sockets are deferred to the wasmnet milestone (see above for the interim `fetch` behavior)
 - Native extensions / C addons: pure JS only
 - npm installation from inside the sandbox: there is no package manager in it; declare packages with the [`dependencies` field](#npm-dependencies) (vendored host-side) or ship a `node_modules` tree via `files`
+
+---
+
+## TypeScript Project Configuration
+
+A project may ship a `tsconfig.json`, uploaded in `files` or already in the session. It is parsed as JSONC, so comments and trailing commas are fine.
+
+**`paths` aliases are honored.** Each alias is materialized under `node_modules` as a small CommonJS shim, so the runtime's own resolver handles it with no rewriting of your imports:
+
+```json
+{
+  "files": {
+    "tsconfig.json": "{\"compilerOptions\":{\"paths\":{\"@app/*\":[\"src/*\"]}}}",
+    "src/util.ts": "export const greet = (n: string) => `hi ${n}`;",
+    "main.ts": "import { greet } from '@app/util'; console.log(greet('there'));"
+  },
+  "entry": "main.ts",
+  "language": "typescript"
+}
+```
+
+`baseUrl` is applied to alias targets. Both sides of an alias must agree on whether they use `*`, and an alias pointing outside the project fails with a `400` rather than a confusing require error at runtime.
+
+**Options that are refused.** These would silently produce broken output, so they fail the request by name instead:
+
+| Option | Why |
+|--------|-----|
+| `experimentalDecorators` | The transpiler has no decorator transform, so decorators would be emitted as-is and the runtime cannot execute them |
+| `emitDecoratorMetadata` | Same |
+| `jsx` other than `"react"` | Only the classic runtime is available; JSX compiles to `React.createElement` calls |
+
+**`target` is accepted and ignored.** There is no down-level pass, so the source syntax reaches the runtime either way. It is a no-op rather than a wrong answer.
+
+**Types are stripped, not checked.** A project with type errors still runs. Run `tsc` yourself if you need type checking.
+
+---
+
+## Streaming Output
+
+By default a response arrives only when execution finishes, which makes a long run silent until the end. Set `stream` to receive output as it happens, as [Server-Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events):
+
+```bash
+curl -N -X POST http://127.0.0.1:8420/api/v1/sessions/$SID/exec \
+  -H 'Content-Type: application/json' \
+  -d '{"source": "for (let i = 0; i < 3; i++) console.log(i);", "stream": true}'
+```
+
+```
+event: output
+data: {"stdout":"0\n1\n","stderr":""}
+
+event: output
+data: {"stdout":"2\n","stderr":""}
+
+event: result
+data: {"stdout":"0\n1\n2\n","stderr":"","exit_code":0,"duration_ms":412}
+```
+
+- `output` events carry only what is new since the previous event. They are best-effort: a fast program may finish before the first sample and produce none at all
+- The final `result` event carries the same object the buffered response would have returned, including the complete output, so a client can ignore the intermediate events entirely
+- Errors that prevent execution from starting (unknown session, bad request) are returned as an ordinary JSON error response, not as an event stream
+- Disconnecting cancels the execution, so an abandoned run does not keep burning a worker
 
 ---
 

--- a/docs/docs/exec/usage/agent-sessions.md
+++ b/docs/docs/exec/usage/agent-sessions.md
@@ -58,6 +58,34 @@ GET /api/v1/sessions/:id
 }
 ```
 
+## List Sessions
+
+```
+GET /api/v1/sessions
+```
+
+Lists the sessions currently available, newest first, so an agent can find one to reuse instead of creating another.
+
+**Response** (200):
+```json
+{
+  "sessions": [
+    {
+      "session_id": "a1b2c3d4e5f6...",
+      "state": "active",
+      "created_at_elapsed_ms": 5000,
+      "last_accessed_elapsed_ms": 1200,
+      "timeout_secs": 300
+    }
+  ],
+  "count": 1
+}
+```
+
+Each entry has the same shape as [Get Session Status](#get-session-status). Expired sessions are omitted even before the cleanup thread collects them, so the listing never advertises a session that cannot be used.
+
+Under [`--auth`](../agent.md#authentication) the listing is scoped to the calling tenant, matching the visibility rule everywhere else: a tenant never learns that another tenant's sessions exist.
+
 ## Destroy a Session
 
 ```

--- a/src/agent/api.rs
+++ b/src/agent/api.rs
@@ -34,6 +34,23 @@ pub struct ExecRequest {
     /// only pure-JS packages are supported and lifecycle scripts never run.
     /// Applies to `source` and `files` execution.
     pub dependencies: Option<HashMap<String, String>>,
+    /// A lockfile returned by a previous exec, replayed to install exactly the
+    /// versions it records instead of re-resolving `dependencies`. Ranges
+    /// resolve to whatever is newest at the time, so this is what makes a
+    /// repeat exec reproducible. Any `dependencies` not covered by the
+    /// lockfile are resolved normally on top of it.
+    pub lockfile: Option<crate::agent::vendor::Lockfile>,
+    /// Install the `dependencies` of the session's package.json (uploaded in
+    /// `files`, or already in the session root) in addition to any listed in
+    /// `dependencies`. Off by default: an uploaded package.json stays inert
+    /// unless asked for, so no exec turns into an unrequested network fetch.
+    /// `devDependencies` are ignored.
+    pub install_package_json: Option<bool>,
+    /// Stream output as Server-Sent Events while the code runs, instead of
+    /// waiting for the buffered JSON response. `output` events carry
+    /// incremental stdout/stderr; a final `result` event carries the same
+    /// object the buffered response would have returned.
+    pub stream: Option<bool>,
     /// Shell command line to execute via the built-in shell emulator.
     /// Supports pipes (`|`), redirection (`>`, `>>`, `<`), and sequencing
     /// (`&&`, `;`) with built-ins for common file/env operations.
@@ -70,6 +87,12 @@ pub struct SessionStatusResponse {
 }
 
 #[derive(Debug, Serialize)]
+pub struct ListSessionsResponse {
+    pub sessions: Vec<SessionStatusResponse>,
+    pub count: usize,
+}
+
+#[derive(Debug, Serialize)]
 pub struct ExecResponse {
     pub stdout: String,
     pub stderr: String,
@@ -81,6 +104,11 @@ pub struct ExecResponse {
     pub output_truncated: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    /// The dependency tree that was installed, when this exec vendored any.
+    /// Send it back as the request's `lockfile` to reproduce these exact
+    /// versions. Omitted when the exec installed nothing.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lockfile: Option<crate::agent::vendor::Lockfile>,
 }
 
 #[derive(Debug, Serialize)]

--- a/src/agent/executor.rs
+++ b/src/agent/executor.rs
@@ -151,11 +151,13 @@ pub fn execute_source_project(
     }
 
     let entry_to_run = if lang.is_typescript() {
+        let tsconfig = TsConfig::load(files, work_dir)?;
         let mut ts_files: Vec<String> = files.keys().filter(|p| is_ts_path(p)).cloned().collect();
         ts_files.sort(); // deterministic transpile order
         if !ts_files.is_empty() {
             transpile_in_session(&ts_files, wasi_env.clone(), limits, cancel.clone())?;
         }
+        tsconfig.write_path_aliases(files, work_dir, limits)?;
         js_output_path(entry)
     } else {
         entry.to_string()
@@ -175,6 +177,254 @@ pub fn execute_source_project(
         cancel,
     )
     .map_err(|e| ApiError::Internal(e.to_string()))
+}
+
+/// The parts of a project's `tsconfig.json` that reach the sandbox.
+///
+/// The transpiler takes file paths and no options, so most compiler options
+/// cannot be honored here. The ones whose absence breaks the output are
+/// refused by name; `paths` is the one this side can deliver.
+#[derive(Debug, Default)]
+struct TsConfig {
+    /// Alias pattern → first target, both as written.
+    paths: Vec<(String, String)>,
+    /// `baseUrl`, normalized to a project-relative prefix ("" for the root).
+    base_url: String,
+}
+
+impl TsConfig {
+    fn load(
+        files: &HashMap<String, String>,
+        work_dir: &Path,
+    ) -> std::result::Result<Self, ApiError> {
+        let raw = match files.get("tsconfig.json") {
+            Some(uploaded) => uploaded.clone(),
+            None => match std::fs::read_to_string(work_dir.join("tsconfig.json")) {
+                Ok(s) => s,
+                Err(_) => return Ok(Self::default()),
+            },
+        };
+        let parsed: serde_json::Value = serde_json::from_str(&strip_jsonc(&raw))
+            .map_err(|e| ApiError::BadRequest(format!("Invalid tsconfig.json: {e}")))?;
+        let Some(opts) = parsed.get("compilerOptions").and_then(|o| o.as_object()) else {
+            return Ok(Self::default());
+        };
+
+        // Refused rather than dropped: the failure otherwise (decorator syntax
+        // QuickJS rejects, JSX for the wrong runtime) is far harder to read.
+        let unsupported = |opt: &str, why: &str| {
+            Err(ApiError::BadRequest(format!(
+                "tsconfig.json sets '{opt}', which the sandbox transpiler cannot apply yet: {why}"
+            )))
+        };
+        if opts.get("experimentalDecorators") == Some(&serde_json::Value::Bool(true)) {
+            return unsupported(
+                "experimentalDecorators",
+                "decorators would be emitted as-is and the runtime cannot execute them",
+            );
+        }
+        if opts.get("emitDecoratorMetadata") == Some(&serde_json::Value::Bool(true)) {
+            return unsupported(
+                "emitDecoratorMetadata",
+                "no decorator transform is available",
+            );
+        }
+        if let Some(jsx) = opts.get("jsx").and_then(|j| j.as_str()) {
+            if jsx != "react" {
+                return unsupported(
+                    "jsx",
+                    &format!(
+                        "only the classic 'react' runtime is available, not '{jsx}'; \
+                         JSX compiles to React.createElement calls"
+                    ),
+                );
+            }
+        }
+        // `target` is not refused: with no down-level pass the source syntax
+        // reaches the runtime either way, so it is a no-op, not a wrong answer.
+
+        let base_url = opts
+            .get("baseUrl")
+            .and_then(|b| b.as_str())
+            .map(|b| {
+                let b = b.trim_start_matches("./").trim_matches('/');
+                if b.is_empty() || b == "." {
+                    String::new()
+                } else {
+                    format!("{b}/")
+                }
+            })
+            .unwrap_or_default();
+
+        let mut paths = Vec::new();
+        if let Some(map) = opts.get("paths").and_then(|p| p.as_object()) {
+            for (pattern, targets) in map {
+                // tsc tries each in order; there is no ambiguity here to resolve.
+                let Some(target) = targets
+                    .as_array()
+                    .and_then(|a| a.first())
+                    .and_then(|t| t.as_str())
+                else {
+                    return Err(ApiError::BadRequest(format!(
+                        "tsconfig.json path alias '{pattern}' must map to a non-empty array of strings"
+                    )));
+                };
+                if pattern.contains('*') != target.contains('*') {
+                    return Err(ApiError::BadRequest(format!(
+                        "tsconfig.json path alias '{pattern}' -> '{target}': either both sides must use '*' or neither"
+                    )));
+                }
+                paths.push((pattern.clone(), target.to_string()));
+            }
+            paths.sort();
+        }
+        Ok(Self { paths, base_url })
+    }
+
+    /// Materialize `paths` aliases as CommonJS shims under `node_modules`, so
+    /// the runtime's stock bare-specifier walk-up resolves them with no
+    /// specifier rewriting and no transpiler involvement.
+    fn write_path_aliases(
+        &self,
+        files: &HashMap<String, String>,
+        work_dir: &Path,
+        limits: &ResourceLimits,
+    ) -> std::result::Result<(), ApiError> {
+        for (pattern, target) in &self.paths {
+            let (alias, module_path) = (pattern.as_str(), target.as_str());
+            match (alias.split_once('*'), module_path.split_once('*')) {
+                // Wildcard alias: shim every project file under the target.
+                (Some((a_pre, a_post)), Some((t_pre, t_post))) => {
+                    let t_pre = format!("{}{}", self.base_url, t_pre.trim_start_matches("./"));
+                    for source in files.keys() {
+                        let Some(rest) = source.strip_prefix(&t_pre) else {
+                            continue;
+                        };
+                        let Some(stem) = rest.strip_suffix(t_post).or_else(|| {
+                            // "src/*" with no suffix matches any extension.
+                            t_post.is_empty().then(|| strip_module_ext(rest))
+                        }) else {
+                            continue;
+                        };
+                        let stem = strip_module_ext(stem);
+                        let shim = format!("node_modules/{a_pre}{stem}{a_post}.js");
+                        write_alias_shim(&shim, &js_output_path(source), work_dir, limits)?;
+                    }
+                }
+                // Exposed through package.json `main` so the alias resolves
+                // as a directory.
+                (None, None) => {
+                    let target =
+                        format!("{}{}", self.base_url, module_path.trim_start_matches("./"));
+                    if !files.contains_key(&target) {
+                        return Err(ApiError::BadRequest(format!(
+                            "tsconfig.json path alias '{alias}' points at '{target}', which is not in the project"
+                        )));
+                    }
+                    write_checked(
+                        &work_dir.join(format!("node_modules/{alias}/package.json")),
+                        br#"{"main":"index.js"}"#,
+                        limits,
+                        work_dir,
+                    )?;
+                    write_alias_shim(
+                        &format!("node_modules/{alias}/index.js"),
+                        &js_output_path(&target),
+                        work_dir,
+                        limits,
+                    )?;
+                }
+                _ => unreachable!("mixed wildcards are rejected at load"),
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Drop a module extension so the stem can be re-suffixed with `.js`.
+fn strip_module_ext(path: &str) -> &str {
+    for ext in [".tsx", ".ts", ".jsx", ".js", ".mjs", ".cjs"] {
+        if let Some(stem) = path.strip_suffix(ext) {
+            return stem;
+        }
+    }
+    path
+}
+
+/// Write a shim at `shim_path` re-exporting the project-relative `target`.
+fn write_alias_shim(
+    shim_path: &str,
+    target: &str,
+    work_dir: &Path,
+    limits: &ResourceLimits,
+) -> std::result::Result<(), ApiError> {
+    // The session root is preopened at `/`, so an absolute specifier is stable
+    // however deeply the shim is nested.
+    let body = format!("module.exports = require('/{target}');\n");
+    write_checked(&work_dir.join(shim_path), body.as_bytes(), limits, work_dir)
+}
+
+/// Strip `//` and `/* */` comments and trailing commas from JSONC. Real
+/// tsconfigs have comments, so refusing them would make this useless.
+fn strip_jsonc(src: &str) -> String {
+    let mut out = String::with_capacity(src.len());
+    let mut chars = src.chars().peekable();
+    let mut in_string = false;
+    let mut escaped = false;
+    while let Some(c) = chars.next() {
+        if in_string {
+            out.push(c);
+            if escaped {
+                escaped = false;
+            } else if c == '\\' {
+                escaped = true;
+            } else if c == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+        match c {
+            '"' => {
+                in_string = true;
+                out.push(c);
+            }
+            '/' if chars.peek() == Some(&'/') => {
+                for c in chars.by_ref() {
+                    if c == '\n' {
+                        out.push('\n');
+                        break;
+                    }
+                }
+            }
+            '/' if chars.peek() == Some(&'*') => {
+                chars.next();
+                let mut prev = '\0';
+                for c in chars.by_ref() {
+                    if prev == '*' && c == '/' {
+                        break;
+                    }
+                    prev = c;
+                }
+            }
+            _ => out.push(c),
+        }
+    }
+    // Trailing commas: drop any comma followed only by whitespace and a close.
+    let mut cleaned = String::with_capacity(out.len());
+    let bytes: Vec<char> = out.chars().collect();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == ',' {
+            let next = bytes[i + 1..].iter().find(|c| !c.is_whitespace());
+            if matches!(next, Some('}') | Some(']')) {
+                i += 1;
+                continue;
+            }
+        }
+        cleaned.push(bytes[i]);
+        i += 1;
+    }
+    cleaned
 }
 
 /// True for paths the transpile stage should convert to JavaScript.
@@ -508,6 +758,155 @@ mod tests {
         .unwrap_err();
         assert_eq!(err.status_code(), 400);
         assert!(err.to_string().contains("traversal"));
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    // ── tsconfig.json ─────────────────────────────────────────────
+
+    fn tsconfig_from(json: &str) -> std::result::Result<TsConfig, ApiError> {
+        let files = HashMap::from([("tsconfig.json".to_string(), json.to_string())]);
+        TsConfig::load(&files, Path::new("/nonexistent"))
+    }
+
+    #[test]
+    fn test_tsconfig_absent_is_a_no_op() {
+        let files = HashMap::from([("main.ts".to_string(), "export const x = 1".to_string())]);
+        let cfg = TsConfig::load(&files, Path::new("/nonexistent")).unwrap();
+        assert!(cfg.paths.is_empty());
+        assert_eq!(cfg.base_url, "");
+    }
+
+    #[test]
+    fn test_tsconfig_accepts_comments_and_trailing_commas() {
+        let cfg = tsconfig_from(
+            r#"{
+                // a real-world tsconfig is JSON with comments
+                "compilerOptions": {
+                    /* block comment */
+                    "target": "ES2022",
+                    "baseUrl": "./src",
+                },
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(cfg.base_url, "src/");
+    }
+
+    #[test]
+    fn test_tsconfig_refuses_options_it_cannot_apply() {
+        for (json, named) in [
+            (
+                r#"{"compilerOptions":{"experimentalDecorators":true}}"#,
+                "experimentalDecorators",
+            ),
+            (
+                r#"{"compilerOptions":{"emitDecoratorMetadata":true}}"#,
+                "emitDecoratorMetadata",
+            ),
+            (r#"{"compilerOptions":{"jsx":"react-jsx"}}"#, "jsx"),
+        ] {
+            let err = tsconfig_from(json).unwrap_err();
+            assert_eq!(err.status_code(), 400);
+            assert!(
+                err.to_string().contains(named),
+                "error should name '{named}': {err}"
+            );
+        }
+
+        // `target` is a no-op rather than a failure: with no down-level pass
+        // the source syntax reaches the runtime either way.
+        assert!(tsconfig_from(r#"{"compilerOptions":{"target":"ES5"}}"#).is_ok());
+        assert!(tsconfig_from(r#"{"compilerOptions":{"jsx":"react"}}"#).is_ok());
+    }
+
+    #[test]
+    fn test_tsconfig_rejects_malformed_path_aliases() {
+        let err = tsconfig_from(r#"{"compilerOptions":{"paths":{"@app/*":["src"]}}}"#).unwrap_err();
+        assert!(err.to_string().contains("both sides must use"), "{err}");
+
+        let err = tsconfig_from(r#"{"compilerOptions":{"paths":{"@app":[]}}}"#).unwrap_err();
+        assert!(err.to_string().contains("non-empty array"), "{err}");
+
+        assert!(tsconfig_from("{not json").is_err());
+    }
+
+    #[test]
+    fn test_tsconfig_wildcard_aliases_become_resolvable_shims() {
+        let tmp = std::env::temp_dir().join(format!("wasmrun-tscfg-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+
+        let files = HashMap::from([
+            (
+                "tsconfig.json".to_string(),
+                r#"{"compilerOptions":{"paths":{"@app/*":["src/*"]}}}"#.to_string(),
+            ),
+            ("src/util.ts".to_string(), "export const x = 1".to_string()),
+            (
+                "src/deep/thing.ts".to_string(),
+                "export const y = 2".to_string(),
+            ),
+            (
+                "main.ts".to_string(),
+                "import {x} from '@app/util'".to_string(),
+            ),
+        ]);
+        let cfg = TsConfig::load(&files, &tmp).unwrap();
+        cfg.write_path_aliases(&files, &tmp, &ResourceLimits::default())
+            .unwrap();
+
+        // require('@app/util') resolves to node_modules/@app/util.js.
+        let shim = std::fs::read_to_string(tmp.join("node_modules/@app/util.js")).unwrap();
+        assert_eq!(shim.trim(), "module.exports = require('/src/util.js');");
+        let deep = std::fs::read_to_string(tmp.join("node_modules/@app/deep/thing.js")).unwrap();
+        assert_eq!(
+            deep.trim(),
+            "module.exports = require('/src/deep/thing.js');"
+        );
+        // Files outside the aliased directory are not shimmed.
+        assert!(!tmp.join("node_modules/@app/main.js").exists());
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn test_tsconfig_exact_alias_uses_package_main() {
+        let tmp = std::env::temp_dir().join(format!("wasmrun-tscfg-exact-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+
+        let files = HashMap::from([
+            (
+                "tsconfig.json".to_string(),
+                r#"{"compilerOptions":{"paths":{"@config":["src/config.ts"]}}}"#.to_string(),
+            ),
+            (
+                "src/config.ts".to_string(),
+                "export const c = 1".to_string(),
+            ),
+        ]);
+        let cfg = TsConfig::load(&files, &tmp).unwrap();
+        cfg.write_path_aliases(&files, &tmp, &ResourceLimits::default())
+            .unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(tmp.join("node_modules/@config/package.json")).unwrap(),
+            r#"{"main":"index.js"}"#
+        );
+        let shim = std::fs::read_to_string(tmp.join("node_modules/@config/index.js")).unwrap();
+        assert_eq!(shim.trim(), "module.exports = require('/src/config.js');");
+
+        // Outside the project: a clear 400, not a shim failing at require time.
+        let files = HashMap::from([(
+            "tsconfig.json".to_string(),
+            r#"{"compilerOptions":{"paths":{"@gone":["src/missing.ts"]}}}"#.to_string(),
+        )]);
+        let cfg = TsConfig::load(&files, &tmp).unwrap();
+        let err = cfg
+            .write_path_aliases(&files, &tmp, &ResourceLimits::default())
+            .unwrap_err();
+        assert!(err.to_string().contains("not in the project"), "{err}");
 
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/src/agent/server.rs
+++ b/src/agent/server.rs
@@ -20,6 +20,115 @@ use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
 use tiny_http::{Header, Method, Request, Response, Server, StatusCode};
 
+/// An exec that has been spawned and is running detached. The session's WASI
+/// buffers accumulate output as it goes, which is what lets the streaming
+/// endpoint report progress without the worker knowing about HTTP.
+struct RunningExec {
+    rx: std::sync::mpsc::Receiver<std::result::Result<i32, ApiError>>,
+    cancel: Arc<AtomicBool>,
+    wasi_env: Arc<Mutex<crate::runtime::wasi::WasiEnv>>,
+    lock_slot: Arc<Mutex<Option<vendor::Lockfile>>>,
+    start: Instant,
+    timeout: Duration,
+    timeout_secs: u64,
+}
+
+/// How often a streaming exec samples the session buffers. Short enough to
+/// feel live, long enough that a tight loop is not one frame per line.
+const STREAM_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Shared by the single-session and list endpoints so they cannot disagree.
+fn session_status_row(s: &crate::agent::session::Session) -> SessionStatusResponse {
+    SessionStatusResponse {
+        session_id: s.id().to_string(),
+        state: match s.state() {
+            SessionState::Active => "active".into(),
+            SessionState::Expired => "expired".into(),
+        },
+        created_at_elapsed_ms: s.created_at().elapsed().as_millis() as u64,
+        last_accessed_elapsed_ms: s.last_accessed().elapsed().as_millis() as u64,
+        timeout_secs: s.timeout().as_secs(),
+    }
+}
+
+/// Work out which npm dependencies an exec should install, and validate them.
+///
+/// Reading package.json is opt-in because an uploaded one would otherwise turn
+/// an ordinary exec into a network fetch nobody asked for. The explicit
+/// `dependencies` map wins on conflict, being the more specific instruction.
+fn resolve_exec_deps(
+    req: &ExecRequest,
+    work_dir: &Path,
+) -> std::result::Result<Option<HashMap<String, String>>, ApiError> {
+    let mut deps = HashMap::new();
+
+    if req.install_package_json.unwrap_or(false) {
+        let raw = match req.files.as_ref().and_then(|f| f.get("package.json")) {
+            Some(uploaded) => Some(uploaded.clone()),
+            None => std::fs::read_to_string(work_dir.join("package.json")).ok(),
+        };
+        let raw = raw.ok_or_else(|| {
+            ApiError::BadRequest(
+                "'install_package_json' is set but no package.json was uploaded or found in the session".into(),
+            )
+        })?;
+        let parsed: serde_json::Value = serde_json::from_str(&raw)
+            .map_err(|e| ApiError::BadRequest(format!("Invalid package.json: {e}")))?;
+        // devDependencies: nothing in the sandbox runs them yet.
+        if let Some(map) = parsed.get("dependencies").and_then(|d| d.as_object()) {
+            for (name, range) in map {
+                let range = range.as_str().ok_or_else(|| {
+                    ApiError::BadRequest(format!(
+                        "package.json dependency '{name}' must map to a version range string"
+                    ))
+                })?;
+                deps.insert(name.clone(), range.to_string());
+            }
+        }
+    }
+
+    if let Some(explicit) = &req.dependencies {
+        deps.extend(explicit.iter().map(|(k, v)| (k.clone(), v.clone())));
+    }
+
+    if deps.is_empty() {
+        return Ok(None);
+    }
+    vendor::validate_deps(&deps)?;
+    Ok(Some(deps))
+}
+
+/// Install an exec's npm dependencies, recording the tree in `lock_out`.
+///
+/// Runs on the exec worker because it is network-bound. A supplied lockfile is
+/// replayed first and carried into the result, so pinning a tree and adding a
+/// dependency yields a lockfile describing both.
+fn vendor_for_exec(
+    registry: &str,
+    deps: Option<&HashMap<String, String>>,
+    lock_in: Option<&vendor::Lockfile>,
+    work_dir: &Path,
+    limits: &ResourceLimits,
+    lock_out: &Mutex<Option<vendor::Lockfile>>,
+) -> std::result::Result<(), ApiError> {
+    if deps.is_none() && lock_in.is_none() {
+        return Ok(());
+    }
+    let v = vendor::Vendor::new(registry)?;
+    let mut lock = vendor::Lockfile::new();
+    if let Some(l) = lock_in {
+        v.vendor_locked(l, work_dir, limits)?;
+        lock.extend(l.iter().map(|(k, e)| (k.clone(), e.clone())));
+    }
+    if let Some(d) = deps {
+        lock.extend(v.vendor(d, work_dir, limits)?);
+    }
+    if let Ok(mut slot) = lock_out.lock() {
+        *slot = Some(lock);
+    }
+    Ok(())
+}
+
 const API_PREFIX: &str = "/api/v1";
 const DEFAULT_EXEC_TIMEOUT_SECS: u64 = 30;
 // Language runtimes (e.g. QuickJS compiled to WASM) generate deep call chains that
@@ -586,6 +695,9 @@ impl AgentServer {
                 self.handle_create_session_with_body(&body, tenant),
                 &log,
             ),
+            (Method::Get, ["sessions"]) => {
+                self.respond_json(request, self.handle_list_sessions(tenant), &log)
+            }
             (Method::Get, ["sessions", id]) => {
                 self.respond_json(request, self.handle_get_session(id, tenant), &log)
             }
@@ -593,7 +705,18 @@ impl AgentServer {
                 self.respond_json(request, self.handle_delete_session(id, tenant), &log)
             }
             (Method::Post, ["sessions", id, "exec"]) => {
-                self.respond_json(request, self.handle_exec(id, &body, tenant), &log)
+                // Read before the request is consumed; a malformed body still
+                // reaches the buffered path, which reports it as a 400.
+                let stream = serde_json::from_str::<ExecRequest>(&body)
+                    .ok()
+                    .and_then(|r| r.stream)
+                    .unwrap_or(false);
+                if stream {
+                    self.handle_exec_stream(request, id, &body, tenant, &log);
+                    Ok(())
+                } else {
+                    self.respond_json(request, self.handle_exec(id, &body, tenant), &log)
+                }
             }
             (Method::Post, ["sessions", id, "files"]) => {
                 self.respond_json(request, self.handle_write_file(id, &body, tenant), &log)
@@ -756,22 +879,26 @@ impl AgentServer {
         })
     }
 
+    pub fn handle_list_sessions(
+        &self,
+        caller: Option<&str>,
+    ) -> std::result::Result<ListSessionsResponse, ApiError> {
+        let sessions = self
+            .session_manager
+            .list_sessions(caller, session_status_row);
+        Ok(ListSessionsResponse {
+            count: sessions.len(),
+            sessions,
+        })
+    }
+
     pub fn handle_get_session(
         &self,
         id: &str,
         caller: Option<&str>,
     ) -> std::result::Result<SessionStatusResponse, ApiError> {
         self.session_manager
-            .get_session(id, caller, |s| SessionStatusResponse {
-                session_id: s.id().to_string(),
-                state: match s.state() {
-                    SessionState::Active => "active".into(),
-                    SessionState::Expired => "expired".into(),
-                },
-                created_at_elapsed_ms: s.created_at().elapsed().as_millis() as u64,
-                last_accessed_elapsed_ms: s.last_accessed().elapsed().as_millis() as u64,
-                timeout_secs: s.timeout().as_secs(),
-            })
+            .get_session(id, caller, session_status_row)
             .map_err(map_session_err)
     }
 
@@ -790,12 +917,28 @@ impl AgentServer {
 
     // ── Exec endpoint ─────────────────────────────────────────────
 
+    /// Buffered exec: start the run and wait for it to finish.
     pub fn handle_exec(
         &self,
         id: &str,
         body: &str,
         caller: Option<&str>,
     ) -> std::result::Result<ExecResponse, ApiError> {
+        let run = self.start_exec(id, body, caller)?;
+        self.collect_exec(run)
+    }
+
+    /// Validate the request, prepare the session, and spawn the exec worker.
+    ///
+    /// Split from collection so the buffered and streaming endpoints share
+    /// every decision about *what* runs. Everything that can fail with a 4xx
+    /// happens here, before a worker or a permit is taken.
+    fn start_exec(
+        &self,
+        id: &str,
+        body: &str,
+        caller: Option<&str>,
+    ) -> std::result::Result<RunningExec, ApiError> {
         let req: ExecRequest =
             serde_json::from_str(body).map_err(|e| ApiError::BadRequest(e.to_string()))?;
 
@@ -825,6 +968,9 @@ impl AgentServer {
                 env.seed_disk_used(dir_size(&work_dir));
             }
         }
+
+        // Validated synchronously so bad input is a 400 before a worker runs.
+        let resolved_deps = resolve_exec_deps(&req, &work_dir)?;
 
         let timeout_secs = req.timeout.unwrap_or(DEFAULT_EXEC_TIMEOUT_SECS);
         let timeout = Duration::from_secs(timeout_secs);
@@ -864,6 +1010,10 @@ impl AgentServer {
             _tenant: tenant_permit,
         };
 
+        // Vendoring runs on the worker but its result belongs in the response,
+        // including on timeout; a slot keeps the channel carrying the exit code.
+        let lock_slot: Arc<Mutex<Option<vendor::Lockfile>>> = Arc::new(Mutex::new(None));
+
         let (tx, rx) = std::sync::mpsc::channel::<std::result::Result<i32, ApiError>>();
         // Cooperative cancellation: the worker runs detached, so if the
         // wall-clock timeout fires we trip this flag to make the (possibly
@@ -899,26 +1049,26 @@ impl AgentServer {
             }
             // Validate dependency names/ranges before spawning (fast 400);
             // the network-bound vendoring itself runs on the worker.
-            let deps = req.dependencies.clone();
-            if let Some(ref d) = deps {
-                vendor::validate_deps(d)?;
-            }
+            let deps = resolved_deps.clone();
+            let lock_in = req.lockfile.clone();
             let registry = self.config.npm_registry.clone();
             let work_dir_clone = work_dir.clone();
             let limits_clone = limits.clone();
             let cancel_worker = cancel.clone();
+            let lock_out = lock_slot.clone();
             std::thread::Builder::new()
                 .stack_size(EXEC_THREAD_STACK_BYTES)
                 .spawn(move || {
                     let permit = permit; // held for the duration of execution
                     let result = (|| {
-                        if let Some(ref d) = deps {
-                            vendor::Vendor::new(&registry)?.vendor(
-                                d,
-                                &work_dir_clone,
-                                &limits_clone,
-                            )?;
-                        }
+                        vendor_for_exec(
+                            &registry,
+                            deps.as_ref(),
+                            lock_in.as_ref(),
+                            &work_dir_clone,
+                            &limits_clone,
+                            &lock_out,
+                        )?;
                         executor::execute_source_project(
                             &files,
                             &entry,
@@ -938,26 +1088,26 @@ impl AgentServer {
             let lang = req.language.unwrap_or_else(|| "javascript".into());
             // Validate language before spawning so callers get a 400 immediately
             executor::resolve_language(&lang)?;
-            let deps = req.dependencies.clone();
-            if let Some(ref d) = deps {
-                vendor::validate_deps(d)?;
-            }
+            let deps = resolved_deps.clone();
+            let lock_in = req.lockfile.clone();
             let registry = self.config.npm_registry.clone();
             let work_dir_clone = work_dir.clone();
             let limits_clone = limits.clone();
             let cancel_worker = cancel.clone();
+            let lock_out = lock_slot.clone();
             std::thread::Builder::new()
                 .stack_size(EXEC_THREAD_STACK_BYTES)
                 .spawn(move || {
                     let permit = permit; // held for the duration of execution
                     let result = (|| {
-                        if let Some(ref d) = deps {
-                            vendor::Vendor::new(&registry)?.vendor(
-                                d,
-                                &work_dir_clone,
-                                &limits_clone,
-                            )?;
-                        }
+                        vendor_for_exec(
+                            &registry,
+                            deps.as_ref(),
+                            lock_in.as_ref(),
+                            &work_dir_clone,
+                            &limits_clone,
+                            &lock_out,
+                        )?;
                         executor::execute_source(
                             &source,
                             &lang,
@@ -1002,6 +1152,169 @@ impl AgentServer {
             ));
         }
 
+        Ok(RunningExec {
+            rx,
+            cancel,
+            wasi_env,
+            lock_slot,
+            start,
+            timeout,
+            timeout_secs,
+        })
+    }
+
+    /// Streaming exec: emit output as Server-Sent Events while it runs.
+    ///
+    /// Takes the raw socket rather than `respond_json`, because the point is
+    /// to send bytes before the result exists. A final `result` event carries
+    /// the same object the buffered endpoint returns, so a client can ignore
+    /// the intermediate frames.
+    fn handle_exec_stream(
+        &self,
+        request: Request,
+        id: &str,
+        body: &str,
+        caller: Option<&str>,
+        log: &ReqLog,
+    ) {
+        let run = match self.start_exec(id, body, caller) {
+            Ok(run) => run,
+            // Nothing has been written yet, so a failure to start is still an
+            // ordinary JSON error response.
+            Err(e) => {
+                let _ = self.respond_json(request, Err::<(), _>(e), log);
+                return;
+            }
+        };
+
+        let mut out = request.into_writer();
+        let headers = "HTTP/1.1 200 OK\r\n\
+             Content-Type: text/event-stream\r\n\
+             Cache-Control: no-cache\r\n\
+             Connection: close\r\n\r\n";
+        if out.write_all(headers.as_bytes()).is_err() {
+            run.cancel.store(true, Ordering::Relaxed);
+            return;
+        }
+
+        let response = self.stream_exec(run, &mut out);
+        let event = serde_json::to_string(&response)
+            .unwrap_or_else(|e| format!(r#"{{"error":"failed to serialize result: {e}"}}"#));
+        let _ = out.write_all(format!("event: result\ndata: {event}\n\n").as_bytes());
+        let _ = out.flush();
+        log.emit(200);
+    }
+
+    /// Drive a running exec, writing `output` events as it produces them, and
+    /// return the response that describes how it ended.
+    fn stream_exec(&self, run: RunningExec, out: &mut dyn std::io::Write) -> ExecResponse {
+        let RunningExec {
+            rx,
+            cancel,
+            wasi_env,
+            lock_slot,
+            start,
+            timeout,
+            timeout_secs,
+        } = run;
+
+        let (mut seen_out, mut seen_err) = (0usize, 0usize);
+        // False once the client has gone away, which is the signal to stop.
+        let mut flush = |out: &mut dyn std::io::Write| -> bool {
+            let (stdout, stderr) = match wasi_env.lock() {
+                Ok(env) => (
+                    take_new_output(&env.get_stdout(), &mut seen_out),
+                    take_new_output(&env.get_stderr(), &mut seen_err),
+                ),
+                Err(_) => return true,
+            };
+            if stdout.is_empty() && stderr.is_empty() {
+                return true;
+            }
+            let payload = serde_json::json!({"stdout": stdout, "stderr": stderr});
+            out.write_all(format!("event: output\ndata: {payload}\n\n").as_bytes())
+                .and_then(|()| out.flush())
+                .is_ok()
+        };
+
+        let exec_result = loop {
+            match rx.recv_timeout(STREAM_POLL_INTERVAL) {
+                Ok(result) => {
+                    flush(out);
+                    break Some(result);
+                }
+                Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                    if !flush(out) || start.elapsed() >= timeout {
+                        cancel.store(true, Ordering::Relaxed);
+                        break None;
+                    }
+                }
+                Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break None,
+            }
+        };
+
+        let duration_ms = start.elapsed().as_millis() as u64;
+        let truncated = read_env_truncated(&wasi_env);
+        if truncated {
+            self.metrics.record_output_truncated();
+        }
+        let lockfile = lock_slot.lock().ok().and_then(|mut l| l.take());
+
+        // Repeat the full output so a client that dropped a frame still has it.
+        let (stdout, stderr) = (read_env_stdout(&wasi_env), read_env_stderr(&wasi_env));
+        match exec_result {
+            Some(Ok(exit_code)) => {
+                self.metrics.record_exec_success(duration_ms);
+                ExecResponse {
+                    stdout,
+                    stderr,
+                    exit_code,
+                    duration_ms,
+                    output_truncated: truncated,
+                    error: None,
+                    lockfile,
+                }
+            }
+            Some(Err(e)) => {
+                self.metrics.record_exec_error(duration_ms);
+                ExecResponse {
+                    stdout,
+                    stderr,
+                    exit_code: -1,
+                    duration_ms,
+                    output_truncated: truncated,
+                    error: Some(e.to_string()),
+                    lockfile,
+                }
+            }
+            None => {
+                self.metrics.record_exec_timeout(duration_ms);
+                ExecResponse {
+                    stdout,
+                    stderr,
+                    exit_code: -1,
+                    duration_ms,
+                    output_truncated: truncated,
+                    error: Some(format!("Execution timed out after {timeout_secs}s")),
+                    lockfile,
+                }
+            }
+        }
+    }
+
+    /// Wait for a running exec and build its response.
+    fn collect_exec(&self, run: RunningExec) -> std::result::Result<ExecResponse, ApiError> {
+        let RunningExec {
+            rx,
+            cancel,
+            wasi_env,
+            lock_slot,
+            start,
+            timeout,
+            timeout_secs,
+        } = run;
+        let take_lock = || lock_slot.lock().ok().and_then(|mut l| l.take());
+
         let duration_ms;
         let exec_result = match rx.recv_timeout(timeout) {
             Ok(result) => {
@@ -1026,6 +1339,7 @@ impl AgentServer {
                     duration_ms,
                     output_truncated: truncated,
                     error: Some(format!("Execution timed out after {timeout_secs}s")),
+                    lockfile: take_lock(),
                 });
             }
             Err(_) => {
@@ -1038,6 +1352,7 @@ impl AgentServer {
                     duration_ms,
                     output_truncated: false,
                     error: Some("Execution thread panicked".into()),
+                    lockfile: take_lock(),
                 });
             }
         };
@@ -1056,6 +1371,7 @@ impl AgentServer {
                     duration_ms,
                     output_truncated: truncated,
                     error: None,
+                    lockfile: take_lock(),
                 })
             }
             Err(e) => {
@@ -1067,6 +1383,7 @@ impl AgentServer {
                     duration_ms,
                     output_truncated: truncated,
                     error: Some(e.to_string()),
+                    lockfile: take_lock(),
                 })
             }
         }
@@ -1592,6 +1909,23 @@ fn read_env_stderr(
     env.lock()
         .map(|e| String::from_utf8_lossy(&e.get_stderr()).into_owned())
         .unwrap_or_default()
+}
+
+/// Bytes appended to a session buffer since `seen`, advancing `seen`.
+///
+/// The buffers only grow during an exec, so an offset is enough. A trailing
+/// partial UTF-8 character is held back rather than emitted as U+FFFD.
+fn take_new_output(buffer: &[u8], seen: &mut usize) -> String {
+    if buffer.len() <= *seen {
+        return String::new();
+    }
+    let fresh = &buffer[*seen..];
+    let valid = match std::str::from_utf8(fresh) {
+        Ok(s) => s.len(),
+        Err(e) => e.valid_up_to(),
+    };
+    *seen += valid;
+    String::from_utf8_lossy(&fresh[..valid]).into_owned()
 }
 
 fn read_env_truncated(
@@ -2420,13 +2754,178 @@ mod tests {
         assert_eq!(err.status_code(), 400);
         assert!(err.to_string().contains("Invalid package name"));
 
-        // Unsupported composite range → immediate 400.
-        let body = r#"{"source": "1", "dependencies": {"lodash": ">=1.0.0 <2.0.0"}}"#;
+        // Composite ranges are supported now, so this needs a malformed one.
+        let body = r#"{"source": "1", "dependencies": {"lodash": ">=not.a.version"}}"#;
         let err = server.handle_exec(&id, body, None).unwrap_err();
         assert_eq!(err.status_code(), 400);
         assert!(err.to_string().contains("Unsupported version range"));
 
         server.session_manager.destroy_all().unwrap();
+    }
+
+    #[test]
+    fn test_take_new_output_emits_only_the_delta() {
+        let mut seen = 0;
+        assert_eq!(take_new_output(b"hello", &mut seen), "hello");
+        assert_eq!(seen, 5);
+        assert_eq!(take_new_output(b"hello", &mut seen), "");
+        assert_eq!(take_new_output(b"hello world", &mut seen), " world");
+        assert_eq!(seen, 11);
+    }
+
+    #[test]
+    fn test_take_new_output_holds_back_split_utf8() {
+        // A character split across samples must not become U+FFFD.
+        let full = "aé".as_bytes(); // [0x61, 0xC3, 0xA9]
+        let mut seen = 0;
+        assert_eq!(take_new_output(&full[..2], &mut seen), "a");
+        assert_eq!(seen, 1, "the partial character is not consumed");
+        assert_eq!(take_new_output(full, &mut seen), "é");
+        assert_eq!(seen, 3);
+    }
+
+    #[test]
+    fn test_stream_exec_writes_output_and_result_events() {
+        let server = test_server();
+        let id = server.handle_create_session().unwrap().session_id;
+
+        // The shell path is fast, so this covers event ordering, not sampling.
+        let run = server
+            .start_exec(&id, r#"{"command": "echo streamed"}"#, None)
+            .unwrap();
+        let mut out: Vec<u8> = Vec::new();
+        let response = server.stream_exec(run, &mut out);
+
+        assert_eq!(response.exit_code, 0);
+        assert!(response.stdout.contains("streamed"));
+
+        let events = String::from_utf8(out).unwrap();
+        // Frames are best-effort, but anything emitted must be well-formed.
+        for frame in events.split("\n\n").filter(|f| !f.trim().is_empty()) {
+            assert!(frame.starts_with("event: output\ndata: {"), "{frame}");
+        }
+
+        server.session_manager.destroy_all().unwrap();
+    }
+
+    #[test]
+    fn test_stream_flag_is_parsed_from_the_request() {
+        let with: ExecRequest = serde_json::from_str(r#"{"source":"1","stream":true}"#).unwrap();
+        assert_eq!(with.stream, Some(true));
+        let without: ExecRequest = serde_json::from_str(r#"{"source":"1"}"#).unwrap();
+        assert_eq!(without.stream, None, "buffered stays the default");
+    }
+
+    #[test]
+    fn test_list_sessions() {
+        let server = test_server();
+        assert_eq!(server.handle_list_sessions(None).unwrap().count, 0);
+
+        let a = server.handle_create_session().unwrap().session_id;
+        let b = server.handle_create_session().unwrap().session_id;
+        let listed = server.handle_list_sessions(None).unwrap();
+        assert_eq!(listed.count, 2);
+        let ids: Vec<&str> = listed
+            .sessions
+            .iter()
+            .map(|s| s.session_id.as_str())
+            .collect();
+        assert!(ids.contains(&a.as_str()) && ids.contains(&b.as_str()));
+        assert!(listed.sessions.iter().all(|s| s.state == "active"));
+
+        server.handle_delete_session(&a, None).unwrap();
+        let listed = server.handle_list_sessions(None).unwrap();
+        assert_eq!(listed.count, 1);
+        assert_eq!(listed.sessions[0].session_id, b);
+
+        server.session_manager.destroy_all().unwrap();
+    }
+
+    #[test]
+    fn test_list_sessions_is_tenant_scoped() {
+        let server = test_server();
+        let mine = server
+            .handle_create_session_with_body("{}", Some("tenant-a"))
+            .unwrap()
+            .session_id;
+        server
+            .handle_create_session_with_body("{}", Some("tenant-b"))
+            .unwrap();
+
+        // A tenant must not learn that another tenant's sessions exist.
+        let listed = server.handle_list_sessions(Some("tenant-a")).unwrap();
+        assert_eq!(listed.count, 1);
+        assert_eq!(listed.sessions[0].session_id, mine);
+
+        server.session_manager.destroy_all().unwrap();
+    }
+
+    #[test]
+    fn test_resolve_exec_deps_from_package_json() {
+        let work_dir = tempfile::tempdir().unwrap();
+        let parse = |body: &str| -> ExecRequest { serde_json::from_str(body).unwrap() };
+
+        // Without the flag an uploaded package.json is inert.
+        let req = parse(
+            r#"{"source":"1","files":{"package.json":"{\"dependencies\":{\"lodash\":\"^4.0.0\"}}"}}"#,
+        );
+        assert!(resolve_exec_deps(&req, work_dir.path()).unwrap().is_none());
+
+        let req = parse(
+            r#"{"source":"1","install_package_json":true,"files":{"package.json":"{\"dependencies\":{\"lodash\":\"^4.0.0\"},\"devDependencies\":{\"jest\":\"^29\"}}"}}"#,
+        );
+        let deps = resolve_exec_deps(&req, work_dir.path()).unwrap().unwrap();
+        assert_eq!(deps.get("lodash").map(String::as_str), Some("^4.0.0"));
+        assert!(!deps.contains_key("jest"), "devDependencies are ignored");
+
+        // The explicit map wins over the file.
+        let req = parse(
+            r#"{"source":"1","install_package_json":true,"dependencies":{"lodash":"4.17.21"},"files":{"package.json":"{\"dependencies\":{\"lodash\":\"^4.0.0\"}}"}}"#,
+        );
+        let deps = resolve_exec_deps(&req, work_dir.path()).unwrap().unwrap();
+        assert_eq!(deps.get("lodash").map(String::as_str), Some("4.17.21"));
+
+        // Falls back to a package.json already in the session.
+        std::fs::write(
+            work_dir.path().join("package.json"),
+            r#"{"dependencies":{"greet":"^1.0.0"}}"#,
+        )
+        .unwrap();
+        let req = parse(r#"{"source":"1","install_package_json":true}"#);
+        let deps = resolve_exec_deps(&req, work_dir.path()).unwrap().unwrap();
+        assert_eq!(deps.get("greet").map(String::as_str), Some("^1.0.0"));
+    }
+
+    #[test]
+    fn test_resolve_exec_deps_package_json_errors() {
+        let work_dir = tempfile::tempdir().unwrap();
+        let parse = |body: &str| -> ExecRequest { serde_json::from_str(body).unwrap() };
+
+        let req = parse(r#"{"source":"1","install_package_json":true}"#);
+        let err = resolve_exec_deps(&req, work_dir.path()).unwrap_err();
+        assert_eq!(err.status_code(), 400);
+        assert!(err.to_string().contains("no package.json"));
+
+        let req = parse(
+            r#"{"source":"1","install_package_json":true,"files":{"package.json":"{not json"}}"#,
+        );
+        let err = resolve_exec_deps(&req, work_dir.path()).unwrap_err();
+        assert_eq!(err.status_code(), 400);
+        assert!(err.to_string().contains("Invalid package.json"));
+
+        let req = parse(
+            r#"{"source":"1","install_package_json":true,"files":{"package.json":"{\"dependencies\":{\"lodash\":5}}"}}"#,
+        );
+        let err = resolve_exec_deps(&req, work_dir.path()).unwrap_err();
+        assert_eq!(err.status_code(), 400);
+
+        // Bad names from a package.json are validated like any other.
+        let req = parse(
+            r#"{"source":"1","install_package_json":true,"files":{"package.json":"{\"dependencies\":{\"../evil\":\"*\"}}"}}"#,
+        );
+        let err = resolve_exec_deps(&req, work_dir.path()).unwrap_err();
+        assert_eq!(err.status_code(), 400);
+        assert!(err.to_string().contains("Invalid package name"));
     }
 
     /// Integration test: the 0.21.3 exit criteria — a project depending on a
@@ -2842,7 +3341,7 @@ mod tests {
         let server = test_server();
         let result = server.handle_get_tools("openai").unwrap();
         let tools = result.as_array().unwrap();
-        assert_eq!(tools.len(), 6);
+        assert_eq!(tools.len(), 7);
         assert_eq!(tools[0]["type"], "function");
         assert!(tools[0]["function"]["name"].is_string());
         assert!(tools[0]["function"]["parameters"].is_object());
@@ -2853,7 +3352,7 @@ mod tests {
         let server = test_server();
         let result = server.handle_get_tools("anthropic").unwrap();
         let tools = result.as_array().unwrap();
-        assert_eq!(tools.len(), 6);
+        assert_eq!(tools.len(), 7);
         assert!(tools[0]["input_schema"].is_object());
         // Anthropic format has no "function" wrapper
         assert!(tools[0].get("function").is_none());

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -444,23 +444,6 @@ impl SessionManager {
         }
     }
 
-    /// List all active (non-expired) session IDs.
-    #[allow(dead_code)] // TODO: Used by agent list sessions endpoint
-    pub fn list_sessions(&self) -> Result<Vec<SessionInfo>, SessionError> {
-        let sessions = self.sessions.read().map_err(|_| SessionError::LockError)?;
-        Ok(sessions
-            .values()
-            .filter(|s| !s.is_expired())
-            .map(|s| SessionInfo {
-                id: s.id().to_string(),
-                state: s.state(),
-                created_at_elapsed: s.created_at().elapsed(),
-                last_accessed_elapsed: s.last_accessed().elapsed(),
-                timeout: s.timeout(),
-            })
-            .collect())
-    }
-
     /// Remove all expired sessions and clean up their resources.
     ///
     /// Returns the number of sessions removed.
@@ -492,6 +475,28 @@ impl SessionManager {
     /// Get the total number of sessions (including expired ones not yet cleaned up).
     pub fn total_count(&self) -> usize {
         self.sessions.read().map(|s| s.len()).unwrap_or(0)
+    }
+
+    /// Status of every active session, newest first.
+    ///
+    /// `caller` scopes the listing exactly as `get_session` does: a tenant
+    /// sees only its own sessions and must not learn that any others exist.
+    /// Expired sessions are omitted even before the cleanup thread collects
+    /// them, so the listing never advertises a session that cannot be used.
+    pub fn list_sessions<F, R>(&self, caller: Option<&str>, f: F) -> Vec<R>
+    where
+        F: Fn(&Session) -> R,
+    {
+        let Ok(sessions) = self.sessions.read() else {
+            return Vec::new();
+        };
+        let mut rows: Vec<(std::time::Instant, R)> = sessions
+            .values()
+            .filter(|s| !s.is_expired() && s.owner() == caller)
+            .map(|s| (s.created_at(), f(s)))
+            .collect();
+        rows.sort_by_key(|(created, _)| std::cmp::Reverse(*created));
+        rows.into_iter().map(|(_, r)| r).collect()
     }
 
     /// Per-session resource report (id, disk footprint, configured memory cap)
@@ -578,19 +583,6 @@ impl Default for SessionManager {
     fn default() -> Self {
         Self::new()
     }
-}
-
-// ── Session Info (for listing) ────────────────────────────────────────
-
-/// Summary information about a session (safe to serialize/return via API).
-#[derive(Debug, Clone)]
-#[allow(dead_code)] // TODO: Used by agent list sessions endpoint
-pub struct SessionInfo {
-    pub id: String,
-    pub state: SessionState,
-    pub created_at_elapsed: Duration,
-    pub last_accessed_elapsed: Duration,
-    pub timeout: Duration,
 }
 
 /// Per-session resource footprint, produced by
@@ -943,15 +935,15 @@ mod tests {
         let id1 = manager.create_session().unwrap();
         let id2 = manager.create_session().unwrap();
 
-        let list = manager.list_sessions().unwrap();
+        let list = manager.list_sessions(None, |s| (s.id().to_string(), s.state()));
         assert_eq!(list.len(), 2);
 
-        let listed_ids: Vec<&str> = list.iter().map(|i| i.id.as_str()).collect();
+        let listed_ids: Vec<&str> = list.iter().map(|(id, _)| id.as_str()).collect();
         assert!(listed_ids.contains(&id1.as_str()));
         assert!(listed_ids.contains(&id2.as_str()));
 
         // All are active
-        assert!(list.iter().all(|i| i.state == SessionState::Active));
+        assert!(list.iter().all(|(_, state)| *state == SessionState::Active));
 
         // Cleanup
         manager.destroy_session(&id1, None).unwrap();
@@ -973,9 +965,9 @@ mod tests {
             .create_session_with_timeout(Duration::from_secs(60))
             .unwrap();
 
-        let list = manager.list_sessions().unwrap();
+        let list = manager.list_sessions(None, |s| s.id().to_string());
         assert_eq!(list.len(), 1);
-        assert_eq!(list[0].id, id2);
+        assert_eq!(list[0], id2);
 
         // Cleanup
         manager.destroy_all().unwrap();

--- a/src/agent/tools.rs
+++ b/src/agent/tools.rs
@@ -45,7 +45,7 @@ pub fn openai_tools() -> Vec<OpenAiTool> {
             r#type: "function",
             function: OpenAiFunction {
                 name: "execute_code",
-                description: "Execute code inside a sandbox session. Provide one of: 'command' (shell-style command line with pipes, redirection, and built-ins like echo/cat/ls/pwd/cd/mkdir/rm/cp/mv/env/export), 'source'+'language' (single JavaScript or TypeScript snippet), 'files'+'entry'+'language' (multi-file JS/TS project with relative require() and node_modules resolution), or 'wasm_path' (pre-compiled WASM). TypeScript is transpiled in-sandbox before execution. JS/TS code can use Node built-ins (path, fs, os, events, util, assert, stream, buffer) and standard globals (Buffer, TextEncoder/TextDecoder, URL/URLSearchParams, crypto.getRandomValues, structuredClone, timers, async/await). The sandbox has NO network access: fetch() rejects with a clear error, and npm packages must be declared via 'dependencies' (vendored host-side). Returns stdout, stderr, exit code, and duration.",
+                description: "Execute code inside a sandbox session. Provide one of: 'command' (shell-style command line with pipes, redirection, and built-ins like echo/cat/ls/pwd/cd/mkdir/rm/cp/mv/env/export), 'source'+'language' (single JavaScript or TypeScript snippet), 'files'+'entry'+'language' (multi-file JS/TS project with relative require() and node_modules resolution), or 'wasm_path' (pre-compiled WASM). TypeScript is transpiled in-sandbox before execution. JS/TS code can use Node built-ins (path, fs, os, events, util, assert, stream, buffer) and standard globals (Buffer, TextEncoder/TextDecoder, URL/URLSearchParams, crypto.getRandomValues, structuredClone, timers, async/await). The sandbox has NO network access: fetch() rejects with a clear error, and npm packages must be declared via 'dependencies' (vendored host-side) or read from the project's package.json with 'install_package_json'. A project may ship a tsconfig.json; its 'paths' aliases are honored. Returns stdout, stderr, exit code, duration, and a 'lockfile' pinning any packages that were installed.",
                 parameters: json!({
                     "type": "object",
                     "properties": {
@@ -73,7 +73,27 @@ pub fn openai_tools() -> Vec<OpenAiTool> {
                         "dependencies": {
                             "type": "object",
                             "additionalProperties": { "type": "string" },
-                            "description": "npm dependencies to install before execution, as a map of package name → version range (e.g. {\"lodash\": \"^4.17.21\"}). Only pure-JS packages work (no native bindings, no install scripts). Use with 'source' or 'files'; the code can then require() them."
+                            "description": "npm dependencies to install before execution, as a map of package name → version range (e.g. {\"lodash\": \"^4.17.21\"}). Full npm range syntax is supported, including unions (\"^1 || ^2\"), comparator sets (\">=1.2.0 <2.0.0\") and hyphen ranges. Only pure-JS packages work (no native bindings, no install scripts). Use with 'source' or 'files'; the code can then require() them."
+                        },
+                        "install_package_json": {
+                            "type": "boolean",
+                            "description": "Also install the dependencies listed in the project's package.json (uploaded in 'files', or already in the session). Off by default so an uploaded package.json never triggers an unrequested install. devDependencies are ignored."
+                        },
+                        "lockfile": {
+                            "type": "object",
+                            "description": "A lockfile from a previous execute_code response, replayed to install exactly the versions it records instead of re-resolving ranges. Use it to make repeat runs reproducible; version ranges otherwise resolve to whatever is newest at the time.",
+                            "additionalProperties": {
+                                "type": "object",
+                                "properties": {
+                                    "version": { "type": "string" },
+                                    "resolved": { "type": "string" },
+                                    "integrity": { "type": "string" }
+                                }
+                            }
+                        },
+                        "stream": {
+                            "type": "boolean",
+                            "description": "Stream output as Server-Sent Events while the code runs, instead of waiting for the full response. 'output' events carry incremental stdout/stderr; a final 'result' event carries the normal response object. Useful for long runs that would otherwise be silent until they finish."
                         },
                         "language": {
                             "type": "string",
@@ -181,6 +201,18 @@ pub fn openai_tools() -> Vec<OpenAiTool> {
         OpenAiTool {
             r#type: "function",
             function: OpenAiFunction {
+                name: "list_sessions",
+                description: "List the sandbox sessions currently available, newest first, with their state and idle timeout. Use it to find a session to reuse instead of creating another one.",
+                parameters: json!({
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": false
+                }),
+            },
+        },
+        OpenAiTool {
+            r#type: "function",
+            function: OpenAiFunction {
                 name: "destroy_session",
                 description: "Destroy a sandbox session and clean up all its files and resources.",
                 parameters: json!({
@@ -217,7 +249,7 @@ mod tests {
     #[test]
     fn test_openai_tools_valid_structure() {
         let tools = openai_tools();
-        assert_eq!(tools.len(), 6);
+        assert_eq!(tools.len(), 7);
         for tool in &tools {
             assert_eq!(tool.r#type, "function");
             assert!(!tool.function.name.is_empty());
@@ -225,7 +257,10 @@ mod tests {
             assert!(tool.function.parameters.is_object());
             assert_eq!(tool.function.parameters["type"], "object");
             assert!(tool.function.parameters["properties"].is_object());
-            assert!(tool.function.parameters["required"].is_array());
+            // list_sessions takes no arguments, so it has no "required" list.
+            if tool.function.name != "list_sessions" {
+                assert!(tool.function.parameters["required"].is_array());
+            }
         }
     }
 
@@ -238,6 +273,7 @@ mod tests {
         assert!(names.contains(&"write_file"));
         assert!(names.contains(&"read_file"));
         assert!(names.contains(&"list_files"));
+        assert!(names.contains(&"list_sessions"));
         assert!(names.contains(&"destroy_session"));
     }
 
@@ -254,6 +290,22 @@ mod tests {
         // wasm_path and source are now both optional (either may be provided)
         assert!(!req_strs.contains(&"wasm_path"));
         assert!(!req_strs.contains(&"source"));
+    }
+
+    #[test]
+    fn test_execute_code_advertises_the_v0_22_fields() {
+        let tools = openai_tools();
+        let exec = tools
+            .iter()
+            .find(|t| t.function.name == "execute_code")
+            .unwrap();
+        let props = exec.function.parameters["properties"].as_object().unwrap();
+        for field in ["lockfile", "install_package_json", "stream"] {
+            assert!(
+                props.contains_key(field),
+                "schema should describe '{field}'"
+            );
+        }
     }
 
     #[test]
@@ -329,7 +381,7 @@ mod tests {
         let tools = openai_tools();
         let json = serde_json::to_string(&tools).unwrap();
         let parsed: Vec<Value> = serde_json::from_str(&json).unwrap();
-        assert_eq!(parsed.len(), 6);
+        assert_eq!(parsed.len(), 7);
         assert_eq!(parsed[0]["type"], "function");
     }
 }

--- a/src/agent/vendor.rs
+++ b/src/agent/vendor.rs
@@ -18,8 +18,8 @@
 
 use crate::agent::api::ApiError;
 use crate::agent::limits::{dir_size, ResourceLimits};
-use serde::Deserialize;
-use std::collections::HashMap;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, HashMap};
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
@@ -64,10 +64,25 @@ struct DistDoc {
     integrity: Option<String>,
 }
 
-/// Per-request state: memoized registry docs and a global package counter.
+/// Per-request state: memoized registry docs, a package counter, and the
+/// lockfile accumulated as the tree is walked.
 struct Ctx {
     docs: HashMap<String, PackageDoc>,
     installed: usize,
+    lock: Lockfile,
+}
+
+/// A resolved dependency tree: install path (relative to the session root,
+/// e.g. `node_modules/a/node_modules/b`) → the package that goes there.
+/// Replaying one pins every version, including transitive ones.
+pub type Lockfile = BTreeMap<String, LockEntry>;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LockEntry {
+    pub version: String,
+    pub resolved: String,
+    /// Verified on every download.
+    pub integrity: String,
 }
 
 /// Validate a `dependencies` map without touching the network, so obviously
@@ -105,20 +120,24 @@ impl Vendor {
         }
     }
 
-    /// Vendor `deps` (name → npm range) into `{work_dir}/node_modules`.
+    /// Vendor `deps` (name → npm range) into `{work_dir}/node_modules`,
+    /// returning a lockfile describing the tree that was resolved.
     ///
     /// Idempotent per session: a dependency already present at a satisfying
     /// version is skipped, so repeat execs with the same `dependencies` map
-    /// cost nothing.
+    /// cost nothing. A package skipped because an *earlier exec* installed it
+    /// is not in the returned lockfile: recording it would need the registry
+    /// lookup the skip exists to avoid.
     pub fn vendor(
         &self,
         deps: &HashMap<String, String>,
         work_dir: &Path,
         limits: &ResourceLimits,
-    ) -> std::result::Result<(), ApiError> {
+    ) -> std::result::Result<Lockfile, ApiError> {
         let mut ctx = Ctx {
             docs: HashMap::new(),
             installed: 0,
+            lock: Lockfile::new(),
         };
         let root_nm = work_dir.join("node_modules");
         let mut chain = vec![root_nm];
@@ -128,6 +147,47 @@ impl Vendor {
         names.sort();
         for name in names {
             self.install_into(name, &deps[name], &mut chain, limits, &mut ctx, 0)?;
+        }
+        Ok(ctx.lock)
+    }
+
+    /// Install exactly the tree a previous `vendor` call recorded.
+    ///
+    /// Replay walks the lockfile rather than the dependency graph, so nothing
+    /// is re-resolved and with a warm cache it runs offline. Tarballs are
+    /// still integrity-verified and scanned for native artifacts.
+    pub fn vendor_locked(
+        &self,
+        lock: &Lockfile,
+        work_dir: &Path,
+        limits: &ResourceLimits,
+    ) -> std::result::Result<(), ApiError> {
+        if lock.len() > MAX_PACKAGES_PER_REQUEST {
+            return Err(ApiError::BadRequest(format!(
+                "Lockfile exceeds {MAX_PACKAGES_PER_REQUEST} packages",
+            )));
+        }
+        // BTreeMap order puts a parent before anything nested inside it.
+        for (path, entry) in lock {
+            let name = validate_lock_path(path)?;
+            let dest = work_dir.join(path);
+
+            if installed_version(&dest).as_deref() == Some(entry.version.as_str()) {
+                continue;
+            }
+
+            let cached =
+                self.ensure_cached(name, &entry.version, &entry.resolved, &entry.integrity)?;
+            if let Some(max_disk) = limits.max_disk_bytes {
+                let current = dir_size(work_dir);
+                if current.saturating_add(dir_size(&cached)) > max_disk {
+                    return Err(ApiError::BadRequest(format!(
+                        "Disk usage limit exceeded while vendoring '{name}@{}'",
+                        entry.version
+                    )));
+                }
+            }
+            copy_dir(&cached, &dest, limits)?;
         }
         Ok(())
     }
@@ -184,11 +244,28 @@ impl Vendor {
             )));
         }
 
-        let cached = self.ensure_cached(name, &vdoc)?;
+        let integrity = vdoc.dist.integrity.as_deref().ok_or_else(|| {
+            ApiError::BadRequest(format!(
+                "Package '{name}@{}' has no sha512 integrity in the registry; refusing to vendor unverifiable tarballs",
+                vdoc.version
+            ))
+        })?;
+        let cached = self.ensure_cached(name, &vdoc.version, &vdoc.dist.tarball, integrity)?;
 
         let parent_nm = chain.last().expect("chain never empty").clone();
         let dest = parent_nm.join(name);
         let session_root = chain[0].parent().expect("root nm has parent").to_path_buf();
+
+        if let Ok(rel) = dest.strip_prefix(&session_root) {
+            ctx.lock.insert(
+                rel.to_string_lossy().replace('\\', "/"),
+                LockEntry {
+                    version: vdoc.version.clone(),
+                    resolved: vdoc.dist.tarball.clone(),
+                    integrity: integrity.to_string(),
+                },
+            );
+        }
 
         // Bound the copy by the session's disk quota before writing.
         if let Some(max_disk) = limits.max_disk_bytes {
@@ -253,10 +330,6 @@ impl Vendor {
             let Ok(ver) = SemVer::parse(ver_str) else {
                 continue;
             };
-            // Prereleases only match an exact range naming that prerelease.
-            if ver.pre.is_some() && !matches!(range, Range::Exact(e) if e == &ver) {
-                continue;
-            }
             if range.matches(&ver) && best.as_ref().is_none_or(|(b, _)| ver > *b) {
                 best = Some((ver, vdoc));
             }
@@ -274,27 +347,21 @@ impl Vendor {
     fn ensure_cached(
         &self,
         name: &str,
-        vdoc: &VersionDoc,
+        version: &str,
+        tarball_url: &str,
+        integrity: &str,
     ) -> std::result::Result<PathBuf, ApiError> {
-        let pkg_cache = self.cache_dir.join(name).join(&vdoc.version);
+        let pkg_cache = self.cache_dir.join(name).join(version);
         if pkg_cache.join("package.json").exists() {
             return Ok(pkg_cache);
         }
 
-        let integrity = vdoc.dist.integrity.as_deref().ok_or_else(|| {
-            ApiError::BadRequest(format!(
-                "Package '{name}@{}' has no sha512 integrity in the registry; refusing to vendor unverifiable tarballs",
-                vdoc.version
-            ))
-        })?;
-
-        let tarball = http_get_bytes(&vdoc.dist.tarball, MAX_TARBALL_BYTES).map_err(|e| {
-            ApiError::Internal(format!("Failed to download '{name}@{}': {e}", vdoc.version))
+        let tarball = http_get_bytes(tarball_url, MAX_TARBALL_BYTES).map_err(|e| {
+            ApiError::Internal(format!("Failed to download '{name}@{version}': {e}"))
         })?;
         verify_integrity(&tarball, integrity).map_err(|e| {
             ApiError::BadRequest(format!(
-                "Integrity check failed for '{name}@{}': {e}",
-                vdoc.version
+                "Integrity check failed for '{name}@{version}': {e}"
             ))
         })?;
 
@@ -303,12 +370,12 @@ impl Vendor {
         let tmp =
             self.cache_dir
                 .join(name)
-                .join(format!(".tmp-{}-{}", vdoc.version, std::process::id()));
+                .join(format!(".tmp-{}-{}", version, std::process::id()));
         let _ = std::fs::remove_dir_all(&tmp);
         extract_tarball(&tarball, &tmp).inspect_err(|_| {
             let _ = std::fs::remove_dir_all(&tmp);
         })?;
-        reject_native_artifacts(name, &vdoc.version, &tmp).inspect_err(|_| {
+        reject_native_artifacts(name, version, &tmp).inspect_err(|_| {
             let _ = std::fs::remove_dir_all(&tmp);
         })?;
 
@@ -339,6 +406,53 @@ fn installed_version(pkg_dir: &Path) -> Option<String> {
 }
 
 /// npm package-name rules (subset): lowercase URL-safe, optionally scoped.
+/// Validate a lockfile install path and return the package name it installs.
+///
+/// Caller-supplied paths decide where files land, so anything but a
+/// well-formed `node_modules/<name>` chain is refused rather than normalized.
+fn validate_lock_path(path: &str) -> std::result::Result<&str, ApiError> {
+    let bad = |why: &str| {
+        Err(ApiError::BadRequest(format!(
+            "Invalid lockfile path '{path}': {why}"
+        )))
+    };
+    if path.contains('\\') || path.starts_with('/') {
+        return bad("must be a relative path with / separators");
+    }
+
+    // Repeated "node_modules/<name>" pairs; <name> is two segments if scoped.
+    let mut segments = path.split('/').peekable();
+    let mut name = None;
+    let mut depth = 0usize;
+    while segments.peek().is_some() {
+        if segments.next() != Some("node_modules") {
+            return bad("every package must sit directly inside a node_modules directory");
+        }
+        depth += 1;
+        if depth > MAX_DEPTH {
+            return bad("nesting too deep");
+        }
+        let Some(first) = segments.next() else {
+            return bad("trailing node_modules with no package");
+        };
+        let pkg = if first.starts_with('@') {
+            let Some(second) = segments.next() else {
+                return bad("scoped name must be @scope/name");
+            };
+            format!("{first}/{second}")
+        } else {
+            first.to_string()
+        };
+        validate_package_name(&pkg)?;
+        name = Some(pkg);
+    }
+
+    let Some(name) = name else {
+        return bad("empty path");
+    };
+    Ok(&path[path.len() - name.len()..])
+}
+
 fn validate_package_name(name: &str) -> std::result::Result<(), ApiError> {
     let bad = |why: &str| {
         Err(ApiError::BadRequest(format!(
@@ -617,92 +731,127 @@ impl Ord for SemVer {
                 // A prerelease sorts below its release.
                 (Some(_), None) => std::cmp::Ordering::Less,
                 (None, Some(_)) => std::cmp::Ordering::Greater,
-                (Some(a), Some(b)) => a.cmp(b),
+                (Some(a), Some(b)) => cmp_prerelease(a, b),
             })
     }
 }
 
-/// The npm range subset wasmrun supports. Composite ranges (`||`,
-/// hyphen-ranges, multi-comparator) are rejected with a clear error.
+/// Semver prerelease ordering: numeric identifiers compare numerically and
+/// sort below alphanumeric ones. String comparison gets `alpha.10` vs
+/// `alpha.2` backwards.
+fn cmp_prerelease(a: &str, b: &str) -> std::cmp::Ordering {
+    use std::cmp::Ordering;
+    let mut ai = a.split('.');
+    let mut bi = b.split('.');
+    loop {
+        match (ai.next(), bi.next()) {
+            (None, None) => return Ordering::Equal,
+            (None, Some(_)) => return Ordering::Less,
+            (Some(_), None) => return Ordering::Greater,
+            (Some(x), Some(y)) => {
+                let ord = match (x.parse::<u64>(), y.parse::<u64>()) {
+                    (Ok(nx), Ok(ny)) => nx.cmp(&ny),
+                    (Ok(_), Err(_)) => Ordering::Less,
+                    (Err(_), Ok(_)) => Ordering::Greater,
+                    (Err(_), Err(_)) => x.cmp(y),
+                };
+                if ord != Ordering::Equal {
+                    return ord;
+                }
+            }
+        }
+    }
+}
+
+impl SemVer {
+    fn core(&self) -> (u64, u64, u64) {
+        (self.major, self.minor, self.patch)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Op {
+    Lt,
+    Lte,
+    Gt,
+    Gte,
+    Eq,
+}
+
+/// An operator plus a version bound. Every range form desugars into one or
+/// two of these, which is what removes the special case per shape.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Comparator {
+    op: Op,
+    ver: SemVer,
+}
+
+impl Comparator {
+    fn matches(&self, v: &SemVer) -> bool {
+        let ord = v.cmp(&self.ver);
+        match self.op {
+            Op::Lt => ord.is_lt(),
+            Op::Lte => ord.is_le(),
+            Op::Gt => ord.is_gt(),
+            Op::Gte => ord.is_ge(),
+            Op::Eq => ord.is_eq(),
+        }
+    }
+}
+
+/// How many components a written version specified: what distinguishes `1.2`
+/// from `1.2.0`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Precision {
+    Major,
+    Minor,
+    Patch,
+}
+
+/// An npm version range: a union of comparator sets. Alternatives separated
+/// by `||` are OR'd, comparators within one are AND'd, and every written shape
+/// (`^1.2.3`, `1.x`, `1.2.0 - 1.4.0`, `>=1.2.0 <2.0.0`) desugars into it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Range {
+    /// `*`, `x`, or empty: any release, never a prerelease.
     Any,
-    Exact(SemVer),
-    Caret(SemVer),
-    Tilde(SemVer),
-    Gte(SemVer),
+    /// Resolved through the registry's dist-tags rather than by matching.
     Tag(String),
+    Set {
+        /// The range as written, kept verbatim for error messages.
+        raw: String,
+        alts: Vec<Vec<Comparator>>,
+    },
 }
 
 impl Range {
     pub fn parse(s: &str) -> std::result::Result<Self, String> {
-        let s = s.trim();
-        if s.is_empty() || s == "*" || s == "x" || s == "X" {
+        let raw = s.trim();
+        if raw.is_empty() || raw == "*" || raw == "x" || raw == "X" {
             return Ok(Range::Any);
         }
-        if s.contains("||") || s.contains(" - ") || s.contains(' ') {
-            return Err(
-                "composite ranges are not supported (use a single ^, ~, >=, exact, or x-range)"
-                    .into(),
-            );
+        if is_dist_tag(raw) {
+            return Ok(Range::Tag(raw.to_string()));
         }
-        if let Some(rest) = s.strip_prefix('^') {
-            return Ok(Range::Caret(parse_partial(rest)?));
+        let mut alts = Vec::new();
+        for part in raw.split("||") {
+            alts.push(parse_comparator_set(part)?);
         }
-        if let Some(rest) = s.strip_prefix('~') {
-            return Ok(Range::Tilde(parse_partial(rest)?));
+        // `* || ^1` and friends collapse to "anything".
+        if alts.iter().any(|a| a.is_empty()) {
+            return Ok(Range::Any);
         }
-        if let Some(rest) = s.strip_prefix(">=") {
-            return Ok(Range::Gte(parse_partial(rest)?));
-        }
-        if s.starts_with('>') || s.starts_with('<') || s.starts_with('=') {
-            return Err(
-                "only ^, ~, >=, exact versions, x-ranges, *, and dist-tags are supported".into(),
-            );
-        }
-        // Exact version, x-range ("1", "1.2", "1.2.x"), or dist-tag.
-        let numericish = s
-            .trim_start_matches('v')
-            .chars()
-            .next()
-            .is_some_and(|c| c.is_ascii_digit());
-        if !numericish {
-            return Ok(Range::Tag(s.to_string()));
-        }
-        let parts: Vec<&str> = s.trim_start_matches('v').split('.').collect();
-        let is_x = |p: &&str| ["x", "X", "*"].contains(p);
-        match parts.len() {
-            1 => Ok(Range::Caret(parse_partial(parts[0])?)), // "1" == ^1.0.0
-            2 if is_x(&parts[1]) => Ok(Range::Caret(parse_partial(parts[0])?)),
-            2 => Ok(Range::Tilde(parse_partial(s)?)), // "1.2" == ~1.2.0
-            3 if is_x(&parts[2]) => {
-                Ok(Range::Tilde(parse_partial(&parts[..2].join("."))?)) // "1.2.x" == ~1.2.0
-            }
-            3 if is_x(&parts[1]) => Ok(Range::Caret(parse_partial(parts[0])?)), // "1.x.x"
-            _ => Ok(Range::Exact(SemVer::parse(s)?)),
-        }
+        Ok(Range::Set {
+            raw: raw.to_string(),
+            alts,
+        })
     }
 
     pub fn matches(&self, v: &SemVer) -> bool {
         match self {
-            Range::Any => true,
+            Range::Any => v.pre.is_none(),
             Range::Tag(_) => false, // resolved via dist-tags, not matching
-            Range::Exact(e) => v == e,
-            Range::Gte(min) => v >= min,
-            Range::Caret(base) => {
-                if v < base {
-                    return false;
-                }
-                // ^ allows changes that don't modify the leftmost non-zero part.
-                if base.major > 0 {
-                    v.major == base.major
-                } else if base.minor > 0 {
-                    v.major == 0 && v.minor == base.minor
-                } else {
-                    v.major == 0 && v.minor == 0 && v.patch == base.patch
-                }
-            }
-            Range::Tilde(base) => v >= base && v.major == base.major && v.minor == base.minor,
+            Range::Set { alts, .. } => alts.iter().any(|alt| set_matches(alt, v)),
         }
     }
 
@@ -722,49 +871,289 @@ impl Range {
         match self {
             Range::Any => "*".into(),
             Range::Tag(t) => t.clone(),
-            Range::Exact(v) => format!("{}.{}.{}", v.major, v.minor, v.patch),
-            Range::Caret(v) => format!("^{}.{}.{}", v.major, v.minor, v.patch),
-            Range::Tilde(v) => format!("~{}.{}.{}", v.major, v.minor, v.patch),
-            Range::Gte(v) => format!(">={}.{}.{}", v.major, v.minor, v.patch),
+            Range::Set { raw, .. } => raw.clone(),
         }
     }
 }
 
-/// Parse a possibly partial version ("1", "1.2", "1.2.3") to a SemVer with
-/// missing components zeroed.
-fn parse_partial(s: &str) -> std::result::Result<SemVer, String> {
+/// A version satisfies an alternative when every comparator in it matches.
+///
+/// Prereleases carry the extra npm rule: `1.2.3-beta` may only satisfy a set
+/// that explicitly names a prerelease of `1.2.3`. Without it, `<2.0.0` would
+/// quietly pull in `2.0.0-rc.1`, which sorts below `2.0.0`.
+fn set_matches(alt: &[Comparator], v: &SemVer) -> bool {
+    if !alt.iter().all(|c| c.matches(v)) {
+        return false;
+    }
+    if v.pre.is_some() {
+        return alt
+            .iter()
+            .any(|c| c.ver.pre.is_some() && c.ver.core() == v.core());
+    }
+    true
+}
+
+/// A bare identifier that is not a version or an operator is a dist-tag.
+fn is_dist_tag(s: &str) -> bool {
+    if s.contains("||") || s.chars().any(char::is_whitespace) {
+        return false;
+    }
+    match s.chars().next() {
+        None => false,
+        Some('^' | '~' | '>' | '<' | '=') => false,
+        Some(_) => !s
+            .trim_start_matches('v')
+            .starts_with(|c: char| c.is_ascii_digit()),
+    }
+}
+
+/// Parse one `||` alternative into an AND-ed list of comparators. An empty
+/// result means "anything".
+fn parse_comparator_set(part: &str) -> std::result::Result<Vec<Comparator>, String> {
+    let part = part.trim();
+    if part.is_empty() || part == "*" || part == "x" || part == "X" {
+        return Ok(Vec::new());
+    }
+
+    // Hyphen range: "1.2.0 - 1.4.0". Checked before tokenizing because the
+    // separator is itself whitespace-delimited.
+    if let Some((lo, hi)) = split_hyphen(part) {
+        let (lo_ver, lo_prec) = parse_partial_spec(lo)?;
+        let (hi_ver, hi_prec) = parse_partial_spec(hi)?;
+        let mut out = vec![Comparator {
+            op: Op::Gte,
+            ver: zeroed(&lo_ver, lo_prec),
+        }];
+        out.push(match hi_prec {
+            Precision::Patch => Comparator {
+                op: Op::Lte,
+                ver: hi_ver,
+            },
+            _ => Comparator {
+                op: Op::Lt,
+                ver: upper_bound(&hi_ver, hi_prec),
+            },
+        });
+        return Ok(out);
+    }
+
+    let mut out = Vec::new();
+    for token in normalize_spacing(part).split_whitespace() {
+        out.extend(parse_comparator(token)?);
+    }
+    if out.is_empty() {
+        return Err(format!("could not parse range '{part}'"));
+    }
+    Ok(out)
+}
+
+/// `>= 1.2.0` is legal npm; drop the spaces so the set splits on whitespace.
+fn normalize_spacing(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        out.push(c);
+        if matches!(c, '>' | '<' | '=' | '^' | '~') {
+            while chars.peek().is_some_and(|c| c.is_whitespace()) {
+                chars.next();
+            }
+        }
+    }
+    out
+}
+
+/// Split a hyphen range, ignoring hyphens inside prerelease identifiers.
+fn split_hyphen(part: &str) -> Option<(&str, &str)> {
+    let idx = part.find(" - ")?;
+    Some((&part[..idx], &part[idx + 3..]))
+}
+
+fn parse_comparator(token: &str) -> std::result::Result<Vec<Comparator>, String> {
+    if token == "*" || token == "x" || token == "X" {
+        return Ok(Vec::new());
+    }
+    if let Some(rest) = token.strip_prefix('^') {
+        let (ver, prec) = parse_partial_spec(rest)?;
+        return Ok(vec![
+            Comparator {
+                op: Op::Gte,
+                ver: zeroed(&ver, prec),
+            },
+            Comparator {
+                op: Op::Lt,
+                ver: caret_upper(&ver, prec),
+            },
+        ]);
+    }
+    if let Some(rest) = token.strip_prefix('~') {
+        let (ver, prec) = parse_partial_spec(rest)?;
+        let upper = match prec {
+            Precision::Major => SemVer::exact(ver.major + 1, 0, 0),
+            _ => SemVer::exact(ver.major, ver.minor + 1, 0),
+        };
+        return Ok(vec![
+            Comparator {
+                op: Op::Gte,
+                ver: zeroed(&ver, prec),
+            },
+            Comparator {
+                op: Op::Lt,
+                ver: upper,
+            },
+        ]);
+    }
+
+    let (op, rest) = if let Some(r) = token.strip_prefix(">=") {
+        (Some(Op::Gte), r)
+    } else if let Some(r) = token.strip_prefix("<=") {
+        (Some(Op::Lte), r)
+    } else if let Some(r) = token.strip_prefix('>') {
+        (Some(Op::Gt), r)
+    } else if let Some(r) = token.strip_prefix('<') {
+        (Some(Op::Lt), r)
+    } else if let Some(r) = token.strip_prefix('=') {
+        (Some(Op::Eq), r)
+    } else {
+        (None, token)
+    };
+
+    let (ver, prec) = parse_partial_spec(rest)?;
+
+    let Some(op) = op else {
+        // No operator: exact if fully specified, x-range otherwise.
+        return Ok(match prec {
+            Precision::Patch => vec![Comparator { op: Op::Eq, ver }],
+            _ => vec![
+                Comparator {
+                    op: Op::Gte,
+                    ver: zeroed(&ver, prec),
+                },
+                Comparator {
+                    op: Op::Lt,
+                    ver: upper_bound(&ver, prec),
+                },
+            ],
+        });
+    };
+
+    // A partial version widens the bound: ">1.2" excludes all of 1.2.x.
+    Ok(match (op, prec) {
+        (Op::Eq, Precision::Patch) => vec![Comparator { op: Op::Eq, ver }],
+        (Op::Eq, _) => vec![
+            Comparator {
+                op: Op::Gte,
+                ver: zeroed(&ver, prec),
+            },
+            Comparator {
+                op: Op::Lt,
+                ver: upper_bound(&ver, prec),
+            },
+        ],
+        (Op::Gt, Precision::Patch) => vec![Comparator { op: Op::Gt, ver }],
+        (Op::Gt, _) => vec![Comparator {
+            op: Op::Gte,
+            ver: upper_bound(&ver, prec),
+        }],
+        (Op::Lte, Precision::Patch) => vec![Comparator { op: Op::Lte, ver }],
+        (Op::Lte, _) => vec![Comparator {
+            op: Op::Lt,
+            ver: upper_bound(&ver, prec),
+        }],
+        (op, _) => vec![Comparator {
+            op,
+            ver: zeroed(&ver, prec),
+        }],
+    })
+}
+
+/// Exclusive upper bound of a caret range. `^0` and `^0.0` widen: an
+/// unwritten component is not a zero the caret has to respect.
+fn caret_upper(v: &SemVer, prec: Precision) -> SemVer {
+    if v.major > 0 || prec == Precision::Major {
+        return SemVer::exact(v.major + 1, 0, 0);
+    }
+    if v.minor > 0 || prec == Precision::Minor {
+        return SemVer::exact(0, v.minor + 1, 0);
+    }
+    SemVer::exact(0, 0, v.patch + 1)
+}
+
+/// The exclusive upper bound of an x-range at the given precision.
+fn upper_bound(v: &SemVer, prec: Precision) -> SemVer {
+    match prec {
+        Precision::Major => SemVer::exact(v.major + 1, 0, 0),
+        Precision::Minor => SemVer::exact(v.major, v.minor + 1, 0),
+        Precision::Patch => SemVer::exact(v.major, v.minor, v.patch),
+    }
+}
+
+/// Drop a prerelease from an unwritten component, so `>=1.2` is `>=1.2.0`.
+fn zeroed(v: &SemVer, prec: Precision) -> SemVer {
+    match prec {
+        Precision::Patch => v.clone(),
+        _ => SemVer::exact(v.major, v.minor, v.patch),
+    }
+}
+
+impl SemVer {
+    fn exact(major: u64, minor: u64, patch: u64) -> Self {
+        Self {
+            major,
+            minor,
+            patch,
+            pre: None,
+        }
+    }
+}
+
+/// Parse a possibly partial version into a SemVer with missing components
+/// zeroed, plus how much of it was written.
+fn parse_partial_spec(s: &str) -> std::result::Result<(SemVer, Precision), String> {
     let s = s.trim().trim_start_matches('v');
     if s.is_empty() {
         return Err("empty version".into());
     }
-    let mut parts = s.split('.');
-    let num = |p: Option<&str>| -> std::result::Result<u64, String> {
-        match p {
-            None => Ok(0),
-            Some(x) if ["x", "X", "*"].contains(&x) => Ok(0),
-            Some(x) => x.parse().map_err(|_| format!("invalid component '{x}'")),
-        }
+    let is_x = |p: &str| ["x", "X", "*"].contains(&p);
+    // Split the prerelease off first: it contains dots of its own.
+    let (core, pre) = match s.split_once('-') {
+        Some((c, p)) => (c, Some(p.split('+').next().unwrap_or(p).to_string())),
+        None => (s.split('+').next().unwrap_or(s), None),
     };
-    // Tolerate a prerelease suffix on the last component (e.g. ^1.2.3-beta.1).
+    let mut parts = core.split('.');
     let first = parts.next();
     let second = parts.next();
-    let third_raw = parts.next();
+    let third = parts.next();
     if parts.next().is_some() {
         return Err("too many version components".into());
     }
-    let (third, pre) = match third_raw {
-        Some(t) => match t.split_once('-') {
-            Some((n, p)) => (Some(n), Some(p.to_string())),
-            None => (Some(t), None),
-        },
-        None => (None, None),
+    let num = |p: Option<&str>| -> std::result::Result<u64, String> {
+        match p {
+            None => Ok(0),
+            Some(x) if is_x(x) => Ok(0),
+            Some(x) => x.parse().map_err(|_| format!("invalid component '{x}'")),
+        }
     };
-    Ok(SemVer {
-        major: num(first)?,
-        minor: num(second)?,
-        patch: num(third)?,
-        pre,
-    })
+    let precision = match (first, second, third) {
+        (Some(f), _, _) if is_x(f) => Precision::Major,
+        (_, Some(s), _) if is_x(s) => Precision::Major,
+        (_, None, _) => Precision::Major,
+        (_, _, Some(t)) if is_x(t) => Precision::Minor,
+        (_, _, None) => Precision::Minor,
+        _ => Precision::Patch,
+    };
+    Ok((
+        SemVer {
+            major: num(first)?,
+            minor: num(second)?,
+            patch: num(third)?,
+            pre: if precision == Precision::Patch {
+                pre
+            } else {
+                None
+            },
+        },
+        precision,
+    ))
 }
 
 #[cfg(test)]
@@ -822,41 +1211,107 @@ mod tests {
         assert!(Range::parse("").unwrap().matches(&v("9.9.9")));
     }
 
+    fn accepts(range: &str, version: &str) -> bool {
+        Range::parse(range)
+            .unwrap_or_else(|e| panic!("parse '{range}': {e}"))
+            .matches(&v(version))
+    }
+
     #[test]
     fn test_range_x_ranges_and_tags() {
-        assert_eq!(Range::parse("1").unwrap(), Range::parse("^1.0.0").unwrap());
-        assert_eq!(
-            Range::parse("1.2").unwrap(),
-            Range::parse("~1.2.0").unwrap()
-        );
-        assert_eq!(
-            Range::parse("1.2.x").unwrap(),
-            Range::parse("~1.2.0").unwrap()
-        );
-        assert_eq!(
-            Range::parse("1.x").unwrap(),
-            Range::parse("^1.0.0").unwrap()
-        );
+        // "1" and "1.x" mean ^1.0.0; "1.2" and "1.2.x" mean ~1.2.0.
+        for r in ["1", "1.x", "1.X", "1.x.x", "^1.0.0"] {
+            assert!(accepts(r, "1.9.9"), "{r} should accept 1.9.9");
+            assert!(!accepts(r, "2.0.0"), "{r} should reject 2.0.0");
+            assert!(!accepts(r, "0.9.9"), "{r} should reject 0.9.9");
+        }
+        for r in ["1.2", "1.2.x", "~1.2.0"] {
+            assert!(accepts(r, "1.2.9"), "{r} should accept 1.2.9");
+            assert!(!accepts(r, "1.3.0"), "{r} should reject 1.3.0");
+        }
         assert!(matches!(Range::parse("latest").unwrap(), Range::Tag(t) if t == "latest"));
         assert!(matches!(Range::parse("beta").unwrap(), Range::Tag(t) if t == "beta"));
     }
 
     #[test]
-    fn test_range_rejects_composites() {
-        assert!(Range::parse(">=1.0.0 <2.0.0").is_err());
-        assert!(Range::parse("1.0.0 || 2.0.0").is_err());
-        assert!(Range::parse("1.0.0 - 2.0.0").is_err());
-        assert!(Range::parse("<2.0.0").is_err());
+    fn test_range_comparator_sets() {
+        assert!(accepts(">=1.2.0 <2.0.0", "1.9.0"));
+        assert!(!accepts(">=1.2.0 <2.0.0", "2.0.0"));
+        assert!(!accepts(">=1.2.0 <2.0.0", "1.1.9"));
+        // Whitespace after an operator is legal npm.
+        assert!(accepts(">= 1.2.0 < 2.0.0", "1.9.0"));
+
+        assert!(accepts("<2.0.0", "1.0.0"));
+        assert!(!accepts("<2.0.0", "2.0.0"));
+        assert!(accepts("<=2.0.0", "2.0.0"));
+        assert!(accepts(">1.2.3", "1.2.4"));
+        assert!(!accepts(">1.2.3", "1.2.3"));
+        assert!(accepts("=1.2.3", "1.2.3"));
+
+        // A partial version widens the bound: ">1.2" excludes all of 1.2.x.
+        assert!(!accepts(">1.2", "1.2.9"));
+        assert!(accepts(">1.2", "1.3.0"));
+        assert!(accepts("<=1.2", "1.2.9"));
+        assert!(!accepts("<=1.2", "1.3.0"));
     }
 
     #[test]
-    fn test_prerelease_only_matches_exact() {
-        let r = Range::parse("^1.0.0").unwrap();
-        // matches() itself is pure math; prerelease filtering happens in
-        // resolve(), which skips prereleases for non-exact ranges.
-        assert!(r.matches(&v("1.5.0")));
-        let exact = Range::parse("2.0.0-beta.1").unwrap();
-        assert!(exact.matches(&v("2.0.0-beta.1")));
+    fn test_range_unions() {
+        assert!(accepts("^1 || ^2", "1.5.0"));
+        assert!(accepts("^1 || ^2", "2.5.0"));
+        assert!(!accepts("^1 || ^2", "3.0.0"));
+        assert!(accepts("1.0.0 || >=3.0.0 <4.0.0", "1.0.0"));
+        assert!(accepts("1.0.0 || >=3.0.0 <4.0.0", "3.2.1"));
+        assert!(!accepts("1.0.0 || >=3.0.0 <4.0.0", "2.0.0"));
+        // An alternative that accepts anything collapses the whole range.
+        assert_eq!(Range::parse("^1 || *").unwrap(), Range::Any);
+    }
+
+    #[test]
+    fn test_range_hyphen() {
+        assert!(accepts("1.2.0 - 1.4.0", "1.3.0"));
+        assert!(
+            accepts("1.2.0 - 1.4.0", "1.4.0"),
+            "upper bound is inclusive"
+        );
+        assert!(!accepts("1.2.0 - 1.4.0", "1.4.1"));
+        assert!(!accepts("1.2.0 - 1.4.0", "1.1.9"));
+        // A partial upper bound covers the whole minor.
+        assert!(accepts("1.2 - 2.3", "2.3.9"));
+        assert!(!accepts("1.2 - 2.3", "2.4.0"));
+    }
+
+    #[test]
+    fn test_caret_partial_widening() {
+        // An unwritten component is not a zero the caret has to respect.
+        assert!(accepts("^0", "0.9.9"));
+        assert!(!accepts("^0", "1.0.0"));
+        assert!(accepts("^0.0", "0.0.9"));
+        assert!(!accepts("^0.0", "0.1.0"));
+        assert!(accepts("^0.2", "0.2.9"));
+        assert!(!accepts("^0.2", "0.3.0"));
+        assert!(accepts("^0.0.3", "0.0.3"));
+        assert!(!accepts("^0.0.3", "0.0.4"));
+    }
+
+    #[test]
+    fn test_prerelease_rules() {
+        // A prerelease never satisfies a range that does not name one.
+        assert!(!accepts("^1.0.0", "2.0.0-beta.1"));
+        assert!(!accepts("<2.0.0", "2.0.0-rc.1"));
+        assert!(!accepts("*", "1.0.0-rc.1"));
+        assert!(accepts("^1.0.0", "1.5.0"));
+        assert!(accepts("2.0.0-beta.1", "2.0.0-beta.1"));
+        assert!(accepts(">=2.0.0-beta.1 <3.0.0", "2.0.0-beta.2"));
+        assert!(!accepts(">=2.0.0-beta.1 <3.0.0", "2.1.0-beta.1"));
+    }
+
+    #[test]
+    fn test_prerelease_ordering_is_numeric() {
+        assert!(v("1.0.0-alpha.2") < v("1.0.0-alpha.10"));
+        assert!(v("1.0.0-alpha.1") < v("1.0.0-alpha.beta"));
+        assert!(v("1.0.0-alpha") < v("1.0.0-alpha.1"));
+        assert!(v("1.0.0-rc.1") < v("1.0.0"));
     }
 
     #[test]
@@ -1079,6 +1534,89 @@ mod tests {
     }
 
     #[test]
+    fn test_vendor_returns_lockfile() {
+        let (_reg, _cache, vendor) = simple_registry();
+        let session = tempfile::tempdir().unwrap();
+
+        let deps = HashMap::from([("greet".to_string(), "^1.0.0".to_string())]);
+        let lock = vendor
+            .vendor(&deps, session.path(), &ResourceLimits::default())
+            .unwrap();
+
+        let entry = lock
+            .get("node_modules/greet")
+            .expect("lockfile records the install path");
+        assert_eq!(entry.version, "1.4.2");
+        assert!(entry.integrity.starts_with("sha512-"));
+        assert!(entry.resolved.ends_with("greet-1.4.2.tgz"));
+    }
+
+    #[test]
+    fn test_vendor_locked_replays_without_the_registry() {
+        let cache = tempfile::tempdir().unwrap();
+        let cache_dir = cache.path().join("npm");
+
+        // Resolve once to get a lockfile and warm the cache.
+        let lock = {
+            let (_reg, _c, _v) = simple_registry();
+            let url = _v.registry.clone();
+            let vendor = Vendor::with_cache_dir(&url, cache_dir.clone());
+            let first = tempfile::tempdir().unwrap();
+            let deps = HashMap::from([("greet".to_string(), "^1.0.0".to_string())]);
+            vendor
+                .vendor(&deps, first.path(), &ResourceLimits::default())
+                .unwrap()
+        };
+        // The registry is now down; replay must still work.
+        let offline = Vendor::with_cache_dir("http://127.0.0.1:1", cache_dir);
+        let session = tempfile::tempdir().unwrap();
+        offline
+            .vendor_locked(&lock, session.path(), &ResourceLimits::default())
+            .unwrap();
+
+        let installed = session.path().join("node_modules/greet");
+        assert_eq!(installed_version(&installed).as_deref(), Some("1.4.2"));
+        assert!(installed.join("index.js").exists());
+    }
+
+    #[test]
+    fn test_vendor_locked_rejects_unsafe_paths() {
+        let vendor = Vendor::with_cache_dir("http://127.0.0.1:1", PathBuf::from("/nonexistent"));
+        let session = tempfile::tempdir().unwrap();
+        let entry = LockEntry {
+            version: "1.0.0".into(),
+            resolved: "http://127.0.0.1:1/x.tgz".into(),
+            integrity: "sha512-x".into(),
+        };
+        for path in [
+            "../escape",
+            "/abs/path",
+            "node_modules/../../escape",
+            "not_node_modules/greet",
+            "node_modules",
+            "greet",
+        ] {
+            let lock = Lockfile::from([(path.to_string(), entry.clone())]);
+            let err = vendor
+                .vendor_locked(&lock, session.path(), &ResourceLimits::default())
+                .unwrap_err();
+            assert_eq!(err.status_code(), 400, "path '{path}' should be refused");
+        }
+
+        // Well-formed shapes get past validation and fail later, differently.
+        for path in ["node_modules/greet", "node_modules/a/node_modules/b"] {
+            let lock = Lockfile::from([(path.to_string(), entry.clone())]);
+            let err = vendor
+                .vendor_locked(&lock, session.path(), &ResourceLimits::default())
+                .unwrap_err();
+            assert!(
+                !err.to_string().contains("Invalid lockfile path"),
+                "path '{path}' should be accepted"
+            );
+        }
+    }
+
+    #[test]
     fn test_vendor_skips_already_satisfied() {
         let (_reg, _cache, vendor) = simple_registry();
         let session = tempfile::tempdir().unwrap();
@@ -1157,7 +1695,7 @@ mod tests {
         let vendor = Vendor::with_cache_dir(&url, cache.path().join("npm"));
         let session = tempfile::tempdir().unwrap();
         let deps = HashMap::from([("app".to_string(), "latest".to_string())]);
-        vendor
+        let lock = vendor
             .vendor(&deps, session.path(), &ResourceLimits::default())
             .unwrap();
 
@@ -1169,6 +1707,13 @@ mod tests {
             .path()
             .join("node_modules/app/node_modules/lib/package.json")
             .exists());
+
+        // The transitive package is locked at its nested path.
+        assert_eq!(
+            lock.keys().collect::<Vec<_>>(),
+            vec!["node_modules/app", "node_modules/app/node_modules/lib"]
+        );
+        assert_eq!(lock["node_modules/app/node_modules/lib"].version, "1.1.0");
     }
 
     #[test]


### PR DESCRIPTION
Version ranges now accept the complete npm grammar. `Range` was a fixed set of shapes (exact/caret/tilde/gte/x-range/tag) and rejected anything else, so a single `>=1.2.0 <2.0.0` or `^1 || ^2` anywhere in a transitive tree failed the whole install even when every package involved was pure JS. It is now a union of comparator sets, which every written form desugars into, covering unions, comparator sets, hyphen ranges and the `<`/`<=`/`>`/`=` operators. Partial versions widen bounds per spec (`>1.2` excludes all of 1.2.x), the prerelease rule moved from the resolver into matching, and prerelease identifiers compare numerically so `alpha.2` sorts below `alpha.10`.

Executions that install anything now return a `lockfile` of the resolved tree, accepted back on a later request to pin exactly. Replay walks the lockfile rather than the dependency graph, so nothing is re-resolved and a warm cache installs offline; tarballs are still integrity-verified and scanned for native artifacts. Caller-supplied paths are validated as strict `node_modules/<name>` chains. New `install_package_json` reads the project's package.json, opt-in so an uploaded one never triggers an unrequested fetch.

`GET /api/v1/sessions` lists sessions newest first, tenant-scoped under `--auth`, and replaces a dead `list_sessions` that carried a TODO naming this endpoint. Exposed to agents as a new `list_sessions` tool.

A project may now ship a `tsconfig.json`, parsed as JSONC. Its `paths` aliases are materialized as shims under `node_modules` so the runtime's own resolver handles them with no specifier rewriting. Options the transpiler cannot apply (`experimentalDecorators`, `emitDecoratorMetadata`, non-classic `jsx`) are refused by name rather than silently dropped; `target` is documented as a no-op since there is no down-level pass.

`stream: true` returns Server-Sent Events while code runs, so long runs are no longer silent until they finish. `handle_exec` splits into `start_exec` and `collect_exec` so the buffered and streaming paths share every decision about what runs.