### PR TITLE
feat(agent): ES module packages, stdin, and wasmhub v0.4.0 built-ins

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,9 +17,9 @@
 
 ---
 
-## ⚠️ The Three Modes: Read This First
+## ⚠️ The Four Modes: Read This First
 
-Wasmrun has **three distinct execution modes**. They are separate systems with separate philosophies. **Do not conflate them.** When working on one mode, do not break another mode's functionality.
+Wasmrun has **four distinct execution modes**. They are separate systems with separate philosophies. **Do not conflate them.** When working on one mode, do not break another mode's functionality.
 
 ### 1. Server Mode (`wasmrun` / `wasmrun run`)
 
@@ -88,20 +88,42 @@ Wasmrun has **three distinct execution modes**. They are separate systems with s
 - **Uses browser:** Yes. Full Preact UI with console, filesystem, kernel panels
 - **Docs:** `docs/docs/os/`
 
+### 4. Agent Mode (`wasmrun agent`)
+
+**Philosophy:** A REST API that gives AI agents isolated sandboxes to execute code in. Exec mode's interpreter, wrapped in a long-lived HTTP server with sessions, resource limits, and multi-tenancy. No Docker, no daemon, no browser.
+
+- **Trigger:** `wasmrun agent --port 8430`
+- **What it does:** Starts an HTTP server → creates per-session sandboxes (isolated work dir + WASI env) → accepts code (shell command, JS/TS source, multi-file project, or `.wasm`) over REST → runs it on the exec interpreter → returns structured JSON (stdout, stderr, exit code, duration)
+- **Key files:**
+  - `src/commands/agent.rs`: command handler
+  - `src/agent/server.rs`: HTTP server, routing, exec orchestration
+  - `src/agent/session.rs`: session lifecycle, isolation, expiry
+  - `src/agent/executor.rs`: source → runtime execution pipeline (JS, TS via swc)
+  - `src/agent/esm.rs`: ESM → CommonJS lowering for vendored packages
+  - `src/agent/vendor.rs`: npm dependency resolution and vendoring
+  - `src/agent/shell.rs`: shell emulation over the session filesystem
+  - `src/agent/auth.rs`, `limits.rs`, `metrics.rs`, `tools.rs`, `api.rs`
+- **Executes with:** the exec-mode interpreter (`runtime/core/` + `runtime/wasi/`). A `.wasm` behaves identically under `wasmrun exec` and `POST /exec`
+- **Uses plugins:** No
+- **Uses browser:** No
+- **Docs:** `docs/docs/agent/`
+
 ### Mode Boundaries: Critical Rules
 
-1. **Never mix mode-specific logic.** Exec mode must never start an HTTP server. Server mode must never invoke the bytecode interpreter. OS mode has its own kernel; don't route it through the server mode pipeline.
+1. **Never mix mode-specific logic.** The exec *interpreter core* (`runtime/core/`) must never start an HTTP server or know that one exists; agent mode owns that surface and calls into the interpreter from outside. Server mode must never invoke the bytecode interpreter. OS mode has its own kernel; don't route it through the server mode pipeline.
 
-2. **Shared code is encouraged, but not at the cost of mode integrity.** If a utility function is useful across modes (e.g., path resolution, error types, WASM binary analysis), keep it in shared modules (`src/utils/`, `src/error.rs`, `src/config/`). But don't bend a mode's design just to share code.
+2. **Agent mode is built on exec mode's engine, not a copy of it.** Execution, WASI syscalls, and interpreter behaviour belong in `runtime/core/` and `runtime/wasi/`, where both modes get them. Agent mode owns only what exec mode has no concept of: sessions, transport, auth, quotas, metrics. Never reimplement interpreter or syscall logic inside `src/agent/`.
 
-3. **When in doubt, ask the user.** If a change could affect multiple modes and the intent is unclear, stop and ask.
+3. **Shared code is encouraged, but not at the cost of mode integrity.** If a utility function is useful across modes (e.g., path resolution, error types, WASM binary analysis), keep it in shared modules (`src/utils/`, `src/error.rs`, `src/config/`). But don't bend a mode's design just to share code.
 
-4. **Mode-specific modules should be commented.** If a file/module belongs to a specific mode, include a comment at the top:
+4. **When in doubt, ask the user.** If a change could affect multiple modes and the intent is unclear, stop and ask.
+
+5. **Mode-specific modules should be commented.** If a file/module belongs to a specific mode, include a comment at the top:
    ```rust
    //! OS mode: Multi-language kernel for browser-based WASM execution
    ```
 
-5. **The plugin system belongs to Server Mode.** Plugins provide compilation support (Rust → WASM, Go → WASM, etc.). Exec mode does not compile; it runs pre-built `.wasm` files. OS mode uses wasmhub runtimes, not compilation plugins.
+6. **The plugin system belongs to Server Mode.** Plugins provide compilation support (Rust → WASM, Go → WASM, etc.). Exec mode does not compile; it runs pre-built `.wasm` files. OS mode uses wasmhub runtimes, not compilation plugins.
 
 ### Shared Components (used by multiple modes)
 
@@ -110,23 +132,24 @@ Wasmrun has **three distinct execution modes**. They are separate systems with s
 | `src/error.rs` | All | Unified error types |
 | `src/utils/` | All | Path resolution, WASM analysis, system utils |
 | `src/config/constants.rs` | Server, OS | Port defaults, paths |
-| `src/runtime/core/module.rs` | Exec, Verify/Inspect | WASM binary parser |
-| `src/runtime/wasi/` | Exec | WASI syscall host functions for interpreter |
+| `src/runtime/core/` | Exec, Agent | WASM interpreter engine (`module.rs` also used by Verify/Inspect) |
+| `src/runtime/wasi/` | Exec, Agent | WASI syscall host functions for interpreter |
+| `src/runtime/runtime_cache.rs` | OS, Agent | wasmhub language runtime fetching + caching |
 | `src/runtime/wasi_fs.rs` | OS, Dev Server | Virtual in-memory filesystem |
 | `src/commands/verify.rs` | Standalone (uses core module parser) | WASM verification |
 
 ### Mode Dependency Map
 
 ```
-Server Mode                     Exec Mode                OS Mode
-─────────────                   ─────────                ───────
-src/commands/run.rs             src/commands/exec.rs     src/commands/os.rs
-src/config/server.rs            src/runtime/core/*       src/runtime/os_server.rs
+Server Mode                     Exec Mode                OS Mode                          Agent Mode
+─────────────                   ─────────                ───────                          ──────────
+src/commands/run.rs             src/commands/exec.rs     src/commands/os.rs               src/commands/agent.rs
+src/config/server.rs            src/runtime/core/*       src/runtime/os_server.rs         src/agent/*
 src/server/*                    src/runtime/wasi/*       src/runtime/multilang_kernel.rs
-src/compiler/*                                           src/runtime/microkernel.rs
-src/plugin/*                                             src/runtime/dev_server.rs
-src/watcher.rs                                           src/runtime/scheduler.rs
-src/template.rs                                          src/runtime/network_namespace.rs
+src/compiler/*                                           src/runtime/microkernel.rs       ↓ executes via
+src/plugin/*                                             src/runtime/dev_server.rs        src/runtime/core/*
+src/watcher.rs                                           src/runtime/scheduler.rs         src/runtime/wasi/*
+src/template.rs                                          src/runtime/network_namespace.rs src/runtime/runtime_cache.rs
 ui/src/ (→ templates/app/)                               src/runtime/wasi_fs.rs
 ui/src/ (→ templates/console/)                           src/runtime/project_files.rs
                                                          src/runtime/runtime_cache.rs
@@ -197,10 +220,23 @@ src/
 ├── main.rs              # Entry point, command dispatch
 ├── cli.rs               # CLI argument parsing (clap)
 ├── error.rs             # Unified error types (WasmrunError)
+├── agent/                # [Agent Mode] ★ REST sandbox API for AI agents
+│   ├── server.rs        #   HTTP server, routing, exec orchestration
+│   ├── session.rs       #   Session lifecycle and isolation
+│   ├── executor.rs      #   Source → runtime execution pipeline (JS/TS)
+│   ├── esm.rs           #   ESM → CommonJS lowering for vendored packages
+│   ├── vendor.rs        #   npm resolution and vendoring
+│   ├── shell.rs         #   Shell emulation over the session filesystem
+│   ├── auth.rs          #   API keys and tenant isolation
+│   ├── limits.rs        #   Resource limits (memory, fuel, output, disk)
+│   ├── metrics.rs       #   Metrics endpoint and access log
+│   ├── tools.rs         #   LLM tool schemas
+│   └── api.rs           #   Request/response types
 ├── commands/             # Subcommand handlers
 │   ├── run.rs           #   [Server Mode] compile + serve
 │   ├── exec.rs          #   [Exec Mode] native WASM execution
 │   ├── os.rs            #   [OS Mode] browser-based kernel
+│   ├── agent.rs         #   [Agent Mode] REST sandbox server
 │   ├── compile.rs       #   [Server Mode] compile only
 │   ├── verify.rs        #   [Shared] WASM binary verification
 │   ├── stop.rs          #   [Server Mode] stop running server
@@ -213,7 +249,7 @@ src/
 ├── logging/              # [OS Mode] Structured log trail system
 ├── plugin/               # [Server Mode] Plugin system
 ├── runtime/
-│   ├── core/             # [Exec Mode] ★ WASM interpreter engine
+│   ├── core/             # [Exec, Agent] ★ WASM interpreter engine
 │   │   ├── module.rs     #   Binary parser (shared with verify/inspect)
 │   │   ├── executor.rs   #   Instruction executor (~4400 lines)
 │   │   ├── memory.rs     #   Linear memory
@@ -222,7 +258,7 @@ src/
 │   │   ├── native_executor.rs  # High-level exec API
 │   │   ├── control_flow.rs     # Control flow analysis
 │   │   └── tests.rs      #   Unit tests
-│   ├── wasi/             # [Exec Mode] WASI syscall implementations
+│   ├── wasi/             # [Exec, Agent] WASI syscall implementations
 │   │   ├── mod.rs        #   WasiEnv, linker setup
 │   │   └── syscalls.rs   #   fd_write, args_get, clock, etc.
 │   ├── os_server.rs      # [OS Mode] HTTP server + API endpoints
@@ -233,7 +269,7 @@ src/
 │   ├── network_namespace.rs # [OS Mode] Network isolation
 │   ├── wasi_fs.rs        # [OS Mode] Virtual in-memory filesystem
 │   ├── project_files.rs  # [OS Mode] Project file bundling
-│   ├── runtime_cache.rs  # [OS Mode] Wasmhub runtime caching
+│   ├── runtime_cache.rs  # [OS, Agent] Wasmhub runtime caching
 │   ├── languages/        # [OS Mode] Language runtime traits
 │   ├── tunnel/           # [OS Mode] Bore tunneling
 │   ├── registry.rs       # [OS Mode] Process/server registry
@@ -258,7 +294,7 @@ src/
 
 ## Documentation Structure
 
-The docs mirror the three-mode architecture:
+The docs mirror the four-mode architecture:
 
 ```
 docs/docs/
@@ -279,6 +315,9 @@ docs/docs/
 │   ├── port-forwarding.md
 │   ├── public-tunneling.md
 │   └── usage/            #   Running, language selection, server options
+├── agent/                # Agent Mode documentation
+│   ├── index.md          #   Overview, CLI flags, auth, tenancy
+│   └── usage/            #   Sessions, execution, files, environment, observability
 ├── plugins/              # Plugin system (Server Mode)
 ├── contributing/         # Development guides
 ├── installation.md
@@ -364,7 +403,8 @@ pnpm typecheck      # TypeScript check
 
 - **Unit tests** live alongside source code (standard Rust `#[cfg(test)]` modules).
 - **Integration tests** are in `tests/` (currently `tests/exec_integration_tests.rs`).
-- **Test count:** ~325+ tests across unit and integration suites.
+- **Test count:** ~750+ tests across unit and integration suites.
+- **Network-gated tests** are `#[ignore]`d so the suite stays offline-friendly; run them with `cargo test -- --ignored` (use `--test-threads=1` the first time, while `~/.wasmrun/runtimes` is cold).
 - Always run `cargo test` before committing.
 - The CI expects zero clippy warnings: `cargo clippy --all-targets --all-features -- -D warnings`.
 
@@ -443,6 +483,11 @@ wasmrun exec <file.wasm> --call <func> [args]  # Call specific exported function
 wasmrun os <path>                 # Run project in browser-based OS environment
 wasmrun os <path> --language python  # Force language detection
 wasmrun os <path> --watch --port 3000  # With file watching and custom port
+
+# Agent Mode
+wasmrun agent                     # Start the REST sandbox API (default port 8430)
+wasmrun agent --port 8430 --max-sessions 100  # With explicit port and session cap
+wasmrun agent --auth ./tenants.toml  # Enable API-key auth and tenant isolation
 ```
 
 ---
@@ -459,6 +504,9 @@ wasmrun os <path> --watch --port 3000  # With file watching and custom port
 | `src/commands/run.rs` | Server | Server mode entry point |
 | `src/commands/exec.rs` | Exec | Exec mode entry point |
 | `src/commands/os.rs` | OS | OS mode entry point |
+| `src/commands/agent.rs` | Agent | Agent mode entry point |
+| `src/agent/server.rs` | Agent | Agent HTTP server, routing, exec orchestration |
+| `src/agent/session.rs` | Agent | Session lifecycle and sandbox isolation |
 | `src/runtime/core/executor.rs` | Exec | The WASM interpreter (~4400 lines) |
 | `src/runtime/core/module.rs` | Exec/Shared | WASM binary parser |
 | `src/runtime/wasi/syscalls.rs` | Exec | WASI syscall implementations |
@@ -492,6 +540,7 @@ wasmrun os <path> --watch --port 3000  # With file watching and custom port
 4. Return proper WASI errno values
 5. Add unit tests
 6. Update docs in `docs/docs/exec/wasi.md`
+7. Agent mode shares this layer, so verify the syscall through `POST /exec` too
 
 ### Adding a new WASM instruction (Exec Mode)
 
@@ -499,6 +548,14 @@ wasmrun os <path> --watch --port 3000  # With file watching and custom port
 2. Add decoding logic in `decode_instruction()`
 3. Add execution logic in `dispatch_instruction()`
 4. Add unit test in `src/runtime/core/tests.rs` or inline `#[cfg(test)]`
+
+### Adding an Agent Mode API endpoint
+
+1. Add the route match in `AgentServer::handle_request()` in `src/agent/server.rs`
+2. Implement the handler as a method returning `Result<T, ApiError>` (the HTTP layer stays separate from the logic, which is what makes handlers unit-testable)
+3. Add request/response types to `src/agent/api.rs`
+4. If agents should discover it, add a tool schema in `src/agent/tools.rs`
+5. Update docs in `docs/docs/agent/`
 
 ### Adding an OS Mode API endpoint
 
@@ -532,8 +589,9 @@ wasmrun os <path> --watch --port 3000  # With file watching and custom port
 - **Division by zero** in WASM should trap (return error), not panic.
 - **clippy must pass with zero warnings**: the CI enforces `-D warnings`.
 - **Version must stay in sync** across `Cargo.toml`, `ui/package.json`, and `docs/package.json`. Use `just sync-version`.
-- **Two different WASI systems exist:** `src/runtime/wasi/` is for Exec Mode (host functions linked to interpreter). `src/runtime/wasi_fs.rs` is for OS Mode (virtual filesystem in browser). Don't confuse them.
-- **Two different "server" concepts:** Server Mode's HTTP server (`src/server/`) serves WASM files for browser execution. OS Mode's HTTP server (`src/runtime/os_server.rs`) serves the OS UI and APIs. They are independent.
+- **Two different WASI systems exist:** `src/runtime/wasi/` is for Exec and Agent Mode (host functions linked to the interpreter). `src/runtime/wasi_fs.rs` is for OS Mode (virtual filesystem in browser). Don't confuse them.
+- **Three different "server" concepts:** Server Mode's HTTP server (`src/server/`) serves WASM files for browser execution. OS Mode's HTTP server (`src/runtime/os_server.rs`) serves the OS UI and APIs. Agent Mode's HTTP server (`src/agent/server.rs`) serves the REST sandbox API. They are independent.
+- **A WASI syscall change affects two modes.** `src/runtime/wasi/` is reached by `wasmrun exec` and by every agent-mode execution, so test both when touching it.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Standard input**: executions accept a `stdin` field, delivered to the program on file descriptor 0. WASI `fd_read` on fd 0 previously always reported end-of-file, so there was no way to give a sandboxed program input at all
+  - Reads resume where the last one stopped and report end-of-file once the input is drained, so a program can consume it in as many reads as it likes and never blocks
+  - Input is per execution: it rewinds every request, and an execution that sends none reads end-of-file rather than inheriting the previous run's leftovers
+  - Reaches programs that read fd 0 through WASI, which today means `wasm_path` modules. JavaScript and TypeScript code cannot read it until the runtime implements `process.stdin`
+- **ES module packages**: npm dependencies that publish ES modules now install and run. The runtime loads CommonJS only, so every ES module in the session's `node_modules` is converted before execution by the same in-sandbox swc transpiler the TypeScript path uses, under the session's own limits. Packages such as `nanoid`, `p-limit` and `escape-string-regexp` previously could not load at all
+  - A package counts as ESM when it declares `"type": "module"` or ships `.mjs` files; `.mjs` sources become `.js`, which is the only extension the runtime's resolver probes
+  - An entry point declared only in an `exports` map is resolved to a file and written to `main`, so the stock resolver finds it. Conditions are tried `require`, `node`, `default`, `import`, never `browser`
+  - A package's own `#alias` subpath imports are materialized as shims inside that package, scoped so two packages using the same alias cannot collide
+  - The converted form is cached per `name@version` alongside the raw download, so repeat installs skip the transform. Only a package still byte-identical to what the registry shipped is ever cached, so an uploaded `node_modules` tree cannot poison the shared cache for other sessions or tenants
+  - A conversion failure names the offending package rather than only the file
+- **Node.js built-in module tail (wasmhub v0.4.0)**: bump the pinned wasmhub release from v0.3.2 to v0.4.0, whose nodejs runtime fills in the standard-library modules ordinary agent code reaches for. Cached runtimes from the older pin are invalidated and re-fetched automatically
+  - New built-ins: `crypto` (`createHash`/`createHmac`/`randomBytes`/`randomInt`/`randomUUID`/`timingSafeEqual`), `url` (WHATWG classes plus the legacy `parse`/`format`/`resolve` and `fileURLToPath`/`pathToFileURL`), `querystring`, and `string_decoder`
+  - Promise APIs: `fs/promises` and `fs.promises`, plus `timers/promises` including `scheduler.wait`
+  - Every module is also reachable through its `node:` prefixed alias
+  - `zlib`, `child_process` and `worker_threads` now resolve but throw a named `ERR_NOT_SUPPORTED` error when used, so a package that merely imports one keeps loading instead of dying at `require()` with "Cannot find module"
+  - Note: the hash functions are pure JavaScript (no libcrypto in the runtime), costing roughly 1.5 s per 64-byte block under the interpreter; `crypto.getRandomValues`/`randomUUID` remain native via the WASI `random_get` syscall
 - **Reproducible npm installs**: every agent execution that installs dependencies now returns a `lockfile` describing the resolved tree, including transitive packages. Send it back as the request's `lockfile` to install exactly those versions again
   - Replay walks the lockfile rather than the dependency graph, so nothing is re-resolved and no registry metadata is fetched; with a warm cache the install runs offline
   - Tarballs are still integrity-verified and scanned for native artifacts on replay
@@ -20,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Options the sandbox transpiler cannot apply (`experimentalDecorators`, `emitDecoratorMetadata`, and `jsx` modes other than the classic runtime) fail the request by name instead of silently producing broken output
 
 ### Changed
+- **Dist-tag dependencies now dedupe**: a tag such as `latest` is resolved to the concrete version it points at once per request, before anything installs, so it dedupes against an already-installed copy and locks like an explicit version. Previously a tag could never match an installed version, so every request reinstalled it and a transitive `latest` always nested a duplicate copy
 - **Full npm version-range support**: dependency ranges now accept the complete npm grammar, including comparator sets (`>=1.2.0 <2.0.0`), unions (`^1 || ^2`), hyphen ranges (`1.2.0 - 1.4.0`), and the `<`, `<=`, `>`, `=` operators. Previously these were rejected, which meant a single composite range anywhere in a transitive dependency tree failed the whole install even when every package involved was pure JavaScript
   - Partial versions widen bounds as npm specifies, so `>1.2` excludes all of `1.2.x`
   - Prereleases follow the npm rule: a prerelease only satisfies a range that names a prerelease of that same version, so `<2.0.0` no longer risks admitting `2.0.0-rc.1`

--- a/docs/docs/agent/index.md
+++ b/docs/docs/agent/index.md
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 5
-title: Agent API
+sidebar_position: 1
+title: Agent Mode
 ---
 
 # Agent API
@@ -27,11 +27,11 @@ wasmrun agent [OPTIONS]
 | `--max-concurrent-exec` | `100` | Maximum executions in flight across all sessions |
 | `--npm-registry` | `https://registry.npmjs.org` | npm registry base URL for dependency vendoring |
 | `--allow-cors` | off | Enable wildcard CORS |
-| `-v, --verbose` | off | Add a request-received line per request (a structured access log is always emitted; see [Observability](./usage/agent-observability.md)) |
+| `-v, --verbose` | off | Add a request-received line per request (a structured access log is always emitted; see [Observability](./usage/observability.md)) |
 | `--auth <PATH>` | off | Path to a TOML auth config; enables API-key auth & tenant isolation (omit = open) |
 | `--hash-key <KEY>` | - | Print `sha256(KEY)` for the auth config and exit (does not start the server) |
 
-For every size/count limit, `0` means **unlimited**. Memory, fuel, output, file-size, and disk caps are **per session** and can be overridden per session at creation (see [Sessions](./usage/agent-sessions.md)); body size and exec concurrency are **server-wide** ingress guards.
+For every size/count limit, `0` means **unlimited**. Memory, fuel, output, file-size, and disk caps are **per session** and can be overridden per session at creation (see [Sessions](./usage/sessions.md)); body size and exec concurrency are **server-wide** ingress guards.
 
 All endpoints are under `http://<host>:<port>/api/v1/`.
 
@@ -110,7 +110,7 @@ key_sha256 = "60303ae22b998861bce3b28f33eec1be758a213c86c93c076dbe9f558c11c752"
   max_requests_per_min = 600
 ```
 
-`[tenants.limits]` sets a per-tenant resource ceiling, with the same fields as a [per-session override](./usage/agent-sessions.md#per-session-limit-overrides) (`max_memory_mb`, `max_fuel`, `max_output_mb`, `max_file_size_mb`, `max_disk_mb`). Effective session limits compose in three layers: **server defaults → tenant baseline → per-session override clamped to the tenant baseline**. The tenant ceiling is a hard cap; a per-session override may only *tighten* a dimension, never raise it above the tenant's cap (a per-session "unlimited" `0` is pulled down to the tenant's finite ceiling).
+`[tenants.limits]` sets a per-tenant resource ceiling, with the same fields as a [per-session override](./usage/sessions.md#per-session-limit-overrides) (`max_memory_mb`, `max_fuel`, `max_output_mb`, `max_file_size_mb`, `max_disk_mb`). Effective session limits compose in three layers: **server defaults → tenant baseline → per-session override clamped to the tenant baseline**. The tenant ceiling is a hard cap; a per-session override may only *tighten* a dimension, never raise it above the tenant's cap (a per-session "unlimited" `0` is pulled down to the tenant's finite ceiling).
 
 `[tenants.rate]` throttles the tenant independently so one tenant cannot exhaust the shared server: `max_sessions`, `max_concurrent_exec`, `max_requests_per_min` (each `0` or omitted inherits the server-wide default). Over any of these limits returns **429 Too Many Requests**.
 
@@ -191,7 +191,7 @@ curl http://localhost:8430/api/v1/sessions
 curl -X DELETE http://localhost:8430/api/v1/sessions/a1b2c3...
 ```
 
-See the [Agent Execution](./usage/agent-exec.md) reference for all four input modes (shell `command`, JS `source`, multi-file `files`+`entry`, `wasm_path`).
+See the [Agent Execution](./usage/exec.md) reference for all four input modes (shell `command`, JS `source`, multi-file `files`+`entry`, `wasm_path`).
 
 ## Tool Schemas for LLM Agents
 
@@ -211,7 +211,7 @@ Each tool includes a description, parameter schema with types, and required fiel
 
 ## Observability
 
-The server exposes runtime metrics at `GET /api/v1/metrics` (Prometheus text by default, JSON with `?format=json`) and writes a structured, request-id-tagged access-log line to stderr for every request. See [Observability](./usage/agent-observability.md) for the full metric set and log format.
+The server exposes runtime metrics at `GET /api/v1/metrics` (Prometheus text by default, JSON with `?format=json`) and writes a structured, request-id-tagged access-log line to stderr for every request. See [Observability](./usage/observability.md) for the full metric set and log format.
 
 ```sh
 curl http://localhost:8430/api/v1/metrics
@@ -224,8 +224,8 @@ curl http://localhost:8430/api/v1/metrics
 
 See the usage sub-pages for full endpoint documentation:
 
-- [Sessions](./usage/agent-sessions.md): create, status, destroy
-- [Execution](./usage/agent-exec.md): run WASM with timeout and structured output
-- [File Operations](./usage/agent-files.md): write, read, list, delete
-- [Environment Variables](./usage/agent-environment.md): set and get per-session env
-- [Observability](./usage/agent-observability.md): metrics endpoint and access log
+- [Sessions](./usage/sessions.md): create, status, destroy
+- [Execution](./usage/exec.md): run WASM with timeout and structured output
+- [File Operations](./usage/files.md): write, read, list, delete
+- [Environment Variables](./usage/environment.md): set and get per-session env
+- [Observability](./usage/observability.md): metrics endpoint and access log

--- a/docs/docs/agent/usage/environment.md
+++ b/docs/docs/agent/usage/environment.md
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 8
-title: Agent Environment
+sidebar_position: 4
+title: Environment
 ---
 
 # Environment Variables

--- a/docs/docs/agent/usage/exec.md
+++ b/docs/docs/agent/usage/exec.md
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 6
-title: Agent Execution
+sidebar_position: 2
+title: Execution
 ---
 
 # Agent Execution
@@ -28,6 +28,7 @@ These apply to every mode:
 |-------|----------|---------|-------------|
 | `timeout` | no | `30` | Execution timeout in seconds |
 | `env` | no | `{}` | Environment variables to set before execution |
+| `stdin` | no | `""` | Text the program reads from standard input (see [Standard Input](#standard-input)) |
 | `stream` | no | `false` | Stream output as Server-Sent Events while the code runs (see [Streaming Output](#streaming-output)) |
 
 ## Common Response
@@ -167,10 +168,29 @@ Declare npm packages with the `dependencies` field (works with `source` and `fil
 
 Prereleases follow the npm rule: `1.2.3-beta` only satisfies a range that names a prerelease of `1.2.3`, so `<2.0.0` never quietly pulls in `2.0.0-rc.1`.
 
+A dist-tag is pinned to the version it points at once per request, before anything is installed, so `latest` dedupes and locks like a version you had written out yourself. Across requests it is still a moving target: pin with a [lockfile](#reproducible-installs-with-a-lockfile) if you need the same tree next time.
+
+**ES module packages work.** The runtime itself loads CommonJS only, so every ES module in `node_modules` is converted to CommonJS before your code runs, by the same in-sandbox swc transpiler the TypeScript path uses. A package is treated as ESM when it declares `"type": "module"` or ships `.mjs` files:
+
+```sh
+curl -X POST http://localhost:8430/api/v1/sessions/$SID/exec \
+  -H 'Content-Type: application/json' \
+  -d '{"source": "const { nanoid } = require(\"nanoid\"); console.log(nanoid());",
+       "dependencies": {"nanoid": "^6"}}'
+```
+
+Note the `require()`: your own code is CommonJS either way, so a default export arrives as `.default`. Details worth knowing:
+
+- An entry point declared only in an `exports` map is resolved and written to `main`, which is what the runtime reads. Conditions are tried in the order `require`, `node`, `default`, `import`; `browser` is never chosen
+- A package's own `#alias` subpath imports are resolved and materialized inside that package, so they cannot collide between packages
+- The converted form is cached per `name@version`, so later installs of the same package skip the transform. Only packages byte-identical to what the registry shipped are cached, so an uploaded `node_modules` tree can never poison the cache for anyone else
+- Conversion failures name the package rather than just the file
+
 **Limitations:**
 
 - Pure-JS packages only: anything with an install script, `binding.gyp`, or prebuilt `.node` binaries is rejected with an error naming the package (native code can't run in the sandbox)
-- CommonJS entry points work best; packages relying on ESM-only entry, `exports` maps, or `fetch`/network at import time may not load
+- A package needing a Node built-in the runtime does not implement (`node:process`, `node:tty`) still fails at `require()` time, whatever its module format. `chalk` is a current example
+- Conversion parses ESM sources as TypeScript, which is a superset of JavaScript. Sources containing JSX or Flow types are rejected
 - An uploaded `package.json` is inert unless you set `install_package_json`, so no execution turns into an unrequested network fetch. `devDependencies` are ignored: there is nothing in the sandbox to run them with yet
 
 Malformed names/ranges fail with HTTP `400` before execution; resolution or download failures surface in the response's `error` field.
@@ -267,7 +287,7 @@ Bare specifiers resolve through a `node_modules/<name>` tree, so a project can s
 
 ## JavaScript Runtime Capabilities
 
-JavaScript executes in the [wasmhub `nodejs` runtime](https://anistark.github.io/wasmhub/runtimes/nodejs/) (QuickJS-based, WASI; v0.3.2+), fetched once and cached. Supported surface:
+JavaScript executes in the [wasmhub `nodejs` runtime](https://anistark.github.io/wasmhub/runtimes/nodejs/) (QuickJS-based, WASI; v0.4.0+), fetched once and cached. Supported surface:
 
 **Module system (CommonJS):**
 - Relative and absolute `require()` (`./x`, `../x`), with `.js`/`.json` extension probing, `index.*` resolution, and `package.json` `main`
@@ -275,7 +295,13 @@ JavaScript executes in the [wasmhub `nodejs` runtime](https://anistark.github.io
 - Node-style module wrapper: `module.exports`, `require.cache`, `require.resolve`, `require.main`, `__filename`, `__dirname`
 - JSON loading via `require('./data.json')`
 
-**Built-in modules:** `path`, `fs`, `os`, `events`, `util`, `assert`, `stream`, `buffer`.
+**Built-in modules:** `path`, `fs`, `fs/promises` (and `fs.promises`), `os`, `events`, `util`, `assert`, `stream`, `buffer`, `crypto`, `url`, `querystring`, `string_decoder`, `timers`, `timers/promises`. Every one is also reachable through its `node:` prefixed alias, so `require('node:fs/promises')` works.
+
+`zlib`, `child_process` and `worker_threads` are present but throw a named `ERR_NOT_SUPPORTED` error when used: the sandbox has no compression library, no process table, and one thread. They resolve rather than being absent so a package that merely imports one keeps loading.
+
+:::note Hashing is pure JavaScript
+`crypto.createHash`/`createHmac` are implemented in JS, with no libcrypto in the runtime, so they cost roughly 1.5 s per 64-byte block under the interpreter. Fine for a short digest, impractical for hashing a large file. `crypto.getRandomValues`/`randomUUID` are native and cheap: they go through the WASI `random_get` syscall.
+:::
 
 **Globals & event loop:** `process`, `setTimeout`/`setInterval`/`setImmediate`, `queueMicrotask`, `process.nextTick`, async/await with full Promise resolution (pending timers and microtasks are drained before exit), `Buffer`, `TextEncoder`/`TextDecoder`, `atob`/`btoa`.
 
@@ -374,6 +400,24 @@ Execute a `.wasm` file already present in the session filesystem.
 
 ---
 
+## Standard Input
+
+Send `stdin` to give the program something to read on file descriptor 0:
+
+```sh
+curl -X POST http://localhost:8430/api/v1/sessions/$SID/exec \
+  -H 'Content-Type: application/json' \
+  -d '{"wasm_path": "wc.wasm", "stdin": "one\ntwo\nthree\n"}'
+```
+
+Input belongs to a single execution: it rewinds at the start of every request, so an execution that sends no `stdin` reads end-of-file immediately rather than picking up what a previous one left. Reads never block; once the input is drained, further reads report end-of-file.
+
+:::note JavaScript cannot read stdin yet
+This reaches any program that reads fd 0 through WASI, which today means `wasm_path` modules. The JavaScript runtime's `process.stdin` is still a stub, so JS and TypeScript code cannot see the input. Pass data to JS through `env`, a file written with the [files API](./files.md), or the source itself.
+:::
+
+---
+
 ## Timeout
 
 If execution exceeds the timeout, the response includes:
@@ -392,7 +436,7 @@ Partial output captured before the timeout is still returned. The worker is then
 
 ## Limits & Errors
 
-Execution is bounded by the per-session resource limits and server-wide ingress guards configured on [`wasmrun agent`](../agent.md#starting-the-server) (and overridable per session). These surface in two ways.
+Execution is bounded by the per-session resource limits and server-wide ingress guards configured on [`wasmrun agent`](../index.md#starting-the-server) (and overridable per session). These surface in two ways.
 
 **Within a 200 response** (the execution ran but hit a soft cap):
 

--- a/docs/docs/agent/usage/files.md
+++ b/docs/docs/agent/usage/files.md
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 7
-title: Agent File Operations
+sidebar_position: 3
+title: File Operations
 ---
 
 # File Operations
@@ -30,7 +30,7 @@ Parent directories are created automatically. Paths are relative to the session 
 }
 ```
 
-A write is rejected with **400 Bad Request** if it would exceed the session's `--max-file-size` (per file) or `--max-disk` (total) quota, and the whole request is rejected with **413 Payload Too Large** if the request body exceeds the server's `--max-body` limit. See [resource limits](../agent.md#starting-the-server).
+A write is rejected with **400 Bad Request** if it would exceed the session's `--max-file-size` (per file) or `--max-disk` (total) quota, and the whole request is rejected with **413 Payload Too Large** if the request body exceeds the server's `--max-body` limit. See [resource limits](../index.md#starting-the-server).
 
 ## Read a File
 
@@ -87,4 +87,4 @@ Deletes files or directories (recursive for directories).
 
 ## Authentication & Tenant Scoping
 
-When the server runs with [`--auth`](../agent.md#authentication), every file request must carry a valid `Authorization: Bearer <key>` header; a missing, malformed, or unknown key returns **401 Unauthorized**. File operations are scoped to the calling tenant's own sessions; targeting a session owned by another tenant returns **404 Not Found**, the same as a nonexistent session.
+When the server runs with [`--auth`](../index.md#authentication), every file request must carry a valid `Authorization: Bearer <key>` header; a missing, malformed, or unknown key returns **401 Unauthorized**. File operations are scoped to the calling tenant's own sessions; targeting a session owned by another tenant returns **404 Not Found**, the same as a nonexistent session.

--- a/docs/docs/agent/usage/observability.md
+++ b/docs/docs/agent/usage/observability.md
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 9
-title: Agent Observability
+sidebar_position: 5
+title: Observability
 ---
 
 # Observability
@@ -76,7 +76,7 @@ Average execution duration is `exec_duration_ms_sum / exec_duration_ms_count`.
 
 ### Authentication
 
-When [`--auth`](../agent.md#authentication) is enabled, `/metrics` requires a valid API key like every other endpoint, and the scrape is limited to **global aggregates**, with no per-tenant or per-session data, so one tenant cannot infer another's activity. A missing or invalid key returns **401** (and increments `exec_rejected_total{reason="unauthorized"}`).
+When [`--auth`](../index.md#authentication) is enabled, `/metrics` requires a valid API key like every other endpoint, and the scrape is limited to **global aggregates**, with no per-tenant or per-session data, so one tenant cannot infer another's activity. A missing or invalid key returns **401** (and increments `exec_rejected_total{reason="unauthorized"}`).
 
 ### Per-session breakdown (open mode only)
 
@@ -111,7 +111,7 @@ ts=2026-06-13T11:18:55.354+00:00 id=d5aafbe6c56c32ec method=POST path=/api/v1/se
 | `dur_ms` | Handling duration in milliseconds |
 | `tenant` | Authenticated tenant id, or `-` in open mode / before auth resolves |
 
-Running with [`-v, --verbose`](../agent.md#starting-the-server) adds a request-received line (`→ METHOD url (id=...)`) ahead of each response line; the structured access line is emitted either way.
+Running with [`-v, --verbose`](../index.md#starting-the-server) adds a request-received line (`→ METHOD url (id=...)`) ahead of each response line; the structured access line is emitted either way.
 
 ### Request correlation
 

--- a/docs/docs/agent/usage/sessions.md
+++ b/docs/docs/agent/usage/sessions.md
@@ -1,6 +1,6 @@
 ---
-sidebar_position: 5
-title: Agent Sessions
+sidebar_position: 1
+title: Sessions
 ---
 
 # Session Management
@@ -23,7 +23,7 @@ POST /api/v1/sessions
 
 ### Per-Session Limit Overrides
 
-The body is optional. To override the server's default [resource limits](../agent.md#starting-the-server) for this session only, pass a `limits` object; any omitted field keeps the server default, and `0` disables that cap:
+The body is optional. To override the server's default [resource limits](../index.md#starting-the-server) for this session only, pass a `limits` object; any omitted field keeps the server default, and `0` disables that cap:
 
 ```json
 {
@@ -39,7 +39,7 @@ The body is optional. To override the server's default [resource limits](../agen
 
 Body size and exec concurrency are server-wide and cannot be overridden per session.
 
-When the server runs with [`--auth`](../agent.md#authentication) and the tenant has a `[tenants.limits]` baseline, a per-session override may only *tighten* a limit; it is clamped to the tenant ceiling and can never raise a cap above it.
+When the server runs with [`--auth`](../index.md#authentication) and the tenant has a `[tenants.limits]` baseline, a per-session override may only *tighten* a limit; it is clamped to the tenant ceiling and can never raise a cap above it.
 
 ## Get Session Status
 
@@ -84,7 +84,7 @@ Lists the sessions currently available, newest first, so an agent can find one t
 
 Each entry has the same shape as [Get Session Status](#get-session-status). Expired sessions are omitted even before the cleanup thread collects them, so the listing never advertises a session that cannot be used.
 
-Under [`--auth`](../agent.md#authentication) the listing is scoped to the calling tenant, matching the visibility rule everywhere else: a tenant never learns that another tenant's sessions exist.
+Under [`--auth`](../index.md#authentication) the listing is scoped to the calling tenant, matching the visibility rule everywhere else: a tenant never learns that another tenant's sessions exist.
 
 ## Destroy a Session
 
@@ -118,4 +118,4 @@ Destroys the session and cleans up its filesystem.
 | 413 | Request body exceeded the server's `--max-body` limit |
 | 429 | Maximum concurrent sessions reached: the global `--max-sessions` cap, or the tenant's own `[tenants.rate]` session cap under `--auth` |
 
-When the server is started with [`--auth`](../agent.md#authentication), each session is owned by the tenant that created it. A request for a session owned by a different tenant returns **404**, identical to a nonexistent session, so existence isn't leaked across tenants.
+When the server is started with [`--auth`](../index.md#authentication), each session is owned by the tenant that created it. A request for a session owned by a different tenant returns **404**, identical to a nonexistent session, so existence isn't leaked across tenants.

--- a/docs/docs/exec/languages.md
+++ b/docs/docs/exec/languages.md
@@ -26,18 +26,18 @@ wasmrun exec ./dist/output.wasm
 
 ## Source Execution (Agent API)
 
-The [Agent API](./agent.md) extends exec mode with direct source execution. Language runtimes are not compiled locally; they are WASM modules fetched from [wasmhub](https://anistark.github.io/wasmhub/) and executed inside the same sandboxed interpreter:
+The [Agent API](../agent/index.md) extends exec mode with direct source execution. Language runtimes are not compiled locally; they are WASM modules fetched from [wasmhub](https://anistark.github.io/wasmhub/) and executed inside the same sandboxed interpreter:
 
 | Language | Aliases | Runtime |
 |---|---|---|
 | JavaScript | `js`, `nodejs` | [wasmhub `nodejs` runtime](https://anistark.github.io/wasmhub/runtimes/nodejs/) (CommonJS `require()`, Node built-ins, web globals) |
 | TypeScript | `ts`, `tsx` | Transpiled in-sandbox by the [wasmhub `swc` module](https://anistark.github.io/wasmhub/runtimes/swc/), then run on the `nodejs` runtime |
 
-See [JavaScript runtime capabilities](./usage/agent-exec.md#javascript-runtime-capabilities) for the supported built-ins and limits. Unsupported languages (for example `python`) return HTTP 400; more runtimes will arrive as they land on wasmhub.
+See [JavaScript runtime capabilities](../agent/usage/exec.md#javascript-runtime-capabilities) for the supported built-ins and limits. Unsupported languages (for example `python`) return HTTP 400; more runtimes will arrive as they land on wasmhub.
 
 ## What Goes Where
 
 - **Compile a language to WASM**: [Server Mode languages](../server/languages/rust.md), powered by [plugins](/docs/plugins)
 - **Run a `.wasm` file natively**: exec mode, this section
-- **Run JS/TS source in a sandbox**: the [Agent API](./agent.md)
+- **Run JS/TS source in a sandbox**: the [Agent API](../agent/index.md)
 - **Browser-based multi-language execution**: [OS Mode language selection](../os/usage/language.md), also powered by wasmhub runtimes

--- a/docs/docs/exec/usage/index.md
+++ b/docs/docs/exec/usage/index.md
@@ -34,4 +34,4 @@ wasmrun exec ./module.wasm --call add 5 3
 | [Function Calling](./functions.md) | Call specific exported functions with `--call` |
 | [Argument Passing](./arguments.md) | Pass arguments to WASM programs |
 
-For HTTP-based access (AI agents, automation), see [Agent API](../agent.md).
+For HTTP-based access (AI agents, automation), see [Agent Mode](../../agent/index.md).

--- a/docs/docs/exec/wasi.md
+++ b/docs/docs/exec/wasi.md
@@ -101,10 +101,10 @@ match executor.execute_with_args(func_idx, args) {
 
 ## Filesystem
 
-Exec mode bridges the executor to wasmrun's `WasiFilesystem`, so modules can open, read, write, list, and delete files through the `path_*` / `fd_*` syscalls above. A host directory is mounted into the sandbox as a WASI preopen; the [agent API](./agent.md), for example, preopens each session's temp directory at `/`.
+Exec mode bridges the executor to wasmrun's `WasiFilesystem`, so modules can open, read, write, list, and delete files through the `path_*` / `fd_*` syscalls above. A host directory is mounted into the sandbox as a WASI preopen; the [agent API](../agent/index.md), for example, preopens each session's temp directory at `/`.
 
 - **Preopened directories**: host directories mounted to a virtual path, surfaced via `fd_prestat_get` / `fd_prestat_dir_name`
 - **Path traversal protection**: every guest path is resolved and confined to its mount; `..` escapes are rejected
 - **Read-only mode**: when enabled, writes and creates fail instead of mutating the host
 - **File size limit**: a write larger than the configured per-file cap is rejected with `EFBIG`
-- **Disk quota**: in the agent, a write that would push the session's total on-disk footprint past `--max-disk` is rejected with `EDQUOT` (see [Agent API](./agent.md))
+- **Disk quota**: in the agent, a write that would push the session's total on-disk footprint past `--max-disk` is rejected with `EDQUOT` (see [Agent API](../agent/index.md))

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 **Wasmrun** is a WebAssembly runtime that simplifies development, compilation, and execution of WASM applications across multiple programming languages.
 
-## Three Modes
+## Four Modes
 
 ### [Server Mode](/docs/server): `wasmrun`
 
@@ -30,6 +30,14 @@ Browser-based execution environment with a WASM virtual machine, virtual filesys
 
 ```sh
 wasmrun os ./my-node-project
+```
+
+### [Agent Mode](/docs/agent): `wasmrun agent`
+
+A REST API that gives AI agents isolated sandboxes to execute code in, built on the exec-mode interpreter. No Docker, no daemon.
+
+```sh
+wasmrun agent --port 8430
 ```
 
 ## Key Features

--- a/docs/docs/os/usage/language.md
+++ b/docs/docs/os/usage/language.md
@@ -133,7 +133,7 @@ curl http://localhost:8420/api/runtimes
   "wasmhub_runtime": "nodejs",
   "cached": true,
   "cached_version": "0.1.4",
-  "wasmhub_version": "0.3.2",
+  "wasmhub_version": "0.4.0",
   "available_languages": ["nodejs", "rustpython"]
 }
 ```

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -130,6 +130,12 @@ const config: Config = {
         },
         {
           type: 'docSidebar',
+          sidebarId: 'agent',
+          position: 'left',
+          label: 'Agent',
+        },
+        {
+          type: 'docSidebar',
           sidebarId: 'plugins',
           position: 'left',
           label: 'Plugins',
@@ -188,6 +194,7 @@ const config: Config = {
             { label: 'Server Mode', to: '/docs/server' },
             { label: 'Exec Mode', to: '/docs/exec' },
             { label: 'OS Mode', to: '/docs/os' },
+            { label: 'Agent Mode', to: '/docs/agent' },
             { label: 'Changelog', to: '/docs/contributing/changelog' },
           ],
         },

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -67,17 +67,27 @@ const sidebars: SidebarsConfig = {
         },
         'exec/languages',
         'exec/wasi',
+      ],
+    },
+  ],
+
+  agent: [
+    {
+      type: 'category',
+      label: 'Agent Mode',
+      collapsed: false,
+      link: { type: 'doc', id: 'agent/index' },
+      items: [
         {
           type: 'category',
-          label: 'Agent API',
-          collapsed: true,
-          link: { type: 'doc', id: 'exec/agent' },
+          label: 'Usage',
+          collapsed: false,
           items: [
-            'exec/usage/agent-sessions',
-            'exec/usage/agent-exec',
-            'exec/usage/agent-files',
-            'exec/usage/agent-environment',
-            'exec/usage/agent-observability',
+            'agent/usage/sessions',
+            'agent/usage/exec',
+            'agent/usage/files',
+            'agent/usage/environment',
+            'agent/usage/observability',
           ],
         },
       ],

--- a/docs/src/pages/index.module.css
+++ b/docs/src/pages/index.module.css
@@ -250,7 +250,7 @@
 
 .modeGrid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(2, 1fr);
   gap: 1.25rem;
 }
 

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -156,6 +156,19 @@ const modes: Mode[] = [
       </svg>
     ),
   },
+  {
+    title: 'Agent Mode',
+    command: 'wasmrun agent',
+    description:
+      'A REST API giving AI agents isolated sandboxes to run code in, on the exec interpreter. No Docker, no daemon.',
+    to: '/docs/agent',
+    icon: (
+      <svg {...iconProps}>
+        <rect x="4" y="8" width="16" height="12" rx="3" />
+        <path d="M12 4v4M9 14h.01M15 14h.01" />
+      </svg>
+    ),
+  },
 ];
 
 function ModeCards() {

--- a/examples/agent-flows/README.md
+++ b/examples/agent-flows/README.md
@@ -1,6 +1,6 @@
 # Agent API Example Flows
 
-Runnable end-to-end flows against the [Agent API](https://wasmrun.readthedocs.io/en/latest/docs/exec/agent): the same request sequences an LLM agent makes through the `execute_code` tool schema (`GET /api/v1/tools`).
+Runnable end-to-end flows against the [Agent API](https://wasmrun.readthedocs.io/en/latest/docs/agent): the same request sequences an LLM agent makes through the `execute_code` tool schema (`GET /api/v1/tools`).
 
 ## Prerequisites
 

--- a/src/agent/api.rs
+++ b/src/agent/api.rs
@@ -51,6 +51,10 @@ pub struct ExecRequest {
     /// incremental stdout/stderr; a final `result` event carries the same
     /// object the buffered response would have returned.
     pub stream: Option<bool>,
+    /// Text the program reads from standard input; absent means immediate
+    /// EOF. Reaches programs reading fd 0 through WASI, so `wasm_path` only:
+    /// the JS runtime's `process.stdin` is still a stub.
+    pub stdin: Option<String>,
     /// Shell command line to execute via the built-in shell emulator.
     /// Supports pipes (`|`), redirection (`>`, `>>`, `<`), and sequencing
     /// (`&&`, `;`) with built-ins for common file/env operations.

--- a/src/agent/esm.rs
+++ b/src/agent/esm.rs
@@ -1,0 +1,691 @@
+//! Agent mode: ESM → CommonJS lowering for vendored npm packages.
+//!
+//! The runtime's module wrapper is CommonJS-only and its resolver probes
+//! `.js`/`.json` but never `.mjs`, so an ESM package cannot load at all.
+//! Rewriting the sources reuses the swc stage the TypeScript path already
+//! runs, rather than waiting on runtime-side ESM support.
+
+use crate::agent::api::ApiError;
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+
+/// Marks the temporary `.ts` copies handed to the transpiler, which accepts
+/// `.ts`/`.tsx` inputs only. TypeScript is a superset, so the parse is the
+/// one the file would get anyway.
+const TMP_SUFFIX: &str = ".wasmrun-esm";
+
+/// Entry-point conditions, in priority order. `import` is accepted last
+/// because it names ESM, which is what this module lowers anyway; `browser`
+/// and `types` are deliberately absent.
+const EXPORT_CONDITIONS: [&str; 4] = ["require", "node", "default", "import"];
+
+/// A vendored package whose sources need lowering. Paths are relative to the
+/// session root.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EsmPackage {
+    pub dir: String,
+    pub name: String,
+    pub version: String,
+    pub files: Vec<String>,
+    /// `main` to write when the runtime would not otherwise find an entry.
+    pub main: Option<String>,
+    /// `#alias` → file within the package, both as written.
+    pub imports: Vec<(String, String)>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct PackageJson {
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    version: String,
+    #[serde(rename = "type", default)]
+    module_type: Option<String>,
+    #[serde(default)]
+    main: Option<String>,
+    #[serde(default)]
+    exports: Option<serde_json::Value>,
+    #[serde(default)]
+    imports: Option<serde_json::Value>,
+}
+
+/// Every package under `work_dir/node_modules` that publishes ESM, nested
+/// ones included.
+pub fn scan(work_dir: &Path) -> Vec<EsmPackage> {
+    let mut out = Vec::new();
+    scan_node_modules(work_dir, &work_dir.join("node_modules"), &mut out);
+    out.sort_by(|a, b| a.dir.cmp(&b.dir));
+    out
+}
+
+fn scan_node_modules(root: &Path, node_modules: &Path, out: &mut Vec<EsmPackage>) {
+    let Ok(entries) = std::fs::read_dir(node_modules) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let file_name = entry.file_name();
+        let name = file_name.to_string_lossy();
+        if name.starts_with('.') {
+            continue;
+        }
+        // A scoped directory (`@scope`) holds packages rather than being one.
+        if name.starts_with('@') {
+            scan_node_modules(root, &path, out);
+            continue;
+        }
+        if let Some(pkg) = inspect_package(root, &path) {
+            out.push(pkg);
+        }
+        scan_node_modules(root, &path.join("node_modules"), out);
+    }
+}
+
+/// Describe one package directory, or `None` when it needs no lowering.
+fn inspect_package(root: &Path, dir: &Path) -> Option<EsmPackage> {
+    let manifest = std::fs::read_to_string(dir.join("package.json")).ok()?;
+    let pkg: PackageJson = serde_json::from_str(&manifest).ok()?;
+    let is_module = pkg.module_type.as_deref() == Some("module");
+
+    let mut sources = Vec::new();
+    collect_sources(dir, is_module, &mut sources);
+    if sources.is_empty() {
+        return None;
+    }
+
+    // `x.mjs` lowers onto `x.js`, so drop it when that sibling exists: the
+    // `.js` is the one the resolver loads.
+    sources.retain(|p| match p.extension().and_then(|e| e.to_str()) {
+        Some("mjs") => !p.with_extension("js").exists(),
+        _ => true,
+    });
+    if sources.is_empty() {
+        return None;
+    }
+
+    let rel_dir = rel_str(root, dir)?;
+    let mut files: Vec<String> = sources.iter().filter_map(|p| rel_str(root, p)).collect();
+    files.sort();
+
+    let main = entry_fix(&pkg);
+    let imports = subpath_imports(&pkg);
+    Some(EsmPackage {
+        dir: rel_dir,
+        name: pkg.name,
+        version: pkg.version,
+        files,
+        main,
+        imports,
+    })
+}
+
+/// The package's own `#alias` subpath imports, resolved to files. Wildcards
+/// are skipped: materializing one means enumerating every file it matches.
+fn subpath_imports(pkg: &PackageJson) -> Vec<(String, String)> {
+    let Some(serde_json::Value::Object(map)) = &pkg.imports else {
+        return Vec::new();
+    };
+    let mut out: Vec<(String, String)> = map
+        .iter()
+        .filter(|(alias, _)| alias.starts_with('#') && !alias.contains('*'))
+        .filter_map(|(alias, value)| {
+            let target = resolve_conditions(value, 0)?;
+            (!target.contains('*')).then(|| (alias.clone(), lowered_name(&target)))
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+/// ESM files in `dir`: always `.mjs`, and `.js` too under `"type": "module"`.
+fn collect_sources(dir: &Path, is_module: bool, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            if entry.file_name() != "node_modules" {
+                collect_sources(&path, is_module, out);
+            }
+            continue;
+        }
+        match path.extension().and_then(|e| e.to_str()) {
+            Some("mjs") => out.push(path),
+            Some("js") if is_module => out.push(path),
+            _ => {}
+        }
+    }
+}
+
+/// A `main` to write when the runtime would otherwise not resolve the
+/// package: the resolver reads `main` then `index.js` and knows nothing about
+/// `exports`, which is where ESM-only packages put their entry. Additive, so a
+/// resolver that later learns `exports` keeps preferring the map.
+fn entry_fix(pkg: &PackageJson) -> Option<String> {
+    if let Some(main) = &pkg.main {
+        let lowered = lowered_name(main);
+        if lowered != *main {
+            return Some(lowered);
+        }
+        return None;
+    }
+    let from_exports = pkg.exports.as_ref().and_then(resolve_root_export);
+    match from_exports {
+        // `index.js` is the resolver's own fallback; no `main` needed.
+        Some(target) if strip_dot_slash(&target) == "index.js" => None,
+        Some(target) => Some(lowered_name(&target)),
+        None => None,
+    }
+}
+
+/// The file the `"."` entry of an `exports` map points at.
+fn resolve_root_export(exports: &serde_json::Value) -> Option<String> {
+    let root = match exports {
+        // Sugar: `"exports": "./index.js"` means the root entry directly.
+        serde_json::Value::String(s) => return Some(s.clone()),
+        serde_json::Value::Object(map) => {
+            // An object is either subpaths (keys start with `.`) or bare
+            // conditions for the root entry.
+            if map.keys().any(|k| k.starts_with('.')) {
+                map.get(".")?
+            } else {
+                exports
+            }
+        }
+        _ => return None,
+    };
+    resolve_conditions(root, 0)
+}
+
+fn resolve_conditions(value: &serde_json::Value, depth: usize) -> Option<String> {
+    if depth > 8 {
+        return None;
+    }
+    match value {
+        serde_json::Value::String(s) => Some(s.clone()),
+        serde_json::Value::Object(map) => EXPORT_CONDITIONS
+            .iter()
+            .find_map(|c| map.get(*c).and_then(|v| resolve_conditions(v, depth + 1))),
+        // First usable branch of an alternatives array, as node does.
+        serde_json::Value::Array(items) => {
+            items.iter().find_map(|v| resolve_conditions(v, depth + 1))
+        }
+        _ => None,
+    }
+}
+
+/// The name a source ends up with after lowering.
+fn lowered_name(path: &str) -> String {
+    match path.strip_suffix(".mjs") {
+        Some(stem) => format!("{stem}.js"),
+        None => path.to_string(),
+    }
+}
+
+fn strip_dot_slash(path: &str) -> &str {
+    path.strip_prefix("./").unwrap_or(path)
+}
+
+fn rel_str(root: &Path, path: &Path) -> Option<String> {
+    Some(path.strip_prefix(root).ok()?.to_string_lossy().into_owned())
+}
+
+/// The temporary `.ts` path a source is transpiled through.
+pub fn tmp_input(file: &str) -> String {
+    let stem = file
+        .strip_suffix(".mjs")
+        .or_else(|| file.strip_suffix(".js"))
+        .unwrap_or(file);
+    format!("{stem}{TMP_SUFFIX}.ts")
+}
+
+/// The `.js` the transpiler emits for [`tmp_input`].
+pub fn tmp_output(file: &str) -> String {
+    let stem = file
+        .strip_suffix(".mjs")
+        .or_else(|| file.strip_suffix(".js"))
+        .unwrap_or(file);
+    format!("{stem}{TMP_SUFFIX}.js")
+}
+
+/// Copy each source to its temporary `.ts` path, returning the transpiler
+/// inputs.
+pub fn stage_inputs(
+    work_dir: &Path,
+    files: &[String],
+) -> std::result::Result<Vec<String>, ApiError> {
+    let mut inputs = Vec::with_capacity(files.len());
+    for file in files {
+        let input = tmp_input(file);
+        std::fs::copy(work_dir.join(file), work_dir.join(&input)).map_err(|e| {
+            ApiError::Internal(format!("Failed to stage '{file}' for ESM lowering: {e}"))
+        })?;
+        inputs.push(input);
+    }
+    Ok(inputs)
+}
+
+/// Move each transpiled result over its source and clean up the staging
+/// files. A lowered `.mjs` is removed: the resolver cannot load it anyway.
+pub fn commit_outputs(work_dir: &Path, files: &[String]) -> std::result::Result<(), ApiError> {
+    for file in files {
+        let emitted = work_dir.join(tmp_output(file));
+        let target = work_dir.join(lowered_name(file));
+        std::fs::rename(&emitted, &target)
+            .map_err(|e| ApiError::Internal(format!("Failed to install lowered '{file}': {e}")))?;
+        let _ = std::fs::remove_file(work_dir.join(tmp_input(file)));
+        if file.ends_with(".mjs") {
+            let _ = std::fs::remove_file(work_dir.join(file));
+        }
+    }
+    Ok(())
+}
+
+/// Remove staging files left by a failed lowering, so the program never sees
+/// them.
+pub fn clean_staging(work_dir: &Path, files: &[String]) {
+    for file in files {
+        let _ = std::fs::remove_file(work_dir.join(tmp_input(file)));
+        let _ = std::fs::remove_file(work_dir.join(tmp_output(file)));
+    }
+}
+
+/// Bring a lowered package's `package.json` in line with what it now holds,
+/// preserving every other field: `"type": "module"` is dropped (true
+/// afterwards, and what stops [`scan`] re-lowering it next run) and `main` is
+/// written when the entry needed one.
+pub fn finalize_manifest(work_dir: &Path, pkg: &EsmPackage) -> std::result::Result<(), ApiError> {
+    let path = work_dir.join(&pkg.dir).join("package.json");
+    let text = std::fs::read_to_string(&path)
+        .map_err(|e| ApiError::Internal(format!("Failed to read {}: {e}", path.display())))?;
+    let mut json: serde_json::Value = serde_json::from_str(&text)
+        .map_err(|e| ApiError::Internal(format!("Invalid package.json in '{}': {e}", pkg.dir)))?;
+    let serde_json::Value::Object(map) = &mut json else {
+        return Ok(());
+    };
+    if map.get("type").and_then(|t| t.as_str()) == Some("module") {
+        map.remove("type");
+    }
+    if let Some(main) = &pkg.main {
+        map.insert("main".into(), serde_json::Value::String(main.clone()));
+    }
+    let rendered = serde_json::to_string_pretty(&json)
+        .map_err(|e| ApiError::Internal(format!("Failed to render package.json: {e}")))?;
+    std::fs::write(&path, rendered)
+        .map_err(|e| ApiError::Internal(format!("Failed to write {}: {e}", path.display())))
+}
+
+/// Attribute a transpiler error to the package owning the offending file.
+/// swc reports the path it was given, so the owner is recoverable from the
+/// message rather than by transpiling each package separately.
+pub fn blame(packages: &[EsmPackage], error: &str) -> String {
+    let owner = packages.iter().find(|p| error.contains(&p.dir));
+    match owner {
+        Some(p) if !p.name.is_empty() => format!(
+            "Failed to convert ES module package '{}@{}' to CommonJS: {}",
+            p.name, p.version, error
+        ),
+        _ => format!("Failed to convert an ES module dependency to CommonJS: {error}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Write a package into `root/node_modules/<name>`.
+    fn write_pkg(root: &Path, name: &str, manifest: &str, files: &[(&str, &str)]) -> PathBuf {
+        let dir = root.join("node_modules").join(name);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("package.json"), manifest).unwrap();
+        for (path, content) in files {
+            let full = dir.join(path);
+            std::fs::create_dir_all(full.parent().unwrap()).unwrap();
+            std::fs::write(full, content).unwrap();
+        }
+        dir
+    }
+
+    #[test]
+    fn test_scan_finds_type_module_package() {
+        let root = tempfile::tempdir().unwrap();
+        write_pkg(
+            root.path(),
+            "esm-pkg",
+            r#"{"name":"esm-pkg","version":"1.0.0","type":"module"}"#,
+            &[
+                ("index.js", "export const x = 1;"),
+                ("lib/util.js", "export const y = 2;"),
+            ],
+        );
+
+        let found = scan(root.path());
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].name, "esm-pkg");
+        assert_eq!(found[0].version, "1.0.0");
+        assert_eq!(
+            found[0].files,
+            vec![
+                "node_modules/esm-pkg/index.js",
+                "node_modules/esm-pkg/lib/util.js"
+            ]
+        );
+        // index.js is the resolver's own fallback, so no main is needed.
+        assert_eq!(found[0].main, None);
+    }
+
+    #[test]
+    fn test_scan_skips_commonjs_package() {
+        let root = tempfile::tempdir().unwrap();
+        write_pkg(
+            root.path(),
+            "cjs-pkg",
+            r#"{"name":"cjs-pkg","version":"2.0.0","main":"index.js"}"#,
+            &[("index.js", "module.exports = 1;")],
+        );
+        assert!(scan(root.path()).is_empty());
+    }
+
+    #[test]
+    fn test_scan_finds_mjs_in_commonjs_package() {
+        let root = tempfile::tempdir().unwrap();
+        write_pkg(
+            root.path(),
+            "dual",
+            r#"{"name":"dual","version":"1.0.0","main":"index.cjs"}"#,
+            &[
+                ("index.cjs", "module.exports = 1;"),
+                ("extra.mjs", "export default 2;"),
+            ],
+        );
+        let found = scan(root.path());
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].files, vec!["node_modules/dual/extra.mjs"]);
+    }
+
+    #[test]
+    fn test_scan_keeps_js_over_sibling_mjs() {
+        // A dual-published file pair: the resolver loads the `.js`, so the
+        // `.mjs` must not lower on top of it.
+        let root = tempfile::tempdir().unwrap();
+        write_pkg(
+            root.path(),
+            "dual",
+            r#"{"name":"dual","version":"1.0.0","main":"index.js"}"#,
+            &[
+                ("index.js", "module.exports = 1;"),
+                ("index.mjs", "export default 1;"),
+            ],
+        );
+        assert!(scan(root.path()).is_empty());
+    }
+
+    #[test]
+    fn test_scan_walks_scoped_and_nested_packages() {
+        let root = tempfile::tempdir().unwrap();
+        write_pkg(
+            root.path(),
+            "@scope/inner",
+            r#"{"name":"@scope/inner","version":"1.0.0","type":"module"}"#,
+            &[("index.js", "export const a = 1;")],
+        );
+        let outer = write_pkg(
+            root.path(),
+            "outer",
+            r#"{"name":"outer","version":"1.0.0"}"#,
+            &[("index.js", "module.exports = 1;")],
+        );
+        std::fs::create_dir_all(outer.join("node_modules/deep")).unwrap();
+        std::fs::write(
+            outer.join("node_modules/deep/package.json"),
+            r#"{"name":"deep","version":"3.0.0","type":"module"}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            outer.join("node_modules/deep/index.js"),
+            "export const b = 2;",
+        )
+        .unwrap();
+
+        let found = scan(root.path());
+        let names: Vec<&str> = found.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(names, vec!["@scope/inner", "deep"]);
+    }
+
+    #[test]
+    fn test_scan_ignores_nested_node_modules_as_own_files() {
+        let root = tempfile::tempdir().unwrap();
+        let outer = write_pkg(
+            root.path(),
+            "outer",
+            r#"{"name":"outer","version":"1.0.0","type":"module"}"#,
+            &[("index.js", "export const a = 1;")],
+        );
+        std::fs::create_dir_all(outer.join("node_modules/deep")).unwrap();
+        std::fs::write(
+            outer.join("node_modules/deep/package.json"),
+            r#"{"name":"deep","version":"3.0.0","type":"module"}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            outer.join("node_modules/deep/index.js"),
+            "export const b = 2;",
+        )
+        .unwrap();
+
+        let found = scan(root.path());
+        let outer_pkg = found.iter().find(|p| p.name == "outer").unwrap();
+        assert_eq!(outer_pkg.files, vec!["node_modules/outer/index.js"]);
+    }
+
+    #[test]
+    fn test_entry_fix_from_exports_map() {
+        let root = tempfile::tempdir().unwrap();
+        write_pkg(
+            root.path(),
+            "mapped",
+            r#"{"name":"mapped","version":"5.0.0","type":"module",
+                "exports":{".":{"types":"./x.d.ts","browser":"./b.js","default":"./dist/main.js"}}}"#,
+            &[("dist/main.js", "export const x = 1;")],
+        );
+        let found = scan(root.path());
+        assert_eq!(found[0].main.as_deref(), Some("./dist/main.js"));
+    }
+
+    #[test]
+    fn test_entry_fix_prefers_require_condition() {
+        let root = tempfile::tempdir().unwrap();
+        write_pkg(
+            root.path(),
+            "mapped",
+            r#"{"name":"mapped","version":"5.0.0","type":"module",
+                "exports":{".":{"import":"./esm/main.js","require":"./cjs/main.js"}}}"#,
+            &[
+                ("esm/main.js", "export const x = 1;"),
+                ("cjs/main.js", "module.exports = 1;"),
+            ],
+        );
+        let found = scan(root.path());
+        assert_eq!(found[0].main.as_deref(), Some("./cjs/main.js"));
+    }
+
+    #[test]
+    fn test_entry_fix_rewrites_mjs_main() {
+        let root = tempfile::tempdir().unwrap();
+        write_pkg(
+            root.path(),
+            "mjs-main",
+            r#"{"name":"mjs-main","version":"1.0.0","main":"./dist/index.mjs"}"#,
+            &[("dist/index.mjs", "export default 1;")],
+        );
+        let found = scan(root.path());
+        assert_eq!(found[0].main.as_deref(), Some("./dist/index.js"));
+    }
+
+    #[test]
+    fn test_entry_fix_absent_when_main_already_usable() {
+        let root = tempfile::tempdir().unwrap();
+        write_pkg(
+            root.path(),
+            "has-main",
+            r#"{"name":"has-main","version":"1.0.0","type":"module","main":"./dist/index.js"}"#,
+            &[("dist/index.js", "export const x = 1;")],
+        );
+        assert_eq!(scan(root.path())[0].main, None);
+    }
+
+    #[test]
+    fn test_exports_string_sugar() {
+        let exports = serde_json::json!("./index.js");
+        assert_eq!(resolve_root_export(&exports).as_deref(), Some("./index.js"));
+    }
+
+    #[test]
+    fn test_exports_bare_conditions_without_subpaths() {
+        let exports = serde_json::json!({"node": "./n.js", "default": "./d.js"});
+        assert_eq!(resolve_root_export(&exports).as_deref(), Some("./n.js"));
+    }
+
+    #[test]
+    fn test_exports_array_alternatives() {
+        let exports = serde_json::json!({".": [{"unknown": "./u.js"}, "./fallback.js"]});
+        assert_eq!(
+            resolve_root_export(&exports).as_deref(),
+            Some("./fallback.js")
+        );
+    }
+
+    #[test]
+    fn test_exports_subpath_only_map_has_no_root() {
+        let exports = serde_json::json!({"./sub": "./sub.js"});
+        assert_eq!(resolve_root_export(&exports), None);
+    }
+
+    #[test]
+    fn test_tmp_paths_round_trip() {
+        assert_eq!(
+            tmp_input("node_modules/a/x.js"),
+            "node_modules/a/x.wasmrun-esm.ts"
+        );
+        assert_eq!(
+            tmp_output("node_modules/a/x.js"),
+            "node_modules/a/x.wasmrun-esm.js"
+        );
+        assert_eq!(tmp_input("a/x.mjs"), "a/x.wasmrun-esm.ts");
+        assert_eq!(lowered_name("a/x.mjs"), "a/x.js");
+        assert_eq!(lowered_name("a/x.js"), "a/x.js");
+    }
+
+    #[test]
+    fn test_stage_and_commit_replace_source() {
+        let root = tempfile::tempdir().unwrap();
+        let dir = root.path().join("node_modules/p");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("index.mjs"), "export default 1;").unwrap();
+
+        let files = vec!["node_modules/p/index.mjs".to_string()];
+        let inputs = stage_inputs(root.path(), &files).unwrap();
+        assert_eq!(inputs, vec!["node_modules/p/index.wasmrun-esm.ts"]);
+        assert!(dir.join("index.wasmrun-esm.ts").exists());
+
+        // Stand in for the transpiler's emit.
+        std::fs::write(dir.join("index.wasmrun-esm.js"), "module.exports = 1;").unwrap();
+        commit_outputs(root.path(), &files).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(dir.join("index.js")).unwrap(),
+            "module.exports = 1;"
+        );
+        assert!(
+            !dir.join("index.mjs").exists(),
+            "lowered .mjs should be removed"
+        );
+        assert!(!dir.join("index.wasmrun-esm.ts").exists());
+    }
+
+    #[test]
+    fn test_clean_staging_removes_both_sides() {
+        let root = tempfile::tempdir().unwrap();
+        let dir = root.path().join("node_modules/p");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("index.wasmrun-esm.ts"), "x").unwrap();
+        std::fs::write(dir.join("index.wasmrun-esm.js"), "x").unwrap();
+
+        clean_staging(root.path(), &["node_modules/p/index.js".to_string()]);
+        assert!(!dir.join("index.wasmrun-esm.ts").exists());
+        assert!(!dir.join("index.wasmrun-esm.js").exists());
+    }
+
+    #[test]
+    fn test_finalize_manifest_writes_main_and_preserves_other_fields() {
+        let root = tempfile::tempdir().unwrap();
+        write_pkg(
+            root.path(),
+            "p",
+            r#"{"name":"p","version":"1.0.0","type":"module","sideEffects":false}"#,
+            &[("index.js", "export const x = 1;")],
+        );
+        let pkg = EsmPackage {
+            dir: "node_modules/p".into(),
+            name: "p".into(),
+            version: "1.0.0".into(),
+            files: vec![],
+            main: Some("./dist/main.js".into()),
+            imports: vec![],
+        };
+        finalize_manifest(root.path(), &pkg).unwrap();
+
+        let text =
+            std::fs::read_to_string(root.path().join("node_modules/p/package.json")).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert_eq!(json["main"], "./dist/main.js");
+        assert_eq!(json["name"], "p");
+        assert_eq!(json["sideEffects"], false);
+    }
+
+    #[test]
+    fn test_finalize_manifest_drops_type_module_so_rescan_is_a_no_op() {
+        let root = tempfile::tempdir().unwrap();
+        write_pkg(
+            root.path(),
+            "p",
+            r#"{"name":"p","version":"1.0.0","type":"module"}"#,
+            &[("index.js", "export const x = 1;")],
+        );
+        let pkg = scan(root.path()).remove(0);
+        finalize_manifest(root.path(), &pkg).unwrap();
+
+        let text =
+            std::fs::read_to_string(root.path().join("node_modules/p/package.json")).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&text).unwrap();
+        assert!(json.get("type").is_none(), "type: module should be dropped");
+        assert!(
+            scan(root.path()).is_empty(),
+            "a lowered package must not be picked up for lowering again"
+        );
+    }
+
+    #[test]
+    fn test_blame_names_the_owning_package() {
+        let packages = vec![EsmPackage {
+            dir: "node_modules/broken".into(),
+            name: "broken".into(),
+            version: "2.1.0".into(),
+            files: vec!["node_modules/broken/index.js".into()],
+            main: None,
+            imports: vec![],
+        }];
+        let msg = blame(
+            &packages,
+            "node_modules/broken/index.js:3:9: Expression expected",
+        );
+        assert!(msg.contains("'broken@2.1.0'"), "{msg}");
+
+        let unknown = blame(&packages, "some other failure");
+        assert!(unknown.contains("an ES module dependency"), "{unknown}");
+    }
+}

--- a/src/agent/executor.rs
+++ b/src/agent/executor.rs
@@ -5,7 +5,9 @@
 //! swc transpile stage that emits JS for the same runtime.
 
 use crate::agent::api::ApiError;
+use crate::agent::esm;
 use crate::agent::limits::{dir_size, ResourceLimits};
+use crate::agent::vendor;
 use crate::runtime::core::native_executor::{execute_wasm_bytes_with_env, ExecLimits};
 use crate::runtime::runtime_cache::RuntimeCache;
 use crate::runtime::wasi::WasiEnv;
@@ -92,6 +94,8 @@ pub fn execute_source(
         script_name
     };
 
+    lower_esm_dependencies(wasi_env.clone(), work_dir, limits, cancel.clone())?;
+
     let wasm_bytes = fetch_runtime_bytes(JS_RUNTIME)?;
 
     // nodejs-runtime dispatch: "run <file>" reads the file and evals it
@@ -162,6 +166,8 @@ pub fn execute_source_project(
     } else {
         entry.to_string()
     };
+
+    lower_esm_dependencies(wasi_env.clone(), work_dir, limits, cancel.clone())?;
 
     let args = vec![
         format!("{JS_RUNTIME}-runtime"),
@@ -490,6 +496,84 @@ fn transpile_in_session(
         } else {
             format!("TypeScript transpilation failed: {detail}")
         }));
+    }
+    Ok(())
+}
+
+/// Convert every ES module under the session's `node_modules` to CommonJS,
+/// the only module system the runtime's wrapper understands.
+///
+/// Works off what is on disk, so vendored packages and `node_modules` trees
+/// uploaded through `files` are both covered; a tree with nothing to lower
+/// costs one directory walk and never starts the transpiler.
+fn lower_esm_dependencies(
+    wasi_env: Arc<Mutex<WasiEnv>>,
+    work_dir: &Path,
+    limits: &ResourceLimits,
+    cancel: Option<Arc<AtomicBool>>,
+) -> std::result::Result<(), ApiError> {
+    let packages = esm::scan(work_dir);
+    if packages.is_empty() {
+        return Ok(());
+    }
+
+    // Checked before anything is rewritten: only a package still identical to
+    // the registry copy may go back to the shared cache.
+    let cacheable: Vec<bool> = packages
+        .iter()
+        .map(|p| {
+            !p.name.is_empty()
+                && !p.version.is_empty()
+                && vendor::body_matches_registry_copy(&p.name, &p.version, &work_dir.join(&p.dir))
+        })
+        .collect();
+
+    let files: Vec<String> = packages.iter().flat_map(|p| p.files.clone()).collect();
+    let inputs = esm::stage_inputs(work_dir, &files)?;
+
+    let result = transpile_in_session(&inputs, wasi_env, limits, cancel).map_err(|e| {
+        // One invocation covers every package, so the owner comes from the
+        // path swc reports rather than from transpiling separately.
+        ApiError::BadRequest(esm::blame(&packages, &e.to_string()))
+    });
+    if result.is_err() {
+        esm::clean_staging(work_dir, &files);
+        return result;
+    }
+
+    esm::commit_outputs(work_dir, &files)?;
+    for (pkg, cacheable) in packages.iter().zip(cacheable) {
+        esm::finalize_manifest(work_dir, pkg)?;
+        write_subpath_imports(pkg, work_dir, limits)?;
+        if cacheable {
+            vendor::store_lowered(&pkg.name, &pkg.version, &work_dir.join(&pkg.dir));
+        }
+    }
+    Ok(())
+}
+
+/// Materialize a package's `#alias` subpath imports as shims the resolver can
+/// find, the same trick the tsconfig `paths` aliases use. Each goes in the
+/// package's *own* `node_modules`, so two packages cannot collide on an
+/// alias.
+fn write_subpath_imports(
+    pkg: &esm::EsmPackage,
+    work_dir: &Path,
+    limits: &ResourceLimits,
+) -> std::result::Result<(), ApiError> {
+    for (alias, target) in &pkg.imports {
+        let target = format!("{}/{}", pkg.dir, target.trim_start_matches("./"));
+        if !work_dir.join(&target).exists() {
+            continue;
+        }
+        let shim_dir = format!("{}/node_modules/{alias}", pkg.dir);
+        write_checked(
+            &work_dir.join(format!("{shim_dir}/package.json")),
+            br#"{"main":"index.js"}"#,
+            limits,
+            work_dir,
+        )?;
+        write_alias_shim(&format!("{shim_dir}/index.js"), &target, work_dir, limits)?;
     }
     Ok(())
 }

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod api;
 pub mod auth;
+pub mod esm;
 pub mod executor;
 pub mod limits;
 pub mod metrics;

--- a/src/agent/server.rs
+++ b/src/agent/server.rs
@@ -956,6 +956,9 @@ impl AgentServer {
                 .map_err(|_| ApiError::Internal("Lock".into()))?;
             env.clear_stdout();
             env.clear_stderr();
+            // Rewound every exec: a request without stdin must see EOF, not
+            // the last run's leftovers.
+            env.set_stdin(req.stdin.clone().unwrap_or_default().into_bytes());
             if let Some(ref vars) = req.env {
                 for (k, v) in vars {
                     env.add_env(k.clone(), v.clone());
@@ -2271,6 +2274,31 @@ mod tests {
         wasm
     }
 
+    // Hand-built WASM that reads up to 64 bytes from fd 0 and writes exactly
+    // what it read to fd 1. Verified against wasmtime before being pasted here.
+    fn echo_stdin_wasm() -> Vec<u8> {
+        #[rustfmt::skip]
+        let wasm: Vec<u8> = vec![
+            0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x0c, 0x02, 0x60,
+            0x04, 0x7f, 0x7f, 0x7f, 0x7f, 0x01, 0x7f, 0x60, 0x00, 0x00, 0x02, 0x44,
+            0x02, 0x16, 0x77, 0x61, 0x73, 0x69, 0x5f, 0x73, 0x6e, 0x61, 0x70, 0x73,
+            0x68, 0x6f, 0x74, 0x5f, 0x70, 0x72, 0x65, 0x76, 0x69, 0x65, 0x77, 0x31,
+            0x07, 0x66, 0x64, 0x5f, 0x72, 0x65, 0x61, 0x64, 0x00, 0x00, 0x16, 0x77,
+            0x61, 0x73, 0x69, 0x5f, 0x73, 0x6e, 0x61, 0x70, 0x73, 0x68, 0x6f, 0x74,
+            0x5f, 0x70, 0x72, 0x65, 0x76, 0x69, 0x65, 0x77, 0x31, 0x08, 0x66, 0x64,
+            0x5f, 0x77, 0x72, 0x69, 0x74, 0x65, 0x00, 0x00, 0x03, 0x02, 0x01, 0x01,
+            0x05, 0x03, 0x01, 0x00, 0x01, 0x07, 0x13, 0x02, 0x06, 0x6d, 0x65, 0x6d,
+            0x6f, 0x72, 0x79, 0x02, 0x00, 0x06, 0x5f, 0x73, 0x74, 0x61, 0x72, 0x74,
+            0x00, 0x02, 0x0a, 0x3c, 0x01, 0x3a, 0x00, 0x41, 0x00, 0x41, 0xe4, 0x00,
+            0x36, 0x02, 0x00, 0x41, 0x04, 0x41, 0xc0, 0x00, 0x36, 0x02, 0x00, 0x41,
+            0x00, 0x41, 0x00, 0x41, 0x01, 0x41, 0x08, 0x10, 0x00, 0x1a, 0x41, 0x10,
+            0x41, 0xe4, 0x00, 0x36, 0x02, 0x00, 0x41, 0x14, 0x41, 0x08, 0x28, 0x02,
+            0x00, 0x36, 0x02, 0x00, 0x41, 0x01, 0x41, 0x10, 0x41, 0x01, 0x41, 0x18,
+            0x10, 0x01, 0x1a, 0x0b,
+        ];
+        wasm
+    }
+
     // ── Session lifecycle ─────────────────────────────────────────
 
     #[test]
@@ -2451,6 +2479,82 @@ mod tests {
         server.session_manager.destroy_all().unwrap();
     }
 
+    /// `stdin` on the request reaches a program reading fd 0.
+    #[test]
+    fn test_exec_stdin_reaches_the_program() {
+        let server = test_server();
+        let id = server.handle_create_session().unwrap().session_id;
+        let work_dir = server
+            .session_manager
+            .get_session(&id, None, |s| s.work_dir().to_path_buf())
+            .unwrap();
+        std::fs::write(work_dir.join("echo.wasm"), echo_stdin_wasm()).unwrap();
+
+        let resp = server
+            .handle_exec(
+                &id,
+                r#"{"wasm_path": "echo.wasm", "stdin": "piped input\n"}"#,
+                None,
+            )
+            .unwrap();
+
+        assert_eq!(resp.exit_code, 0, "error: {:?}", resp.error);
+        assert_eq!(resp.stdout, "piped input\n");
+
+        server.session_manager.destroy_all().unwrap();
+    }
+
+    /// Without `stdin`, fd 0 is at EOF: the program reads nothing and does
+    /// not hang.
+    #[test]
+    fn test_exec_without_stdin_reads_eof() {
+        let server = test_server();
+        let id = server.handle_create_session().unwrap().session_id;
+        let work_dir = server
+            .session_manager
+            .get_session(&id, None, |s| s.work_dir().to_path_buf())
+            .unwrap();
+        std::fs::write(work_dir.join("echo.wasm"), echo_stdin_wasm()).unwrap();
+
+        let resp = server
+            .handle_exec(&id, r#"{"wasm_path": "echo.wasm"}"#, None)
+            .unwrap();
+
+        assert_eq!(resp.exit_code, 0, "error: {:?}", resp.error);
+        assert_eq!(resp.stdout, "");
+
+        server.session_manager.destroy_all().unwrap();
+    }
+
+    /// Each exec gets its own stdin, neither inherited nor pre-consumed.
+    #[test]
+    fn test_exec_stdin_is_per_request() {
+        let server = test_server();
+        let id = server.handle_create_session().unwrap().session_id;
+        let work_dir = server
+            .session_manager
+            .get_session(&id, None, |s| s.work_dir().to_path_buf())
+            .unwrap();
+        std::fs::write(work_dir.join("echo.wasm"), echo_stdin_wasm()).unwrap();
+
+        let first = server
+            .handle_exec(&id, r#"{"wasm_path": "echo.wasm", "stdin": "one"}"#, None)
+            .unwrap();
+        assert_eq!(first.stdout, "one");
+
+        let second = server
+            .handle_exec(&id, r#"{"wasm_path": "echo.wasm", "stdin": "two"}"#, None)
+            .unwrap();
+        assert_eq!(second.stdout, "two");
+
+        let third = server
+            .handle_exec(&id, r#"{"wasm_path": "echo.wasm"}"#, None)
+            .unwrap();
+        assert_eq!(third.stdout, "");
+
+        server.session_manager.destroy_all().unwrap();
+    }
+
     #[test]
     fn test_exec_nonexistent_wasm() {
         let server = test_server();
@@ -2542,6 +2646,11 @@ mod tests {
     /// Ignored by default so the test suite stays offline-friendly (needs
     /// network on first run to fetch the runtime; cached after). Run with:
     ///   cargo test --release multi_file_js_require_integration -- --ignored --nocapture
+    ///
+    /// On a cold `~/.wasmrun/runtimes` cache, run the ignored tests with
+    /// `--test-threads=1` the first time. The runtime fetch happens inside the
+    /// timeout-guarded exec worker, so a parallel run has every test racing to
+    /// download the same two artifacts and spending its timeout doing it.
     #[test]
     #[ignore]
     fn test_multi_file_js_require_integration() {
@@ -2929,21 +3038,24 @@ mod tests {
     }
 
     /// Integration test: the 0.21.3 exit criteria — a project depending on a
-    /// real pure-JS npm package (lodash) executes in one request, resolved
-    /// through the runtime's own `require()` from the vendored node_modules.
+    /// real pure-JS npm package executes in one request, resolved through the
+    /// runtime's own `require()` from the vendored node_modules.
     ///
     /// Needs network (npm registry + wasmhub runtime fetch on first run).
     /// Ignored by default; see test_multi_file_js_require_integration.
     #[test]
     #[ignore]
-    fn test_npm_dependency_lodash_integration() {
+    fn test_npm_dependency_integration() {
         let server = test_server();
         let id = server.handle_create_session().unwrap().session_id;
 
+        // `ms` rather than lodash: the vendoring path is what is under test
+        // and 3 KB exercises all of it, where lodash's ~540 KB bundle takes
+        // ~24 s to parse in release and past 300 s under a debug build.
         let body = r#"{
-            "source": "const _ = require('lodash'); console.log(JSON.stringify(_.chunk([1,2,3,4], 2)));",
+            "source": "const ms = require('ms'); console.log(ms('2 days') + '|' + ms(60000));",
             "language": "javascript",
-            "dependencies": {"lodash": "^4.17.21"},
+            "dependencies": {"ms": "^2.1.3"},
             "timeout": 120
         }"#;
         let resp = server.handle_exec(&id, body, None).unwrap();
@@ -2953,8 +3065,8 @@ mod tests {
             resp.stderr, resp.error
         );
         assert!(
-            resp.stdout.contains("[[1,2],[3,4]]"),
-            "lodash output missing: {:?}",
+            resp.stdout.contains("172800000|1m"),
+            "vendored package output missing: {:?}",
             resp.stdout
         );
 
@@ -3009,6 +3121,119 @@ mod tests {
             "fetch should reject with a clear network-unsupported error: {:?}",
             resp.stdout
         );
+
+        server.session_manager.destroy_all().unwrap();
+    }
+
+    /// Integration test: an ESM-only package (nanoid declares `"type":
+    /// "module"` and puts its entry only in an `exports` map) installs, is
+    /// lowered to CommonJS, and loads through the runtime's own `require()`.
+    /// Needs network; ignored by default, see
+    /// test_multi_file_js_require_integration.
+    #[test]
+    #[ignore]
+    fn test_esm_only_package_integration() {
+        let server = test_server();
+        let id = server.handle_create_session().unwrap().session_id;
+
+        let body = r#"{
+            "source": "const { nanoid } = require('nanoid'); console.log('len=' + nanoid().length);",
+            "language": "javascript",
+            "dependencies": {"nanoid": "^6"},
+            "timeout": 240
+        }"#;
+        let resp = server.handle_exec(&id, body, None).unwrap();
+        assert_eq!(
+            resp.exit_code, 0,
+            "exit_code != 0; stderr: {}; error: {:?}",
+            resp.stderr, resp.error
+        );
+        assert!(
+            resp.stdout.contains("len=21"),
+            "ESM package output missing: {:?}; stderr: {}",
+            resp.stdout,
+            resp.stderr
+        );
+
+        server.session_manager.destroy_all().unwrap();
+    }
+
+    /// Integration test: an ESM package whose own dependency is also ESM-only
+    /// (p-limit → yocto-queue), so every level of the tree must be lowered.
+    /// Needs network; ignored by default, see
+    /// test_multi_file_js_require_integration.
+    #[test]
+    #[ignore]
+    fn test_esm_transitive_dependency_integration() {
+        let server = test_server();
+        let id = server.handle_create_session().unwrap().session_id;
+
+        let body = r#"{
+            "source": "const pLimit = require('p-limit').default; const limit = pLimit(2); Promise.all([limit(() => 1), limit(() => 2)]).then(r => console.log('plimit=' + JSON.stringify(r)));",
+            "language": "javascript",
+            "dependencies": {"p-limit": "^6"},
+            "timeout": 240
+        }"#;
+        let resp = server.handle_exec(&id, body, None).unwrap();
+        assert_eq!(
+            resp.exit_code, 0,
+            "exit_code != 0; stderr: {}; error: {:?}",
+            resp.stderr, resp.error
+        );
+        assert!(
+            resp.stdout.contains("plimit=[1,2]"),
+            "transitive ESM output missing: {:?}; stderr: {}",
+            resp.stdout,
+            resp.stderr
+        );
+
+        server.session_manager.destroy_all().unwrap();
+    }
+
+    /// Integration test: the built-in module tail added by wasmhub v0.4.0 —
+    /// `crypto`, `querystring`, `string_decoder`, `url` helpers, `fs/promises`,
+    /// `timers/promises`, `node:` aliases, and the deliberately-throwing `zlib`
+    /// stub — all reachable from agent code.
+    ///
+    /// Also the first execution `fs/promises` and `timers/promises` get:
+    /// wasmhub's node harness cannot reach them, so they shipped unverified.
+    /// Ignored by default; see test_multi_file_js_require_integration.
+    #[test]
+    #[ignore]
+    fn test_js_builtin_modules_tail_integration() {
+        let server = test_server();
+        let id = server.handle_create_session().unwrap().session_id;
+
+        // One 64-byte block on purpose: hashing is pure JS, ~1.6 s per block
+        // in release and ~27 s under the debug build tests run on. createHmac
+        // is left out for the same reason (4 blocks, same code path).
+        let body = r#"{
+            "source": "const crypto = require('node:crypto'); console.log('sha=' + crypto.createHash('sha256').update('abc').digest('hex').slice(0, 8)); console.log('qs=' + require('querystring').stringify({a: 1, b: 'x y'})); const {StringDecoder} = require('string_decoder'); const d = new StringDecoder('utf8'); console.log('sd=' + d.write(Buffer.from([0xe2, 0x82])) + d.end(Buffer.from([0xac]))); console.log('url=' + require('url').fileURLToPath('file:///tmp/a.txt')); try { require('zlib').gzipSync('x'); } catch (e) { console.log('zlib=' + (e.code === 'ERR_NOT_SUPPORTED')); } const fsp = require('node:fs/promises'); const tp = require('timers/promises'); (async () => { await fsp.writeFile('/promises.txt', 'hi'); console.log('fsp=' + (await fsp.readFile('/promises.txt', 'utf8'))); await tp.setTimeout(5); console.log('tp=ok'); })();",
+            "language": "javascript",
+            "timeout": 240
+        }"#;
+        let resp = server.handle_exec(&id, body, None).unwrap();
+        assert_eq!(
+            resp.exit_code, 0,
+            "exit_code != 0; stderr: {}; error: {:?}",
+            resp.stderr, resp.error
+        );
+        for expected in [
+            "sha=ba7816bf",   // crypto.createHash, sha256("abc")
+            "qs=a=1&b=x%20y", // querystring.stringify
+            "sd=\u{20ac}",    // string_decoder holds back a split UTF-8 euro sign
+            "url=/tmp/a.txt", // url.fileURLToPath
+            "zlib=true",      // present-but-throwing stub, named error code
+            "fsp=hi",         // fs/promises write + read round-trip
+            "tp=ok",          // timers/promises setTimeout resolves
+        ] {
+            assert!(
+                resp.stdout.contains(expected),
+                "missing {expected:?} in stdout: {:?}; stderr: {}",
+                resp.stdout,
+                resp.stderr
+            );
+        }
 
         server.session_manager.destroy_all().unwrap();
     }

--- a/src/agent/tools.rs
+++ b/src/agent/tools.rs
@@ -45,7 +45,7 @@ pub fn openai_tools() -> Vec<OpenAiTool> {
             r#type: "function",
             function: OpenAiFunction {
                 name: "execute_code",
-                description: "Execute code inside a sandbox session. Provide one of: 'command' (shell-style command line with pipes, redirection, and built-ins like echo/cat/ls/pwd/cd/mkdir/rm/cp/mv/env/export), 'source'+'language' (single JavaScript or TypeScript snippet), 'files'+'entry'+'language' (multi-file JS/TS project with relative require() and node_modules resolution), or 'wasm_path' (pre-compiled WASM). TypeScript is transpiled in-sandbox before execution. JS/TS code can use Node built-ins (path, fs, os, events, util, assert, stream, buffer) and standard globals (Buffer, TextEncoder/TextDecoder, URL/URLSearchParams, crypto.getRandomValues, structuredClone, timers, async/await). The sandbox has NO network access: fetch() rejects with a clear error, and npm packages must be declared via 'dependencies' (vendored host-side) or read from the project's package.json with 'install_package_json'. A project may ship a tsconfig.json; its 'paths' aliases are honored. Returns stdout, stderr, exit code, duration, and a 'lockfile' pinning any packages that were installed.",
+                description: "Execute code inside a sandbox session. Provide one of: 'command' (shell-style command line with pipes, redirection, and built-ins like echo/cat/ls/pwd/cd/mkdir/rm/cp/mv/env/export), 'source'+'language' (single JavaScript or TypeScript snippet), 'files'+'entry'+'language' (multi-file JS/TS project with relative require() and node_modules resolution), or 'wasm_path' (pre-compiled WASM). TypeScript is transpiled in-sandbox before execution. JS/TS code can use Node built-ins (path, fs, fs/promises, os, events, util, assert, stream, buffer, crypto, url, querystring, string_decoder, timers/promises, and their node: aliases) and standard globals (Buffer, TextEncoder/TextDecoder, URL/URLSearchParams, crypto.getRandomValues, structuredClone, timers, async/await). The sandbox has NO network access: fetch() rejects with a clear error, and npm packages must be declared via 'dependencies' (vendored host-side) or read from the project's package.json with 'install_package_json'. A project may ship a tsconfig.json; its 'paths' aliases are honored. Returns stdout, stderr, exit code, duration, and a 'lockfile' pinning any packages that were installed.",
                 parameters: json!({
                     "type": "object",
                     "properties": {
@@ -73,7 +73,7 @@ pub fn openai_tools() -> Vec<OpenAiTool> {
                         "dependencies": {
                             "type": "object",
                             "additionalProperties": { "type": "string" },
-                            "description": "npm dependencies to install before execution, as a map of package name → version range (e.g. {\"lodash\": \"^4.17.21\"}). Full npm range syntax is supported, including unions (\"^1 || ^2\"), comparator sets (\">=1.2.0 <2.0.0\") and hyphen ranges. Only pure-JS packages work (no native bindings, no install scripts). Use with 'source' or 'files'; the code can then require() them."
+                            "description": "npm dependencies to install before execution, as a map of package name → version range (e.g. {\"lodash\": \"^4.17.21\"}). Full npm range syntax is supported, including unions (\"^1 || ^2\"), comparator sets (\">=1.2.0 <2.0.0\") and hyphen ranges. Only pure-JS packages work (no native bindings, no install scripts). ES module packages are supported: they are converted to CommonJS before execution, so require() them like any other package (a default export arrives as .default). Use with 'source' or 'files'."
                         },
                         "install_package_json": {
                             "type": "boolean",
@@ -90,6 +90,10 @@ pub fn openai_tools() -> Vec<OpenAiTool> {
                                     "integrity": { "type": "string" }
                                 }
                             }
+                        },
+                        "stdin": {
+                            "type": "string",
+                            "description": "Text the program reads from standard input; omitting it means an immediate EOF. Reaches programs that read fd 0 through WASI, which today means 'wasm_path' modules only: JavaScript and TypeScript code cannot read it yet, because the runtime's process.stdin is still a stub."
                         },
                         "stream": {
                             "type": "boolean",

--- a/src/agent/vendor.rs
+++ b/src/agent/vendor.rs
@@ -100,12 +100,120 @@ pub fn validate_deps(deps: &HashMap<String, String>) -> std::result::Result<(), 
     Ok(())
 }
 
+/// Root of the per-`name@version` package cache (`~/.wasmrun/npm`).
+pub fn default_cache_dir() -> Option<PathBuf> {
+    Some(dirs::home_dir()?.join(".wasmrun").join("npm"))
+}
+
+/// Cache entry holding the CommonJS-lowered form, beside the `<version>`
+/// directory holding what the tarball shipped.
+fn lowered_dir(cache_dir: &Path, name: &str, version: &str) -> PathBuf {
+    cache_dir.join(name).join(format!("{version}.cjs"))
+}
+
+/// Whether the package body at `dir` is byte-identical to what the registry
+/// shipped for `name@version`.
+///
+/// Gates writes to the lowering cache, which is shared across sessions and
+/// tenants: an uploaded `node_modules` tree can claim any `name@version`, and
+/// caching a lowered form of one would poison it for everyone after.
+pub fn body_matches_registry_copy(name: &str, version: &str, dir: &Path) -> bool {
+    let Some(cache_dir) = default_cache_dir() else {
+        return false;
+    };
+    let raw = cache_dir.join(name).join(version);
+    if !raw.join("package.json").exists() {
+        return false;
+    }
+    let (Some(a), Some(b)) = (package_files(&raw), package_files(dir)) else {
+        return false;
+    };
+    if a != b {
+        return false;
+    }
+    a.iter().all(
+        |rel| match (std::fs::read(raw.join(rel)), std::fs::read(dir.join(rel))) {
+            (Ok(x), Ok(y)) => x == y,
+            _ => false,
+        },
+    )
+}
+
+/// Sorted file paths of a package body, excluding nested `node_modules`.
+fn package_files(dir: &Path) -> Option<Vec<PathBuf>> {
+    fn walk(base: &Path, dir: &Path, out: &mut Vec<PathBuf>) -> Option<()> {
+        for entry in std::fs::read_dir(dir).ok()? {
+            let path = entry.ok()?.path();
+            if path.is_dir() {
+                if path.file_name().is_some_and(|n| n == "node_modules") {
+                    continue;
+                }
+                walk(base, &path, out)?;
+            } else {
+                out.push(path.strip_prefix(base).ok()?.to_path_buf());
+            }
+        }
+        Some(())
+    }
+    let mut out = Vec::new();
+    walk(dir, dir, &mut out)?;
+    out.sort();
+    Some(out)
+}
+
+/// Store `dir` as the CommonJS-lowered form of `name@version`, so later
+/// installs skip the transform. Callers must have checked
+/// [`body_matches_registry_copy`] *before* lowering. Best-effort: a failed
+/// write costs a repeat transform, not the request.
+pub fn store_lowered(name: &str, version: &str, dir: &Path) {
+    let Some(cache_dir) = default_cache_dir() else {
+        return;
+    };
+    let dest = lowered_dir(&cache_dir, name, version);
+    if dest.join("package.json").exists() {
+        return;
+    }
+    // Populate a temp sibling and rename, so a crash mid-copy never leaves a
+    // half-written entry that a later install would trust.
+    let tmp = cache_dir
+        .join(name)
+        .join(format!(".tmp-cjs-{}-{}", version, std::process::id()));
+    let _ = std::fs::remove_dir_all(&tmp);
+    if copy_dir_excluding_nested(dir, &tmp).is_err() {
+        let _ = std::fs::remove_dir_all(&tmp);
+        return;
+    }
+    if std::fs::rename(&tmp, &dest).is_err() {
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+}
+
+/// `copy_dir`, minus nested `node_modules` (separate packages, installed on
+/// their own). No size checks: this writes to the host cache, and every file
+/// was already installed into the session under its limits.
+fn copy_dir_excluding_nested(src: &Path, dest: &Path) -> std::result::Result<(), ApiError> {
+    std::fs::create_dir_all(dest).map_err(|e| ApiError::Internal(format!("vendor copy: {e}")))?;
+    let entries =
+        std::fs::read_dir(src).map_err(|e| ApiError::Internal(format!("vendor copy: {e}")))?;
+    for entry in entries.flatten() {
+        let from = entry.path();
+        if from.is_dir() {
+            if entry.file_name() == "node_modules" {
+                continue;
+            }
+            copy_dir_excluding_nested(&from, &dest.join(entry.file_name()))?;
+        } else {
+            std::fs::copy(&from, dest.join(entry.file_name()))
+                .map_err(|e| ApiError::Internal(format!("vendor copy: {e}")))?;
+        }
+    }
+    Ok(())
+}
+
 impl Vendor {
     pub fn new(registry: &str) -> std::result::Result<Self, ApiError> {
-        let cache_dir = dirs::home_dir()
-            .ok_or_else(|| ApiError::Internal("Could not determine home directory".into()))?
-            .join(".wasmrun")
-            .join("npm");
+        let cache_dir = default_cache_dir()
+            .ok_or_else(|| ApiError::Internal("Could not determine home directory".into()))?;
         Ok(Self {
             registry: registry.trim_end_matches('/').to_string(),
             cache_dir,
@@ -216,13 +324,29 @@ impl Vendor {
             ))
         })?;
 
+        // A dist-tag names whatever the registry points at right now, which
+        // no installed version can be checked against. Pin it to that concrete
+        // version first and it dedupes and locks like any written-out version;
+        // the registry document is fetched once per request, so this is free.
+        let parsed_range = match &parsed_range {
+            Range::Tag(tag) => {
+                let version = self.resolve_tag(name, tag, ctx)?;
+                Range::parse(&version).map_err(|e| {
+                    ApiError::Internal(format!(
+                        "dist-tag '{tag}' for '{name}' resolved to unparseable version '{version}': {e}"
+                    ))
+                })?
+            }
+            _ => parsed_range,
+        };
+
         // Walk-up dedupe: if any ancestor node_modules already provides a
         // satisfying version, node's resolver will find it — skip. This is
         // also what terminates dependency cycles.
         for nm in chain.iter().rev() {
             if let Some(existing) = installed_version(&nm.join(name)) {
                 if let Ok(v) = SemVer::parse(&existing) {
-                    if parsed_range.matches_or_any_tag(&v, &existing) {
+                    if parsed_range.matches(&v) {
                         return Ok(());
                     }
                 }
@@ -294,6 +418,42 @@ impl Vendor {
         result
     }
 
+    /// Fetch the registry document for `name` into `ctx`, once per request.
+    fn ensure_doc(&self, name: &str, ctx: &mut Ctx) -> std::result::Result<(), ApiError> {
+        if ctx.docs.contains_key(name) {
+            return Ok(());
+        }
+        let url = format!("{}/{}", self.registry, urlencode_name(name));
+        let body = http_get_string(&url).map_err(|e| {
+            ApiError::Internal(format!("npm registry request failed for '{name}': {e}"))
+        })?;
+        let doc: PackageDoc = serde_json::from_str(&body).map_err(|e| {
+            ApiError::Internal(format!("Invalid registry metadata for '{name}': {e}"))
+        })?;
+        ctx.docs.insert(name.to_string(), doc);
+        Ok(())
+    }
+
+    /// The concrete version a dist-tag ("latest", "next") currently points at.
+    fn resolve_tag(
+        &self,
+        name: &str,
+        tag: &str,
+        ctx: &mut Ctx,
+    ) -> std::result::Result<String, ApiError> {
+        self.ensure_doc(name, ctx)?;
+        let doc = &ctx.docs[name];
+        let ver = doc.dist_tags.get(tag).ok_or_else(|| {
+            ApiError::BadRequest(format!("Unknown dist-tag '{tag}' for package '{name}'"))
+        })?;
+        if !doc.versions.contains_key(ver) {
+            return Err(ApiError::Internal(format!(
+                "dist-tag '{tag}' points at missing version {ver} for '{name}'"
+            )));
+        }
+        Ok(ver.clone())
+    }
+
     /// Resolve `range` against the registry document for `name`.
     fn resolve(
         &self,
@@ -301,30 +461,15 @@ impl Vendor {
         range: &Range,
         ctx: &mut Ctx,
     ) -> std::result::Result<VersionDoc, ApiError> {
-        if !ctx.docs.contains_key(name) {
-            let url = format!("{}/{}", self.registry, urlencode_name(name));
-            let body = http_get_string(&url).map_err(|e| {
-                ApiError::Internal(format!("npm registry request failed for '{name}': {e}"))
-            })?;
-            let doc: PackageDoc = serde_json::from_str(&body).map_err(|e| {
-                ApiError::Internal(format!("Invalid registry metadata for '{name}': {e}"))
-            })?;
-            ctx.docs.insert(name.to_string(), doc);
-        }
-        let doc = &ctx.docs[name];
-
-        // A dist-tag range ("latest", "next", ...) resolves through dist-tags.
+        // Callers pin dist-tags before they get here; handled anyway rather
+        // than leaving the method partial on part of its own input type.
         if let Range::Tag(tag) = range {
-            let ver = doc.dist_tags.get(tag).ok_or_else(|| {
-                ApiError::BadRequest(format!("Unknown dist-tag '{tag}' for package '{name}'"))
-            })?;
-            return doc.versions.get(ver).cloned().ok_or_else(|| {
-                ApiError::Internal(format!(
-                    "dist-tag '{tag}' points at missing version {ver} for '{name}'"
-                ))
-            });
+            let ver = self.resolve_tag(name, tag, ctx)?;
+            return Ok(ctx.docs[name].versions[&ver].clone());
         }
 
+        self.ensure_doc(name, ctx)?;
+        let doc = &ctx.docs[name];
         let mut best: Option<(SemVer, &VersionDoc)> = None;
         for (ver_str, vdoc) in &doc.versions {
             let Ok(ver) = SemVer::parse(ver_str) else {
@@ -351,6 +496,13 @@ impl Vendor {
         tarball_url: &str,
         integrity: &str,
     ) -> std::result::Result<PathBuf, ApiError> {
+        // A cached lowered form is the same package with its ES modules
+        // already converted, so installing it skips the transform.
+        let lowered = lowered_dir(&self.cache_dir, name, version);
+        if lowered.join("package.json").exists() {
+            return Ok(lowered);
+        }
+
         let pkg_cache = self.cache_dir.join(name).join(version);
         if pkg_cache.join("package.json").exists() {
             return Ok(pkg_cache);
@@ -852,18 +1004,6 @@ impl Range {
             Range::Any => v.pre.is_none(),
             Range::Tag(_) => false, // resolved via dist-tags, not matching
             Range::Set { alts, .. } => alts.iter().any(|alt| set_matches(alt, v)),
-        }
-    }
-
-    /// `matches`, but a dist-tag range accepts the exact version string the
-    /// tag resolved to (used by the walk-up dedupe check).
-    fn matches_or_any_tag(&self, v: &SemVer, _raw: &str) -> bool {
-        match self {
-            // For dedupe purposes any installed version satisfies a tag range
-            // only if it is what the tag currently resolves to — we can't
-            // know that offline, so be conservative and never dedupe tags.
-            Range::Tag(_) => false,
-            _ => self.matches(v),
         }
     }
 
@@ -1633,6 +1773,160 @@ mod tests {
             .vendor(&deps, session.path(), &ResourceLimits::default())
             .unwrap();
         assert!(marker.exists());
+    }
+
+    #[test]
+    fn test_vendor_dist_tag_skips_already_satisfied() {
+        let (_reg, _cache, vendor) = simple_registry();
+        let session = tempfile::tempdir().unwrap();
+        let deps = HashMap::from([("greet".to_string(), "latest".to_string())]);
+        vendor
+            .vendor(&deps, session.path(), &ResourceLimits::default())
+            .unwrap();
+
+        // A tag resolves to a concrete version, so the second request must
+        // dedupe against the installed copy exactly like a version range
+        // would. Before the tag was pinned first, this reinstalled every time.
+        let marker = session.path().join("node_modules/greet/marker.txt");
+        std::fs::write(&marker, "kept").unwrap();
+        vendor
+            .vendor(&deps, session.path(), &ResourceLimits::default())
+            .unwrap();
+        assert!(
+            marker.exists(),
+            "dist-tag request reinstalled over a copy it already had"
+        );
+    }
+
+    #[test]
+    fn test_vendor_dist_tag_dedupes_against_range_install() {
+        let (_reg, _cache, vendor) = simple_registry();
+        let session = tempfile::tempdir().unwrap();
+
+        // Installed by range, then requested by tag: the tag points at the
+        // same version, so nothing should be re-fetched.
+        vendor
+            .vendor(
+                &HashMap::from([("greet".to_string(), "^1.0.0".to_string())]),
+                session.path(),
+                &ResourceLimits::default(),
+            )
+            .unwrap();
+        let marker = session.path().join("node_modules/greet/marker.txt");
+        std::fs::write(&marker, "kept").unwrap();
+        vendor
+            .vendor(
+                &HashMap::from([("greet".to_string(), "latest".to_string())]),
+                session.path(),
+                &ResourceLimits::default(),
+            )
+            .unwrap();
+        assert!(marker.exists());
+    }
+
+    #[test]
+    fn test_vendor_dist_tag_dedupes_transitively() {
+        // app@1.0.0 depends on greet@latest, and the root already has a
+        // satisfying greet: walk-up dedupe must find it rather than nesting a
+        // second copy under app.
+        let greet_tb = pkg_tarball("greet", "1.4.2", "module.exports = 1;");
+        let app_tb = pkg_tarball("app", "1.0.0", "module.exports = require('greet');");
+
+        let server = std::sync::Arc::new(tiny_http::Server::http("127.0.0.1:0").unwrap());
+        let url = format!("http://{}", server.server_addr());
+        let mut docs = HashMap::new();
+        docs.insert(
+            "app".to_string(),
+            serde_json::json!({
+                "dist-tags": {"latest": "1.0.0"},
+                "versions": {"1.0.0": version_doc("app", "1.0.0", &url, &app_tb, &[("greet", "latest")], false)},
+            })
+            .to_string()
+            .into_bytes(),
+        );
+        docs.insert(
+            "greet".to_string(),
+            serde_json::json!({
+                "dist-tags": {"latest": "1.4.2"},
+                "versions": {"1.4.2": version_doc("greet", "1.4.2", &url, &greet_tb, &[], false)},
+            })
+            .to_string()
+            .into_bytes(),
+        );
+        docs.insert("tarballs/app-1.0.0.tgz".to_string(), app_tb);
+        docs.insert("tarballs/greet-1.4.2.tgz".to_string(), greet_tb);
+        let _reg = serve_docs(server, url.clone(), docs);
+
+        let cache = tempfile::tempdir().unwrap();
+        let vendor = Vendor::with_cache_dir(&url, cache.path().join("npm"));
+        let session = tempfile::tempdir().unwrap();
+
+        // greet at the root first, then app: installation is depth-first over
+        // sorted names, so this is what puts a candidate above app's own
+        // dependency for the walk-up to find.
+        vendor
+            .vendor(
+                &HashMap::from([("greet".to_string(), "^1.0.0".to_string())]),
+                session.path(),
+                &ResourceLimits::default(),
+            )
+            .unwrap();
+        let lock = vendor
+            .vendor(
+                &HashMap::from([("app".to_string(), "^1.0.0".to_string())]),
+                session.path(),
+                &ResourceLimits::default(),
+            )
+            .unwrap();
+
+        assert!(
+            !session
+                .path()
+                .join("node_modules/app/node_modules/greet")
+                .exists(),
+            "transitive dist-tag dependency nested a second copy instead of deduping"
+        );
+        assert_eq!(lock.keys().collect::<Vec<_>>(), vec!["node_modules/app"]);
+    }
+
+    #[test]
+    fn test_ensure_cached_prefers_lowered_variant() {
+        // Both forms cached: the CommonJS-lowered one is what installs, so the
+        // ESM transform is not repeated. The registry is unreachable here, so
+        // reaching the network at all would fail the test.
+        let cache = tempfile::tempdir().unwrap();
+        let cache_dir = cache.path().join("npm");
+        for (dir, body) in [
+            ("1.0.0", "export const x = 1;"),
+            ("1.0.0.cjs", "exports.x = 1;"),
+        ] {
+            let pkg = cache_dir.join("dual-form").join(dir);
+            std::fs::create_dir_all(&pkg).unwrap();
+            std::fs::write(
+                pkg.join("package.json"),
+                r#"{"name":"dual-form","version":"1.0.0"}"#,
+            )
+            .unwrap();
+            std::fs::write(pkg.join("index.js"), body).unwrap();
+        }
+
+        let vendor = Vendor::with_cache_dir("http://127.0.0.1:1", cache_dir.clone());
+        let resolved = vendor
+            .ensure_cached("dual-form", "1.0.0", "http://127.0.0.1:1/t.tgz", "sha512-x")
+            .unwrap();
+        assert_eq!(resolved, cache_dir.join("dual-form").join("1.0.0.cjs"));
+    }
+
+    #[test]
+    fn test_vendor_unknown_dist_tag_fails_clearly() {
+        let (_reg, _cache, vendor) = simple_registry();
+        let session = tempfile::tempdir().unwrap();
+        let deps = HashMap::from([("greet".to_string(), "nightly".to_string())]);
+        let err = vendor
+            .vendor(&deps, session.path(), &ResourceLimits::default())
+            .unwrap_err();
+        assert_eq!(err.status_code(), 400);
+        assert!(err.to_string().contains("Unknown dist-tag 'nightly'"));
     }
 
     #[test]

--- a/src/runtime/runtime_cache.rs
+++ b/src/runtime/runtime_cache.rs
@@ -7,8 +7,8 @@ use std::path::PathBuf;
 /// The wasmhub release wasmrun is pinned to. Must match the tag in
 /// `WASMHUB_BASE_URL`; cached runtimes downloaded from a different release
 /// are invalidated and re-fetched.
-const WASMHUB_RELEASE: &str = "v0.3.2";
-const WASMHUB_BASE_URL: &str = "https://github.com/anistark/wasmhub/releases/download/v0.3.2";
+const WASMHUB_RELEASE: &str = "v0.4.0";
+const WASMHUB_BASE_URL: &str = "https://github.com/anistark/wasmhub/releases/download/v0.4.0";
 /// Development/testing override: point runtime fetches at an alternate
 /// wasmhub-shaped host (e.g. a local HTTP server serving unreleased
 /// artifacts). When set, it also becomes the cache's release identity so

--- a/src/runtime/wasi/mod.rs
+++ b/src/runtime/wasi/mod.rs
@@ -42,6 +42,12 @@ pub struct WasiEnv {
     env_vars: Vec<(String, String)>,
     stdout: Vec<u8>,
     stderr: Vec<u8>,
+    /// Input handed to the program on fd 0. Empty means an immediate EOF,
+    /// which is what a program sees when the caller supplied no stdin.
+    stdin: Vec<u8>,
+    /// How much of `stdin` has been consumed; reads resume from here so a
+    /// program can drain it across several `fd_read` calls.
+    stdin_pos: usize,
     fd_table: HashMap<u32, FdEntry>,
     next_fd: u32,
     #[allow(dead_code)]
@@ -102,6 +108,8 @@ impl WasiEnv {
             env_vars: Vec::new(),
             stdout: Vec::new(),
             stderr: Vec::new(),
+            stdin: Vec::new(),
+            stdin_pos: 0,
             fd_table,
             next_fd: WASI_FIRST_PREOPEN_FD,
             preopens: Vec::new(),
@@ -144,6 +152,21 @@ impl WasiEnv {
 
     pub fn set_args(&mut self, args: Vec<String>) {
         self.args = args;
+    }
+
+    /// Set the bytes the program reads from fd 0, rewinding to the start.
+    pub fn set_stdin(&mut self, stdin: Vec<u8>) {
+        self.stdin = stdin;
+        self.stdin_pos = 0;
+    }
+
+    /// Consume up to `max` bytes of stdin. An empty return means EOF, which is
+    /// how a program learns the input is finished rather than blocking.
+    pub fn read_stdin(&mut self, max: usize) -> Vec<u8> {
+        let end = self.stdin.len().min(self.stdin_pos.saturating_add(max));
+        let chunk = self.stdin[self.stdin_pos.min(self.stdin.len())..end].to_vec();
+        self.stdin_pos = end;
+        chunk
     }
 
     pub fn args(&self) -> &[String] {

--- a/src/runtime/wasi/syscalls.rs
+++ b/src/runtime/wasi/syscalls.rs
@@ -168,6 +168,53 @@ pub fn fd_write(
     WASI_ESUCCESS
 }
 
+/// Fill the iovecs from the session's stdin buffer.
+///
+/// Whatever is left is handed over in order across calls, and a read past the
+/// end reports 0 bytes: WASI has no way to block here, so an exhausted (or
+/// never-supplied) stdin is simply EOF.
+fn read_stdin_into(
+    iovs_ptr: u32,
+    iovs_len: u32,
+    nread_ptr: u32,
+    memory: &mut LinearMemory,
+    env: &Arc<Mutex<WasiEnv>>,
+) -> i32 {
+    let mut e = match env.lock() {
+        Ok(e) => e,
+        Err(_) => return WASI_EIO,
+    };
+
+    let mut total_read: u32 = 0;
+    for i in 0..iovs_len {
+        let iov_base = iovs_ptr as usize + (i as usize) * 8;
+        let buf_ptr = match memory.read_i32(iov_base) {
+            Ok(v) => v as u32 as usize,
+            Err(_) => return WASI_EINVAL,
+        };
+        let buf_len = match memory.read_i32(iov_base + 4) {
+            Ok(v) => v as u32 as usize,
+            Err(_) => return WASI_EINVAL,
+        };
+        let chunk = e.read_stdin(buf_len);
+        if chunk.is_empty() {
+            break;
+        }
+        if memory.write_bytes(buf_ptr, &chunk).is_err() {
+            return WASI_EINVAL;
+        }
+        total_read += chunk.len() as u32;
+    }
+
+    if memory
+        .write_i32(nread_ptr as usize, total_read as i32)
+        .is_err()
+    {
+        return WASI_EINVAL;
+    }
+    WASI_ESUCCESS
+}
+
 pub fn fd_read(
     fd: u32,
     iovs_ptr: u32,
@@ -177,11 +224,7 @@ pub fn fd_read(
     env: &Arc<Mutex<WasiEnv>>,
 ) -> i32 {
     if fd == WASI_STDIN_FD {
-        return if memory.write_i32(nread_ptr as usize, 0).is_ok() {
-            WASI_ESUCCESS
-        } else {
-            WASI_EINVAL
-        };
+        return read_stdin_into(iovs_ptr, iovs_len, nread_ptr, memory, env);
     }
     if fd == WASI_STDOUT_FD || fd == WASI_STDERR_FD {
         return WASI_EBADF;
@@ -1117,6 +1160,89 @@ mod tests {
         let errno = fd_read(WASI_STDIN_FD, 0, 0, 100, &mut mem, &env);
         assert_eq!(errno, WASI_ESUCCESS);
         assert_eq!(mem.read_i32(100).unwrap(), 0);
+    }
+
+    /// One iovec, enough room for everything: the whole input lands in memory.
+    #[test]
+    fn test_fd_read_stdin_fills_buffer() {
+        let env = make_env();
+        env.lock().unwrap().set_stdin(b"hello stdin".to_vec());
+        let mut mem = LinearMemory::new(1, None).unwrap();
+        // iovec at 0: buffer at 200, length 32.
+        mem.write_i32(0, 200).unwrap();
+        mem.write_i32(4, 32).unwrap();
+
+        let errno = fd_read(WASI_STDIN_FD, 0, 1, 100, &mut mem, &env);
+        assert_eq!(errno, WASI_ESUCCESS);
+        assert_eq!(mem.read_i32(100).unwrap(), 11);
+        assert_eq!(mem.read_bytes(200, 11).unwrap(), b"hello stdin");
+    }
+
+    /// A program draining stdin in small reads gets it in order, then EOF.
+    #[test]
+    fn test_fd_read_stdin_resumes_across_calls() {
+        let env = make_env();
+        env.lock().unwrap().set_stdin(b"abcdef".to_vec());
+        let mut mem = LinearMemory::new(1, None).unwrap();
+        mem.write_i32(0, 200).unwrap();
+        mem.write_i32(4, 4).unwrap();
+
+        assert_eq!(
+            fd_read(WASI_STDIN_FD, 0, 1, 100, &mut mem, &env),
+            WASI_ESUCCESS
+        );
+        assert_eq!(mem.read_i32(100).unwrap(), 4);
+        assert_eq!(mem.read_bytes(200, 4).unwrap(), b"abcd");
+
+        assert_eq!(
+            fd_read(WASI_STDIN_FD, 0, 1, 100, &mut mem, &env),
+            WASI_ESUCCESS
+        );
+        assert_eq!(mem.read_i32(100).unwrap(), 2);
+        assert_eq!(mem.read_bytes(200, 2).unwrap(), b"ef");
+
+        // Drained: further reads are EOF, never a block.
+        assert_eq!(
+            fd_read(WASI_STDIN_FD, 0, 1, 100, &mut mem, &env),
+            WASI_ESUCCESS
+        );
+        assert_eq!(mem.read_i32(100).unwrap(), 0);
+    }
+
+    /// Multiple iovecs are filled in order, as a scatter read must.
+    #[test]
+    fn test_fd_read_stdin_across_iovecs() {
+        let env = make_env();
+        env.lock().unwrap().set_stdin(b"abcdefgh".to_vec());
+        let mut mem = LinearMemory::new(1, None).unwrap();
+        mem.write_i32(0, 200).unwrap();
+        mem.write_i32(4, 3).unwrap();
+        mem.write_i32(8, 300).unwrap();
+        mem.write_i32(12, 16).unwrap();
+
+        let errno = fd_read(WASI_STDIN_FD, 0, 2, 100, &mut mem, &env);
+        assert_eq!(errno, WASI_ESUCCESS);
+        assert_eq!(mem.read_i32(100).unwrap(), 8);
+        assert_eq!(mem.read_bytes(200, 3).unwrap(), b"abc");
+        assert_eq!(mem.read_bytes(300, 5).unwrap(), b"defgh");
+    }
+
+    /// Setting stdin again rewinds, so one exec never inherits another's
+    /// partially-consumed input.
+    #[test]
+    fn test_set_stdin_rewinds() {
+        let env = make_env();
+        let mut mem = LinearMemory::new(1, None).unwrap();
+        mem.write_i32(0, 200).unwrap();
+        mem.write_i32(4, 32).unwrap();
+
+        env.lock().unwrap().set_stdin(b"first".to_vec());
+        fd_read(WASI_STDIN_FD, 0, 1, 100, &mut mem, &env);
+        env.lock().unwrap().set_stdin(b"second".to_vec());
+        fd_read(WASI_STDIN_FD, 0, 1, 100, &mut mem, &env);
+
+        assert_eq!(mem.read_i32(100).unwrap(), 6);
+        assert_eq!(mem.read_bytes(200, 6).unwrap(), b"second");
     }
 
     #[test]


### PR DESCRIPTION
Bumps the pinned wasmhub release to v0.4.0, which fills in the Node.js standard library the runtime was missing: `crypto`, `url`, `querystring`, `string_decoder`, `fs/promises`, `timers/promises` and the `node:` aliases, plus `zlib`, `child_process` and `worker_threads` as present-but-throwing so a package that merely imports one keeps loading. `fs/promises` and `timers/promises` had never been executed anywhere before this, since wasmhub's node harness cannot reach them, so `test_js_builtin_modules_tail_integration` is their first real run.

ES module packages now work. The runtime's module wrapper is CommonJS-only and its resolver never probes `.mjs`, so an ESM-only package could not load at all, which covers most of npm published since
2021. New `src/agent/esm.rs` converts every ES module under `node_modules` to CommonJS before the program runs, reusing the in-sandbox swc stage the TypeScript path already has. An entry point declared only in an `exports` map is resolved and written to `main`, `#alias` subpath imports are materialized as shims scoped to the declaring package, and the converted form is cached per `name@version`. Only a package still byte-identical to what the registry shipped is cached, so an uploaded `node_modules` tree cannot poison that cache for other sessions or tenants. Verified against nanoid, p-limit (ESM through an ESM dependency) and escape-string-regexp.

Dist-tag dependencies dedupe. A tag like `latest` names whatever the registry points at right now, which no installed version could be checked against, so every request reinstalled the package and a transitive `latest` always nested a duplicate. It is now pinned to a concrete version up front, off the registry document already fetched once per request, and behaves like any written-out version from there.

`stdin` on the exec request reaches programs reading fd 0, which used to see an immediate EOF with no way to supply input. Reads resume across calls and report EOF once drained, and the buffer rewinds per exec so one run never inherits another's leftovers. JavaScript cannot see it until the runtime implements `process.stdin`, noted in the docs and the tool schema.

Agent mode also becomes a mode of its own in `AGENTS.md`, alongside server, exec and OS. It has its own CLI verb, sessions, auth, quotas and metrics, and filing it under exec left the boundary rule "exec must never start an HTTP server" contradicted by the code. Execution still belongs to exec: `src/agent/` runs everything through `runtime/core` and `runtime/wasi`, and a new rule says so outright so nobody grows a second interpreter in there. The docs move to `docs/docs/agent/` with their own sidebar, navbar entry and homepage card, so existing `/docs/exec/agent*` URLs will 404.

One test swap worth flagging: the npm integration test uses `ms` rather than `lodash`, since the vendoring path is what it covers and lodash's 540 KB bundle takes ~24 s to parse in release and over 300 s under the debug build the tests run on.